### PR TITLE
feat(recall): expose reversible export provenance

### DIFF
--- a/recall/client/mac.py
+++ b/recall/client/mac.py
@@ -396,6 +396,7 @@ class ExportImporter:
         native_key = f"{file_sha}\x1f{member}\x1f{index}"
         native_id = "export-" + hashlib.sha256(native_key.encode()).hexdigest()
         occurred = iso_mtime(path)
+        uri = "export://" + file_sha
         return _envelope(
             source_id=self.source_id,
             native_id=native_id,
@@ -405,7 +406,12 @@ class ExportImporter:
             principal_id=self.principal_id,
             visibility=self.visibility,
             occurred_at=occurred,
-            provenance={"uri": "export://" + file_sha, "archive": path.name, "member": member},
+            provenance={
+                "uri": uri,
+                "original_path": f"{uri}/{member}",
+                "archive": path.name,
+                "member": member,
+            },
         )
 
     def import_with(self, client: BrainClient, inputs: Iterable[Path]) -> dict:

--- a/recall/server/recall_server/db.py
+++ b/recall/server/recall_server/db.py
@@ -296,7 +296,17 @@ class BrainStore:
         with self.connect() as conn:
             event = conn.execute(
                 """SELECT id,source_id,native_id,native_parent_id,kind,occurred_at,observed_at,principal_id,
-                   visibility,content_type,content_sha256,revision,is_tombstone
+                   visibility,content_type,content_sha256,revision,is_tombstone,
+                   jsonb_strip_nulls(jsonb_build_object(
+                     'uri', envelope #>> '{provenance,uri}',
+                     'original_path', envelope #>> '{provenance,original_path}',
+                     'archive', envelope #>> '{provenance,archive}',
+                     'member', envelope #>> '{provenance,member}',
+                     'harness', envelope #>> '{provenance,harness}',
+                     'cwd', envelope #>> '{provenance,cwd}',
+                     'branch', envelope #>> '{provenance,branch}',
+                     'slot', envelope #>> '{provenance,slot}'
+                   )) AS provenance
                    FROM source_events event
                    WHERE source_id=%s AND native_id=%s AND revision=%s
                      AND NOT EXISTS (

--- a/recall/server/tests/e2e_brainstore.py
+++ b/recall/server/tests/e2e_brainstore.py
@@ -106,6 +106,7 @@ def main() -> None:
                 raise AssertionError("server did not become healthy")
 
             first = make_envelope("session-1:turn-1", {"role": "user", "text": "quartz decision"})
+            first["provenance"]["private_internal"] = "synthetic-not-client-visible"
             status, ack = request(base, "POST", "/v1/ingest/batches", {"events": [first]}, "batch-first")
             assert status == 201 and ack["inserted"] == 1 and not ack["replay"]
 
@@ -120,6 +121,11 @@ def main() -> None:
             assert first_hit["path"] == "/evidence/codex-linux/session-1.jsonl"
             assert first_hit["receipt"].startswith("recall://codex:linux/session-1:turn-1?rev=1#item=")
             assert first_hit["tier"] >= 1 and first_hit["legs"]
+            first_resolved = request(
+                base, "GET", "/v1/receipts/resolve?" + urllib.parse.urlencode({"receipt": first_hit["receipt"]})
+            )[1]
+            assert first_resolved["event"]["provenance"]["original_path"] == first_hit["path"]
+            assert "private_internal" not in first_resolved["event"]["provenance"]
             diagnostics = searched["diagnostics"]
             assert diagnostics["deadline_ms"] < 500 and diagnostics["elapsed_ms"] >= 0
 
@@ -159,6 +165,12 @@ def main() -> None:
             assert second_import["acknowledgement"]["replay"] is True
             export_search = export_client.search(export_marker, limit=5)
             assert export_search["results"] and export_search["results"][0]["receipt"].startswith("recall://export:mac:e2e/")
+            export_hit = export_search["results"][0]
+            assert export_hit["path"].startswith("export://")
+            assert export_hit["path"].endswith("/supported-export.jsonl#record=0")
+            export_resolved = export_client.resolve(export_hit["receipt"])
+            assert export_resolved["event"]["provenance"]["member"] == "supported-export.jsonl#record=0"
+            assert export_resolved["event"]["provenance"]["original_path"] == export_hit["path"]
 
             # The exact portable collector core survives an offline scan and only
             # advances its committed cursor after the deployed API acknowledges it.

--- a/recall/server/tests/e2e_macos_export_c6c.py
+++ b/recall/server/tests/e2e_macos_export_c6c.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""Packaged-runtime C6C proof for reversible supported-export replay."""
+from __future__ import annotations
+
+import argparse
+import ctypes
+import ctypes.util
+import json
+import os
+import shutil
+import stat
+import sys
+import urllib.error
+import zipfile
+from pathlib import Path
+
+from client.mac import (
+    BrainClient,
+    ExportImporter,
+    MemoryClient,
+    PrivacyError,
+    load_keychain_token,
+    store_keychain_token,
+)
+
+
+ITEM_NOT_FOUND = -25300
+
+
+def delete_keychain_token(service: str, account: str) -> int:
+    security = ctypes.CDLL(ctypes.util.find_library("Security"))
+    security.SecKeychainFindGenericPassword.restype = ctypes.c_int32
+    security.SecKeychainItemDelete.restype = ctypes.c_int32
+    service_bytes = service.encode()
+    account_bytes = account.encode()
+    item = ctypes.c_void_p()
+    status = security.SecKeychainFindGenericPassword(
+        None,
+        len(service_bytes), ctypes.c_char_p(service_bytes),
+        len(account_bytes), ctypes.c_char_p(account_bytes),
+        None, None, ctypes.byref(item),
+    )
+    if status == 0:
+        try:
+            status = security.SecKeychainItemDelete(item)
+        finally:
+            core = ctypes.CDLL(ctypes.util.find_library("CoreFoundation"))
+            core.CFRelease.argtypes = [ctypes.c_void_p]
+            core.CFRelease(item)
+    return status
+
+
+def doctor_counts(client: BrainClient) -> tuple[int, int]:
+    doctor = client.doctor()
+    return doctor["source_events"], doctor["live_items"]
+
+
+def expected_provenance(inventory: dict) -> list[dict]:
+    return [record["provenance"] for record in inventory["records"]]
+
+
+def assert_receipts(
+    client: BrainClient, receipts: list[str], provenances: list[dict]
+) -> None:
+    assert len(receipts) == len(provenances)
+    for receipt, provenance in zip(receipts, provenances, strict=True):
+        resolved = client.resolve(receipt)
+        actual = resolved["event"]["provenance"]
+        assert actual["uri"] == provenance["uri"]
+        assert actual["archive"] == provenance["archive"]
+        assert actual["member"] == provenance["member"]
+        assert actual["original_path"] == provenance["original_path"]
+        assert resolved["items"]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--endpoint", required=True)
+    parser.add_argument("--keychain-service", required=True)
+    parser.add_argument("--source-id", required=True)
+    parser.add_argument("--nonce", required=True)
+    parser.add_argument("--workspace", type=Path, required=True)
+    args = parser.parse_args()
+
+    credential = json.load(sys.stdin)
+    if not isinstance(credential, str) or not credential:
+        raise ValueError("stdin must contain one credential string")
+
+    export_root = args.workspace / "synthetic-exports"
+    receipts: list[str] = []
+    tombstoned: set[str] = set()
+    client = None
+    result = None
+    try:
+        export_root.mkdir(parents=True)
+        jsonl = export_root / "chatgpt-synthetic.jsonl"
+        jsonl.write_text(
+            json.dumps({"text": f"c6c-jsonl-first-{args.nonce}"}) + "\n"
+            + json.dumps({"text": f"c6c-jsonl-second-{args.nonce}"}) + "\n"
+        )
+        archive = export_root / "cowork-synthetic.zip"
+        with zipfile.ZipFile(archive, "w") as output:
+            output.writestr(
+                "conversations/alpha.json",
+                json.dumps([{"text": f"c6c-zip-alpha-{args.nonce}"}]),
+            )
+            output.writestr(
+                "cowork/beta.jsonl",
+                json.dumps({"text": f"c6c-zip-target-{args.nonce}"}) + "\n"
+                + json.dumps({"text": f"c6c-zip-tail-{args.nonce}"}) + "\n",
+            )
+
+        store_keychain_token(args.keychain_service, args.source_id, credential)
+        assert load_keychain_token(args.keychain_service, args.source_id) == credential
+        client = BrainClient(
+            endpoint=args.endpoint,
+            token=credential,
+            source_id=args.source_id,
+            principal_id="owner",
+            visibility="private",
+        )
+        memory = MemoryClient(
+            endpoint=args.endpoint,
+            token=credential,
+            source_id=args.source_id,
+            principal_id="owner",
+            visibility="private",
+        )
+        importer = ExportImporter(
+            source_id=args.source_id, principal_id="owner", visibility="private"
+        )
+
+        assert doctor_counts(client) == (0, 0)
+        jsonl_inventory = importer.inventory([jsonl])
+        zip_inventory = importer.inventory([archive])
+        assert len(jsonl_inventory["records"]) == 2
+        assert len(zip_inventory["records"]) == 3
+
+        first_jsonl = importer.import_with(client, [jsonl])
+        first_zip = importer.import_with(client, [archive])
+        jsonl_receipts = first_jsonl["acknowledgement"]["receipts"]
+        zip_receipts = first_zip["acknowledgement"]["receipts"]
+        receipts = [*jsonl_receipts, *zip_receipts]
+        assert first_jsonl["acknowledgement"]["inserted"] == 2
+        assert first_zip["acknowledgement"]["inserted"] == 3
+        assert doctor_counts(client) == (5, 5)
+        assert_receipts(client, jsonl_receipts, expected_provenance(jsonl_inventory))
+        assert_receipts(client, zip_receipts, expected_provenance(zip_inventory))
+
+        replay_jsonl = importer.import_with(client, [jsonl])
+        replay_zip = importer.import_with(client, [archive])
+        assert replay_jsonl["acknowledgement"]["replay"] is True
+        assert replay_zip["acknowledgement"]["replay"] is True
+        assert replay_jsonl["acknowledgement"]["receipts"] == jsonl_receipts
+        assert replay_zip["acknowledgement"]["receipts"] == zip_receipts
+        assert doctor_counts(client) == (5, 5)
+
+        target = f"c6c-zip-target-{args.nonce}"
+        searched = client.search(target, limit=5)
+        assert searched["results"]
+        target_hit = searched["results"][0]
+        assert target_hit["source_id"] == args.source_id
+        assert target_hit["path"].endswith("/cowork/beta.jsonl#record=0")
+        assert target_hit["text"] == target
+
+        traversal = export_root / "traversal.zip"
+        with zipfile.ZipFile(traversal, "w") as output:
+            output.writestr("../escape.json", json.dumps({"text": "must-not-write"}))
+        before_attack = doctor_counts(client)
+        try:
+            importer.import_with(client, [traversal])
+        except PrivacyError:
+            traversal_rejected = True
+        else:
+            raise AssertionError("archive traversal reached ingest")
+        assert doctor_counts(client) == before_attack
+
+        linked = export_root / "linked.jsonl"
+        os.symlink(jsonl, linked)
+        try:
+            importer.import_with(client, [linked])
+        except PrivacyError:
+            symlink_rejected = True
+        else:
+            raise AssertionError("symlink export input reached ingest")
+        assert doctor_counts(client) == before_attack
+
+        for receipt in receipts:
+            deletion = memory.delete(receipt)
+            tombstoned.add(receipt)
+            assert deletion["receipt"].endswith("?rev=2")
+        assert doctor_counts(client) == (10, 0)
+        assert client.search(args.nonce, limit=10)["results"] == []
+        for receipt in receipts:
+            try:
+                client.resolve(receipt)
+            except urllib.error.HTTPError as error:
+                assert error.code == 404
+            else:
+                raise AssertionError("tombstoned export receipt still resolves")
+
+        result = {
+            "status": "pass",
+            "summary": {
+                "jsonl_items": 2,
+                "zip_items": 3,
+                "resolved_provenance": 5,
+                "jsonl_replay": True,
+                "zip_replay": True,
+                "canonical_events_before_rollback": 5,
+                "live_items_before_rollback": 5,
+                "unique_nonce_member_exact": True,
+                "traversal_rejected_before_write": traversal_rejected,
+                "symlink_rejected_before_write": symlink_rejected,
+                "source_events_after_rollback": 10,
+                "live_items_after_rollback": 0,
+                "old_receipts_hidden": 5,
+                "credential_bytes_rendered": False,
+            },
+        }
+    finally:
+        if client is not None:
+            fallback = MemoryClient(
+                endpoint=args.endpoint,
+                token=credential,
+                source_id=args.source_id,
+                principal_id="owner",
+                visibility="private",
+            )
+            for receipt in receipts:
+                if receipt not in tombstoned:
+                    try:
+                        fallback.delete(receipt)
+                    except Exception:
+                        pass
+        status = delete_keychain_token(args.keychain_service, args.source_id)
+        if status not in {0, ITEM_NOT_FOUND}:
+            raise RuntimeError(f"Keychain cleanup failed with OSStatus {status}")
+        shutil.rmtree(export_root, ignore_errors=True)
+
+    try:
+        load_keychain_token(args.keychain_service, args.source_id)
+    except RuntimeError as error:
+        if f"OSStatus {ITEM_NOT_FOUND}" not in str(error):
+            raise
+    else:
+        raise AssertionError("Keychain credential residue remains")
+    assert not export_root.exists()
+    assert result is not None
+    result["summary"]["keychain_residue"] = 0
+    result["summary"]["generated_export_residue"] = 0
+    print(json.dumps(result, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/recall/tests/test_mac_client.py
+++ b/recall/tests/test_mac_client.py
@@ -101,6 +101,13 @@ class SupportedExportTest(unittest.TestCase):
         members = {record["provenance"]["member"] for record in first["records"]}
         self.assertIn("supported-export.jsonl#record=1", members)
         self.assertIn("conversations/chat.json#record=0", members)
+        for record in first["records"]:
+            provenance = record["provenance"]
+            self.assertEqual(
+                provenance["original_path"],
+                f"{provenance['uri']}/{provenance['member']}",
+            )
+            self.assertNotIn(str(self.root), provenance["original_path"])
         self.assertTrue(all(record["kind"] == "chat_export" for record in first["records"]))
 
     def test_archive_traversal_and_symlink_members_are_rejected(self) -> None:


### PR DESCRIPTION
## Summary
- give supported export records stable content-addressed member paths
- expose an explicit safe provenance projection on receipt resolution
- add a synthetic packaged macOS E2E for JSONL/ZIP replay, attacks, and rollback

## Verification
- TDD red: missing export `original_path`
- 65 Recall tests and 8 portability tests
- PostgreSQL 17 BrainStore E2E after final provenance review
- authenticated Codex projection E2E
- packaged macOS JSONL/ZIP lifecycle E2E
- two byte-identical content-free packages
- privacy scan: zero added secret patterns and no transcript/log artifacts