### PR TITLE
fix(recall): project current Codex record shapes

### DIFF
--- a/recall/server/tests/e2e_codex_projection.py
+++ b/recall/server/tests/e2e_codex_projection.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""Synthetic C6A proof for current Codex projection through HTTP and PostgreSQL."""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+from pathlib import Path
+
+import psycopg
+
+ROOT = Path(__file__).resolve().parents[3]
+SERVER = ROOT / "recall/server"
+RECALL = ROOT / "recall"
+sys.path.insert(0, str(SERVER))
+sys.path.insert(0, str(RECALL))
+
+from client.mac import BrainClient, MemoryClient
+from recall_server.db import BrainStore
+from recall_server.projectors import canonical_json
+
+
+def envelope(*, source: str, native: str, parent: str, harness: str, content: dict) -> dict:
+    value = {
+        "schema_version": 1,
+        "source_id": source,
+        "native_id": native,
+        "native_parent_id": parent,
+        "kind": "transcript_record",
+        "occurred_at": "2026-07-13T00:00:00Z",
+        "observed_at": "2026-07-13T00:00:01Z",
+        "principal_id": "owner",
+        "visibility": "private",
+        "content_type": "application/json",
+        "content": content,
+        "provenance": {
+            "harness": harness,
+            "original_path": f"/synthetic/{harness}/session.jsonl",
+        },
+    }
+    value["content_sha256"] = hashlib.sha256(canonical_json(content)).hexdigest()
+    return value
+
+
+def wait_healthy(client: BrainClient) -> None:
+    for _ in range(50):
+        try:
+            client.doctor()
+            return
+        except (OSError, urllib.error.URLError):
+            time.sleep(0.1)
+    raise AssertionError("authenticated server did not become healthy")
+
+
+def rank_for(result: dict, receipt: str) -> int:
+    for rank, item in enumerate(result["results"], 1):
+        if item["receipt"].split("#", 1)[0] == receipt:
+            return rank
+    raise AssertionError("committed receipt was not returned by source-scoped search")
+
+
+def main() -> None:
+    dsn = os.environ["RECALL_DATABASE_URL"]
+    port = int(os.environ.get("RECALL_E2E_PORT", "18789"))
+    endpoint = f"http://127.0.0.1:{port}"
+    store = BrainStore(dsn)
+    store.migrate()
+    with store.connect() as connection:
+        connection.execute(
+            "TRUNCATE chunks,items,sessions,projection_watermarks,source_events,"
+            "ingest_batches,collector_credentials,source_grants,sources,dead_letters,"
+            "audit_events RESTART IDENTITY CASCADE"
+        )
+
+    codex_source = "codex:mac:c6a"
+    claude_source = "claude:mac:c6a"
+    codex_credential = store.create_collector_token(
+        "c6a-codex", codex_source, ["read", "write"]
+    )
+    claude_credential = store.create_collector_token(
+        "c6a-claude", claude_source, ["read", "write"]
+    )
+    codex = BrainClient(
+        endpoint=endpoint, token=codex_credential["token"], source_id=codex_source
+    )
+    claude = BrainClient(
+        endpoint=endpoint, token=claude_credential["token"], source_id=claude_source
+    )
+
+    with tempfile.TemporaryDirectory(prefix="recall-c6a-e2e-") as temporary:
+        log_path = Path(temporary) / "server.log"
+        with log_path.open("w") as log:
+            environment = os.environ | {
+                "PYTHONPATH": str(SERVER),
+                "RECALL_DATABASE_URL": dsn,
+                "RECALL_PORT": str(port),
+                "RECALL_AUTH_REQUIRED": "1",
+            }
+            process = subprocess.Popen(
+                [sys.executable, "-m", "recall_server.app"],
+                env=environment, stdout=log, stderr=log,
+            )
+            try:
+                wait_healthy(codex)
+                codex_marker = "c6a-codex-projector-ember-4f18"
+                codex_event = envelope(
+                    source=codex_source,
+                    native="codex-current:1",
+                    parent="codex-current",
+                    harness="codex",
+                    content={
+                        "timestamp": "2026-07-13T00:00:00Z",
+                        "type": "event_msg",
+                        "payload": {
+                            "type": "agent_message",
+                            "message": codex_marker,
+                            "phase": "final_answer",
+                            "memory_citation": None,
+                        },
+                        "_recall_collector_generation": 0,
+                    },
+                )
+                acknowledgements = [
+                    codex._request(
+                        "/v1/ingest/batches", body={"events": [codex_event]},
+                        idempotency_key=f"c6a-codex-delivery-{delivery}",
+                    )
+                    for delivery in range(3)
+                ]
+                receipt = acknowledgements[0]["receipts"][0]
+                assert acknowledgements[0]["inserted"] == 1
+                assert [ack["duplicate_events"] for ack in acknowledgements] == [0, 1, 1]
+                codex_rank = rank_for(codex.search(codex_marker, limit=5), receipt)
+                resolved = codex.resolve(receipt)
+                assert resolved["items"] and resolved["items"][0]["text_redacted"] == codex_marker
+
+                claude_marker = "c6a-claude-parity-sable-91b0"
+                claude_event = envelope(
+                    source=claude_source,
+                    native="claude-current:1",
+                    parent="claude-current",
+                    harness="claude",
+                    content={
+                        "timestamp": "2026-07-13T00:00:00Z",
+                        "type": "assistant",
+                        "message": {"content": claude_marker},
+                        "_recall_collector_generation": 0,
+                    },
+                )
+                claude_ack = claude.ingest([claude_event])
+                claude_rank = rank_for(
+                    claude.search(claude_marker, limit=5), claude_ack["receipts"][0]
+                )
+
+                with store.connect() as connection:
+                    assert connection.execute(
+                        "SELECT count(*) AS n FROM source_events WHERE source_id=%s",
+                        (codex_source,),
+                    ).fetchone()["n"] == 1
+                    assert connection.execute(
+                        "SELECT count(*) AS n FROM items WHERE source_id=%s AND deleted_at IS NULL",
+                        (codex_source,),
+                    ).fetchone()["n"] == 1
+
+                MemoryClient(
+                    endpoint=endpoint, token=codex_credential["token"], source_id=codex_source
+                ).delete(receipt)
+                assert codex.search(codex_marker, limit=5)["results"] == []
+                try:
+                    codex.resolve(receipt)
+                except urllib.error.HTTPError as error:
+                    assert error.code == 404
+                else:
+                    raise AssertionError("tombstoned Codex receipt still resolves")
+
+                result = {
+                    "status": "pass",
+                    "runtime": {
+                        "python": sys.version.split()[0],
+                        "postgres": "17-alpine",
+                        "psycopg": psycopg.__version__,
+                    },
+                    "summary": {
+                        "codex_deliveries": 3,
+                        "codex_canonical_events": 1,
+                        "codex_live_items_before_delete": 1,
+                        "codex_rank": codex_rank,
+                        "codex_receipt_exact": True,
+                        "codex_deleted_search_and_receipt": True,
+                        "claude_rank": claude_rank,
+                        "claude_receipt_exact": True,
+                    },
+                }
+                rendered = json.dumps(result, sort_keys=True)
+                if output := os.environ.get("RECALL_E2E_OUT"):
+                    Path(output).write_text(rendered + "\n")
+                print(rendered)
+            finally:
+                process.terminate()
+                try:
+                    process.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    process.kill()
+                    process.wait()
+
+
+if __name__ == "__main__":
+    main()

--- a/recall/skills/recall/scripts/recall.py
+++ b/recall/skills/recall/scripts/recall.py
@@ -477,11 +477,23 @@ def codex_record(data: dict) -> tuple[list[tuple[float | None, str, str, list[tu
                 value = payload.get(source, data.get(source))
                 meta[target] = clean_text(value) if isinstance(value, str) else value
         return out, meta
+    if typ == "event_msg" and isinstance(payload, dict):
+        event_surface = {
+            "user_message": "user",
+            "agent_message": "assistant",
+        }.get(payload.get("type"))
+        message = payload.get("message")
+        if event_surface and isinstance(message, str) and message:
+            out.append((ts, event_surface, clean_text(message), []))
+        return out, meta
     if typ != "response_item" or not isinstance(payload, dict):
         return out, meta
     role = payload.get("role")
     ptype = payload.get("type")
-    if role in ("user", "assistant"):
+    message_surface = role if role in ("user", "assistant") else (
+        "assistant" if ptype == "agent_message" else None
+    )
+    if message_surface:
         texts = []
         for block in payload.get("content", []) if isinstance(payload.get("content"), list) else []:
             if isinstance(block, dict) and block.get("type") in ("input_text", "output_text", "text"):
@@ -489,12 +501,13 @@ def codex_record(data: dict) -> tuple[list[tuple[float | None, str, str, list[tu
         if not texts and isinstance(payload.get("content"), str):
             texts = [payload["content"]]
         if texts:
-            out.append((ts, role, clean_text("\n".join(texts)), []))
-    elif ptype == "function_call":
+            out.append((ts, message_surface, clean_text("\n".join(texts)), []))
+    elif ptype in {"function_call", "custom_tool_call"}:
         name = str(payload.get("name", ""))
-        out.append((ts, "tool_input", clipped(payload.get("arguments", ""), MAX_TOOL_INPUT), [("tool", name)] if name else []))
-    elif ptype == "function_call_output":
-        out.append((ts, "tool_output", clipped(payload.get("output", ""), MAX_TOOL_OUTPUT), []))
+        tool_input = payload.get("arguments") if ptype == "function_call" else payload.get("input")
+        out.append((ts, "tool_input", clipped(tool_input or "", MAX_TOOL_INPUT), [("tool", name)] if name else []))
+    elif ptype in {"function_call_output", "custom_tool_call_output"}:
+        out.append((ts, "tool_output", clipped(content_text(payload.get("output", "")), MAX_TOOL_OUTPUT), []))
     return [(a, b, c, d) for a, b, c, d in out if c], meta
 
 

--- a/recall/tests/test_engine.py
+++ b/recall/tests/test_engine.py
@@ -144,6 +144,79 @@ class RecallEngineTest(unittest.TestCase):
         self.assertNotIn(secret, stored[0]); self.assertNotIn(secret, stored[1])
         self.assertEqual(stored[0], "[redacted-secret-line]")
 
+    def test_current_codex_record_shapes_project_user_agent_and_tool_surfaces(self):
+        marker = "c6a-current-codex-projection-4f18"
+        cases = [
+            (
+                {
+                    "timestamp": "2026-07-13T00:00:00Z",
+                    "type": "event_msg",
+                    "payload": {
+                        "type": "user_message", "message": marker + " question",
+                        "images": [], "local_images": [], "text_elements": [],
+                    },
+                },
+                ("user", marker + " question"),
+            ),
+            (
+                {
+                    "timestamp": "2026-07-13T00:00:00Z",
+                    "type": "event_msg",
+                    "payload": {
+                        "type": "agent_message", "message": marker,
+                        "phase": "final_answer", "memory_citation": None,
+                    },
+                },
+                ("assistant", marker),
+            ),
+            (
+                {
+                    "timestamp": "2026-07-13T00:00:01Z",
+                    "type": "response_item",
+                    "payload": {
+                        "type": "agent_message", "author": "assistant",
+                        "recipient": "user", "content": [
+                            {"type": "text", "text": marker + " response"},
+                            {"type": "encrypted_content", "encrypted_content": "opaque"},
+                        ],
+                    },
+                },
+                ("assistant", marker + " response"),
+            ),
+            (
+                {
+                    "timestamp": "2026-07-13T00:00:02Z",
+                    "type": "response_item",
+                    "payload": {
+                        "type": "custom_tool_call", "name": "synthetic_tool",
+                        "call_id": "call-1", "input": marker + " input",
+                    },
+                },
+                ("tool_input", marker + " input"),
+            ),
+            (
+                {
+                    "timestamp": "2026-07-13T00:00:03Z",
+                    "type": "response_item",
+                    "payload": {
+                        "type": "custom_tool_call_output", "call_id": "call-1",
+                        "output": [{"type": "text", "text": marker + " output"}],
+                    },
+                },
+                ("tool_output", marker + " output"),
+            ),
+        ]
+        for record, expected in cases:
+            with self.subTest(record_type=record["payload"]["type"]):
+                parsed, _metadata = engine.codex_record(record)
+                self.assertEqual([(surface, text) for _, surface, text, _ in parsed], [expected])
+
+        ignored, _metadata = engine.codex_record({
+            "timestamp": "2026-07-13T00:00:04Z", "type": "event_msg",
+            "payload": {"type": "token_count", "info": {"total": 42}},
+        })
+        self.assertEqual(ignored, [])
+
     def test_partial_fts_or_fallback_returns_natural_partial_matches(self):
         (self.claude / "alpha.jsonl").write_text(json.dumps({"type":"user", "timestamp":"2026-01-01T00:00:00Z", "message":{"content":"alpha bravo only"}}) + "\n")
         (self.claude / "beta.jsonl").write_text(json.dumps({"type":"user", "timestamp":"2026-01-01T00:00:01Z", "message":{"content":"alpha charlie only"}}) + "\n")


### PR DESCRIPTION
Fixes the ACK-with-zero-searchable-items gap for current Codex session records.

- projects current user/agent event messages
- projects current agent and custom-tool response items
- adds a synthetic authenticated HTTP/PostgreSQL 17 E2E covering exact receipts, rank-1 search, three-delivery deduplication, tombstone reversal, and Claude parity

Verification:
- 65 Recall tests
- PostgreSQL 17 focused and full E2Es
- root portability tests
- npm package dry-run
- tracked privacy scan