### PR TITLE
test(recall): prove packaged collector recovery

### DIFF
--- a/recall/server/scripts/backup_restore.sh
+++ b/recall/server/scripts/backup_restore.sh
@@ -21,16 +21,18 @@ case "$MODE" in
   backup)
     [ -n "$BACKUP_DIR" ] && [ -n "${RECALL_DATABASE_URL:-}" ] || usage
     mkdir -p "$BACKUP_DIR"
+    stage=$(mktemp -d "$BACKUP_DIR/.backup.XXXXXX")
+    trap 'rm -rf "$stage"' EXIT
     started=$(date -u +%s)
     started_ms=$(date -u +%s%3N)
-    docker run --rm --network host -v "$BACKUP_DIR:/backup" "$TOOLS_IMAGE" \
+    docker run --rm --network host -v "$stage:/backup" "$TOOLS_IMAGE" \
       pg_dump "$RECALL_DATABASE_URL" --format=custom --no-owner --file=/backup/brain.dump
-    dump_sha=$(sha256sum "$BACKUP_DIR/brain.dump" | awk '{print $1}')
+    dump_sha=$(sha256sum "$stage/brain.dump" | awk '{print $1}')
     source_fingerprint=$(fingerprint "$RECALL_DATABASE_URL")
     newest_epoch=$(psql "$RECALL_DATABASE_URL" -At -c "SELECT COALESCE(extract(epoch FROM max(created_at))::bigint,0) FROM source_events")
     completed=$(date -u +%s)
     completed_ms=$(date -u +%s%3N)
-    BACKUP_DIR="$BACKUP_DIR" STARTED="$started" COMPLETED="$completed" STARTED_MS="$started_ms" COMPLETED_MS="$completed_ms" DUMP_SHA="$dump_sha" \
+    BACKUP_DIR="$stage" STARTED="$started" COMPLETED="$completed" STARTED_MS="$started_ms" COMPLETED_MS="$completed_ms" DUMP_SHA="$dump_sha" \
       SOURCE_FINGERPRINT="$source_fingerprint" NEWEST_EPOCH="$newest_epoch" TOOLS_IMAGE="$TOOLS_IMAGE" \
       python3 - <<'PY'
 import json, os
@@ -50,17 +52,25 @@ manifest = {
 Path(os.environ["BACKUP_DIR"], "manifest.json").write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
 print(json.dumps(manifest, sort_keys=True))
 PY
+    mv -f "$stage/brain.dump" "$BACKUP_DIR/brain.dump"
+    mv -f "$stage/manifest.json" "$BACKUP_DIR/manifest.json"
+    rmdir "$stage"
+    trap - EXIT
     ;;
   restore-test)
     [ -n "$BACKUP_DIR" ] && [ -n "${RECALL_RESTORE_DATABASE_URL:-}" ] || usage
     [ -f "$BACKUP_DIR/brain.dump" ] && [ -f "$BACKUP_DIR/manifest.json" ] || usage
-    expected_sha=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["dump_sha256"])' "$BACKUP_DIR/manifest.json")
-    actual_sha=$(sha256sum "$BACKUP_DIR/brain.dump" | awk '{print $1}')
+    snapshot=$(mktemp -d "$BACKUP_DIR/.restore.XXXXXX")
+    trap 'rm -rf "$snapshot"' EXIT
+    ln "$BACKUP_DIR/brain.dump" "$snapshot/brain.dump"
+    cp "$BACKUP_DIR/manifest.json" "$snapshot/manifest.json"
+    expected_sha=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["dump_sha256"])' "$snapshot/manifest.json")
+    actual_sha=$(sha256sum "$snapshot/brain.dump" | awk '{print $1}')
     [ "$expected_sha" = "$actual_sha" ] || { echo "dump hash mismatch" >&2; exit 1; }
-    expected_fingerprint=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["source_fingerprint"])' "$BACKUP_DIR/manifest.json")
+    expected_fingerprint=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["source_fingerprint"])' "$snapshot/manifest.json")
     started=$(date -u +%s)
     started_ms=$(date -u +%s%3N)
-    docker run --rm --network host -v "$BACKUP_DIR:/backup:ro" "$TOOLS_IMAGE" \
+    docker run --rm --network host -v "$snapshot:/backup:ro" "$TOOLS_IMAGE" \
       pg_restore --dbname="$RECALL_RESTORE_DATABASE_URL" --clean --if-exists --no-owner /backup/brain.dump
     actual_fingerprint=$(fingerprint "$RECALL_RESTORE_DATABASE_URL")
     completed=$(date -u +%s)
@@ -76,6 +86,8 @@ print(json.dumps({
     "rto_ms": int(os.environ["COMPLETED_MS"]) - int(os.environ["STARTED_MS"]),
 }, sort_keys=True))
 PY
+    rm -rf "$snapshot"
+    trap - EXIT
     ;;
   *) usage ;;
 esac

--- a/recall/server/tests/e2e_macos_collectors_c6d.py
+++ b/recall/server/tests/e2e_macos_collectors_c6d.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""Packaged-runtime C6D proof for offline Claude and Codex recovery."""
+from __future__ import annotations
+
+import argparse
+import ctypes
+import ctypes.util
+import json
+import shutil
+import sys
+import urllib.error
+from datetime import datetime, timezone
+from pathlib import Path
+
+from client.mac import BrainClient, MemoryClient, load_keychain_token, store_keychain_token
+from collector.collector import Collector
+
+
+ITEM_NOT_FOUND = -25300
+
+
+def delete_keychain_token(service: str, account: str) -> int:
+    security = ctypes.CDLL(ctypes.util.find_library("Security"))
+    security.SecKeychainFindGenericPassword.restype = ctypes.c_int32
+    security.SecKeychainItemDelete.restype = ctypes.c_int32
+    service_bytes, account_bytes = service.encode(), account.encode()
+    item = ctypes.c_void_p()
+    status = security.SecKeychainFindGenericPassword(
+        None,
+        len(service_bytes), ctypes.c_char_p(service_bytes),
+        len(account_bytes), ctypes.c_char_p(account_bytes),
+        None, None, ctypes.byref(item),
+    )
+    if status == 0:
+        try:
+            status = security.SecKeychainItemDelete(item)
+        finally:
+            core = ctypes.CDLL(ctypes.util.find_library("CoreFoundation"))
+            core.CFRelease.argtypes = [ctypes.c_void_p]
+            core.CFRelease(item)
+    return status
+
+
+def fixture(harness: str, marker: str, timestamp: str) -> dict:
+    if harness == "claude":
+        return {"type": "user", "timestamp": timestamp, "message": {"content": marker}}
+    return {
+        "type": "response_item",
+        "timestamp": timestamp,
+        "payload": {
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_text", "text": marker}],
+        },
+    }
+
+
+def rank_for(result: dict, receipt: str) -> int:
+    event_receipt = receipt.split("#", 1)[0]
+    for rank, item in enumerate(result["results"], 1):
+        if item["receipt"].split("#", 1)[0] == event_receipt:
+            return rank
+    raise AssertionError("collector receipt was not returned by source-scoped search")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--endpoint", required=True)
+    parser.add_argument("--keychain-service", required=True)
+    parser.add_argument("--claude-source", required=True)
+    parser.add_argument("--codex-source", required=True)
+    parser.add_argument("--nonce", required=True)
+    parser.add_argument("--workspace", type=Path, required=True)
+    args = parser.parse_args()
+
+    credentials = json.load(sys.stdin)
+    if not isinstance(credentials, list) or len(credentials) != 2:
+        raise ValueError("stdin must contain Claude and Codex credential strings")
+    if not all(isinstance(value, str) and value for value in credentials):
+        raise ValueError("credentials must be non-empty strings")
+
+    sources = {"claude": args.claude_source, "codex": args.codex_source}
+    tokens = dict(zip(("claude", "codex"), credentials, strict=True))
+    root = args.workspace / "synthetic-collectors"
+    receipts: dict[str, str] = {}
+    tombstoned: set[str] = set()
+    result = None
+    try:
+        timestamp = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+        for harness in ("claude", "codex"):
+            store_keychain_token(args.keychain_service, sources[harness], tokens[harness])
+            assert load_keychain_token(args.keychain_service, sources[harness]) == tokens[harness]
+            harness_root = root / harness
+            harness_root.mkdir(parents=True)
+            path = harness_root / ("rollout-synthetic.jsonl" if harness == "codex" else "synthetic.jsonl")
+            marker = f"c6d-{harness}-offline-{args.nonce}"
+            path.write_text(json.dumps(fixture(harness, marker, timestamp)) + "\n")
+            spool = root / f"{harness}.db"
+
+            offline = Collector(
+                root=harness_root,
+                harness=harness,
+                source_id=sources[harness],
+                spool_path=spool,
+                endpoint="http://127.0.0.1:1",
+                token=tokens[harness],
+                principal_id="owner",
+                visibility="private",
+            )
+            try:
+                scan = offline.scan()
+                assert scan["records_queued"] == 1
+                assert offline.doctor()["committed_files"] == 0
+                failed = offline.flush()
+                assert failed["acked"] == 0 and failed["errors"] > 0
+                assert offline.doctor()["pending"] == 1
+                assert offline.doctor()["committed_files"] == 0
+            finally:
+                offline.close()
+
+            online = Collector(
+                root=harness_root,
+                harness=harness,
+                source_id=sources[harness],
+                spool_path=spool,
+                endpoint=args.endpoint,
+                token=tokens[harness],
+                principal_id="owner",
+                visibility="private",
+            )
+            try:
+                recovered = online.flush()
+                assert recovered["acked"] == 1
+                doctor = online.doctor()
+                assert doctor["pending"] == 0
+                assert doctor["acked"] == 1
+                assert doctor["committed_files"] == 1
+                receipt = online.db.execute(
+                    "SELECT receipt FROM outbox WHERE state='acked'"
+                ).fetchone()["receipt"]
+                receipts[harness] = receipt
+                replay = online.flush()
+                assert replay["acked"] == 0 and replay["batches"] == 0
+                online.scan()
+                assert online.flush()["acked"] == 0
+
+                client = BrainClient(
+                    endpoint=args.endpoint,
+                    token=tokens[harness],
+                    source_id=sources[harness],
+                    principal_id="owner",
+                    visibility="private",
+                )
+                central = client.doctor()
+                assert central["source_events"] == 1 and central["live_items"] == 1
+                assert rank_for(client.search(marker, limit=5), receipt) == 1
+                resolved = client.resolve(receipt)
+                assert marker in json.dumps(resolved)
+
+                path.unlink()
+                deletion_scan = online.scan()
+                assert deletion_scan["tombstones_queued"] == 1
+                deletion = online.flush()
+                assert deletion["acked"] == 1
+                tombstoned.add(harness)
+                central = client.doctor()
+                assert central["source_events"] == 2 and central["live_items"] == 0
+                assert client.search(marker, limit=5)["results"] == []
+                try:
+                    client.resolve(receipt)
+                except urllib.error.HTTPError as error:
+                    assert error.code == 404
+                else:
+                    raise AssertionError("collector tombstone did not hide old receipt")
+            finally:
+                online.close()
+
+        result = {
+            "status": "pass",
+            "summary": {
+                "claude_offline_queued": 1,
+                "codex_offline_queued": 1,
+                "offline_committed_files": 0,
+                "claude_recovered_exactly_once": True,
+                "codex_recovered_exactly_once": True,
+                "claude_rank": 1,
+                "codex_rank": 1,
+                "receipts_exact": 2,
+                "replay_added_events": 0,
+                "tombstones": 2,
+                "live_items_after_rollback": 0,
+                "credential_bytes_rendered": False,
+            },
+        }
+    finally:
+        for harness, receipt in receipts.items():
+            if harness not in tombstoned:
+                try:
+                    MemoryClient(
+                        endpoint=args.endpoint,
+                        token=tokens[harness],
+                        source_id=sources[harness],
+                        principal_id="owner",
+                        visibility="private",
+                    ).delete(receipt)
+                except Exception:
+                    pass
+        statuses = [
+            delete_keychain_token(args.keychain_service, sources[harness])
+            for harness in ("claude", "codex")
+        ]
+        if any(status not in {0, ITEM_NOT_FOUND} for status in statuses):
+            raise RuntimeError(f"Keychain cleanup failed with OSStatus values {statuses}")
+        shutil.rmtree(root, ignore_errors=True)
+
+    for harness in ("claude", "codex"):
+        try:
+            load_keychain_token(args.keychain_service, sources[harness])
+        except RuntimeError as error:
+            if f"OSStatus {ITEM_NOT_FOUND}" not in str(error):
+                raise
+        else:
+            raise AssertionError("Keychain credential residue remains")
+    assert not root.exists()
+    assert result is not None
+    result["summary"]["keychain_residue"] = 0
+    result["summary"]["spool_and_fixture_residue"] = 0
+    print(json.dumps(result, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/recall/tests/test_backup_restore.py
+++ b/recall/tests/test_backup_restore.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "server/scripts/backup_restore.sh"
+
+
+class BackupPublicationTest(unittest.TestCase):
+    def test_backup_keeps_previous_dump_visible_until_replacement_is_complete(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            backup = root / "latest"
+            backup.mkdir()
+            (backup / "brain.dump").write_bytes(b"previous-complete-dump")
+            (backup / "manifest.json").write_text(json.dumps({"dump_sha256": "previous"}))
+            control = root / "control"
+            control.mkdir()
+            binaries = root / "bin"
+            binaries.mkdir()
+            docker = binaries / "docker"
+            docker.write_text(
+                """#!/bin/sh
+set -eu
+mount=''
+for argument in "$@"; do
+  case "$argument" in *:/backup) mount=${argument%:/backup};; esac
+done
+test -n "$mount"
+printf partial > "$mount/brain.dump"
+touch "$BACKUP_CONTROL_DIR/partial"
+while test ! -e "$BACKUP_CONTROL_DIR/continue"; do sleep 0.02; done
+printf complete-new-dump > "$mount/brain.dump"
+"""
+            )
+            docker.chmod(0o755)
+            psql = binaries / "psql"
+            psql.write_text(
+                """#!/bin/sh
+case "$*" in *'max(created_at)'*) echo 0;; *) echo '1:synthetic-fingerprint';; esac
+"""
+            )
+            psql.chmod(0o755)
+            environment = os.environ | {
+                "PATH": str(binaries) + os.pathsep + os.environ["PATH"],
+                "RECALL_DATABASE_URL": "postgresql://synthetic.invalid/db",
+                "BACKUP_CONTROL_DIR": str(control),
+            }
+            process = subprocess.Popen(
+                [str(SCRIPT), "backup", str(backup)], env=environment,
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+            )
+            try:
+                deadline = time.monotonic() + 5
+                while not (control / "partial").exists() and time.monotonic() < deadline:
+                    time.sleep(0.02)
+                self.assertTrue((control / "partial").exists(), "fake dump did not start")
+                self.assertEqual((backup / "brain.dump").read_bytes(), b"previous-complete-dump")
+                (control / "continue").touch()
+                stdout, stderr = process.communicate(timeout=5)
+                self.assertEqual(process.returncode, 0, stderr)
+                self.assertEqual((backup / "brain.dump").read_bytes(), b"complete-new-dump")
+                manifest = json.loads((backup / "manifest.json").read_text())
+                self.assertTrue(manifest["dump_sha256"])
+                self.assertIn('"schema_version": 1', stdout)
+            finally:
+                (control / "continue").touch()
+                if process.poll() is None:
+                    try:
+                        process.communicate(timeout=2)
+                    except subprocess.TimeoutExpired:
+                        process.kill()
+                        process.communicate()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a synthetic packaged-runtime macOS E2E for offline Claude and Codex recovery
- pin committed-cursor fail-closed behavior, exactly-once recovery, rank-1 receipts, replay stability, tombstone rollback, and cleanup
- publish logical backups from private staging and restore from a stable hard-linked snapshot

## Verification
- TDD red reproduced partial dump visibility during backup
- packaged collector, memory, and export E2Es against one candidate
- 66 Recall tests and 8 portability tests
- byte-identical content-free package builds
- PostgreSQL 17 E2Es
- isolated backup/restore drill
- zero added credential patterns or transcript/log artifacts