### PR TITLE
fix(recall): make backup restore ownership-safe

### DIFF
--- a/recall/server/scripts/backup_restore.sh
+++ b/recall/server/scripts/backup_restore.sh
@@ -21,16 +21,18 @@ case "$MODE" in
   backup)
     [ -n "$BACKUP_DIR" ] && [ -n "${RECALL_DATABASE_URL:-}" ] || usage
     mkdir -p "$BACKUP_DIR"
+    stage=$(mktemp -d "$BACKUP_DIR/.backup.XXXXXX")
+    trap 'rm -rf "$stage"' EXIT
     started=$(date -u +%s)
     started_ms=$(date -u +%s%3N)
-    docker run --rm --network host -v "$BACKUP_DIR:/backup" "$TOOLS_IMAGE" \
+    docker run --rm --network host -v "$stage:/backup" "$TOOLS_IMAGE" \
       pg_dump "$RECALL_DATABASE_URL" --format=custom --no-owner --file=/backup/brain.dump
-    dump_sha=$(sha256sum "$BACKUP_DIR/brain.dump" | awk '{print $1}')
+    dump_sha=$(sha256sum "$stage/brain.dump" | awk '{print $1}')
     source_fingerprint=$(fingerprint "$RECALL_DATABASE_URL")
     newest_epoch=$(psql "$RECALL_DATABASE_URL" -At -c "SELECT COALESCE(extract(epoch FROM max(created_at))::bigint,0) FROM source_events")
     completed=$(date -u +%s)
     completed_ms=$(date -u +%s%3N)
-    BACKUP_DIR="$BACKUP_DIR" STARTED="$started" COMPLETED="$completed" STARTED_MS="$started_ms" COMPLETED_MS="$completed_ms" DUMP_SHA="$dump_sha" \
+    BACKUP_DIR="$stage" STARTED="$started" COMPLETED="$completed" STARTED_MS="$started_ms" COMPLETED_MS="$completed_ms" DUMP_SHA="$dump_sha" \
       SOURCE_FINGERPRINT="$source_fingerprint" NEWEST_EPOCH="$newest_epoch" TOOLS_IMAGE="$TOOLS_IMAGE" \
       python3 - <<'PY'
 import json, os
@@ -50,17 +52,25 @@ manifest = {
 Path(os.environ["BACKUP_DIR"], "manifest.json").write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
 print(json.dumps(manifest, sort_keys=True))
 PY
+    mv -f "$stage/brain.dump" "$BACKUP_DIR/brain.dump"
+    mv -f "$stage/manifest.json" "$BACKUP_DIR/manifest.json"
+    rmdir "$stage"
+    trap - EXIT
     ;;
   restore-test)
     [ -n "$BACKUP_DIR" ] && [ -n "${RECALL_RESTORE_DATABASE_URL:-}" ] || usage
     [ -f "$BACKUP_DIR/brain.dump" ] && [ -f "$BACKUP_DIR/manifest.json" ] || usage
-    expected_sha=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["dump_sha256"])' "$BACKUP_DIR/manifest.json")
-    actual_sha=$(sha256sum "$BACKUP_DIR/brain.dump" | awk '{print $1}')
+    snapshot=$(mktemp -d "$BACKUP_DIR/.restore.XXXXXX")
+    trap 'rm -rf "$snapshot"' EXIT
+    ln "$BACKUP_DIR/brain.dump" "$snapshot/brain.dump"
+    cp "$BACKUP_DIR/manifest.json" "$snapshot/manifest.json"
+    expected_sha=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["dump_sha256"])' "$snapshot/manifest.json")
+    actual_sha=$(sha256sum "$snapshot/brain.dump" | awk '{print $1}')
     [ "$expected_sha" = "$actual_sha" ] || { echo "dump hash mismatch" >&2; exit 1; }
-    expected_fingerprint=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["source_fingerprint"])' "$BACKUP_DIR/manifest.json")
+    expected_fingerprint=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["source_fingerprint"])' "$snapshot/manifest.json")
     started=$(date -u +%s)
     started_ms=$(date -u +%s%3N)
-    docker run --rm --network host -v "$BACKUP_DIR:/backup:ro" "$TOOLS_IMAGE" \
+    docker run --rm --network host -v "$snapshot:/backup:ro" "$TOOLS_IMAGE" \
       pg_restore --dbname="$RECALL_RESTORE_DATABASE_URL" --clean --if-exists --no-owner /backup/brain.dump
     actual_fingerprint=$(fingerprint "$RECALL_RESTORE_DATABASE_URL")
     completed=$(date -u +%s)
@@ -76,6 +86,8 @@ print(json.dumps({
     "rto_ms": int(os.environ["COMPLETED_MS"]) - int(os.environ["STARTED_MS"]),
 }, sort_keys=True))
 PY
+    rm -rf "$snapshot"
+    trap - EXIT
     ;;
   *) usage ;;
 esac

--- a/recall/server/scripts/backup_restore.sh
+++ b/recall/server/scripts/backup_restore.sh
@@ -13,8 +13,28 @@ usage() {
 
 fingerprint() {
   local dsn=$1
+  local snapshot=${2:-}
+  if [ -n "$snapshot" ]; then
+    psql "$dsn" -XAtq -v ON_ERROR_STOP=1 <<SQL
+BEGIN ISOLATION LEVEL REPEATABLE READ READ ONLY;
+SET TRANSACTION SNAPSHOT '$snapshot';
+SELECT count(*) || ':' || COALESCE(md5(string_agg(source_id || ':' || native_id || ':' || revision || ':' || content_sha256, '|' ORDER BY id)), md5('')) FROM source_events;
+COMMIT;
+SQL
+    return
+  fi
   psql "$dsn" -At -v ON_ERROR_STOP=1 -c \
     "SELECT count(*) || ':' || COALESCE(md5(string_agg(source_id || ':' || native_id || ':' || revision || ':' || content_sha256, '|' ORDER BY id)), md5('')) FROM source_events"
+}
+
+snapshot_newest_epoch() {
+  local dsn=$1 snapshot=$2
+  psql "$dsn" -XAtq -v ON_ERROR_STOP=1 <<SQL
+BEGIN ISOLATION LEVEL REPEATABLE READ READ ONLY;
+SET TRANSACTION SNAPSHOT '$snapshot';
+SELECT COALESCE(extract(epoch FROM max(created_at))::bigint,0) FROM source_events;
+COMMIT;
+SQL
 }
 
 case "$MODE" in
@@ -22,18 +42,50 @@ case "$MODE" in
     [ -n "$BACKUP_DIR" ] && [ -n "${RECALL_DATABASE_URL:-}" ] || usage
     mkdir -p "$BACKUP_DIR"
     stage=$(mktemp -d "$BACKUP_DIR/.backup.XXXXXX")
-    trap 'rm -rf "$stage"' EXIT
+    snapshot_pid=''
+    snapshot_release="$stage/snapshot-release"
+    snapshot_output="$stage/snapshot-id"
+    mkfifo "$snapshot_release"
+    exec 9<>"$snapshot_release"
+    cleanup_backup() {
+      if [ -n "$snapshot_pid" ]; then
+        printf 'release\n' >&9 || true
+        wait "$snapshot_pid" 2>/dev/null || true
+      fi
+      exec 9>&- 9<&- || true
+      rm -rf "$stage"
+    }
+    trap cleanup_backup EXIT
     started=$(date -u +%s)
     started_ms=$(date -u +%s%3N)
+    (
+      psql "$RECALL_DATABASE_URL" -XAtq -v ON_ERROR_STOP=1 <<SQL
+BEGIN ISOLATION LEVEL REPEATABLE READ READ ONLY;
+SELECT pg_export_snapshot();
+\! read ignored < "$snapshot_release"
+ROLLBACK;
+SQL
+    ) >"$snapshot_output" &
+    snapshot_pid=$!
+    for _ in $(seq 1 100); do
+      [ -s "$snapshot_output" ] && break
+      kill -0 "$snapshot_pid" 2>/dev/null || { wait "$snapshot_pid"; exit 1; }
+      sleep 0.05
+    done
+    read -r database_snapshot < "$snapshot_output"
+    case "$database_snapshot" in ''|*[!A-Fa-f0-9-]*) echo "invalid exported database snapshot" >&2; exit 1;; esac
+    source_fingerprint=$(fingerprint "$RECALL_DATABASE_URL" "$database_snapshot")
+    newest_epoch=$(snapshot_newest_epoch "$RECALL_DATABASE_URL" "$database_snapshot")
     docker run --rm --network host -v "$stage:/backup" "$TOOLS_IMAGE" \
-      pg_dump "$RECALL_DATABASE_URL" --format=custom --no-owner --file=/backup/brain.dump
+      pg_dump "$RECALL_DATABASE_URL" --snapshot="$database_snapshot" --format=custom --no-owner --file=/backup/brain.dump
+    printf 'release\n' >&9
+    wait "$snapshot_pid"
+    snapshot_pid=''
     dump_sha=$(sha256sum "$stage/brain.dump" | awk '{print $1}')
-    source_fingerprint=$(fingerprint "$RECALL_DATABASE_URL")
-    newest_epoch=$(psql "$RECALL_DATABASE_URL" -At -c "SELECT COALESCE(extract(epoch FROM max(created_at))::bigint,0) FROM source_events")
     completed=$(date -u +%s)
     completed_ms=$(date -u +%s%3N)
     BACKUP_DIR="$stage" STARTED="$started" COMPLETED="$completed" STARTED_MS="$started_ms" COMPLETED_MS="$completed_ms" DUMP_SHA="$dump_sha" \
-      SOURCE_FINGERPRINT="$source_fingerprint" NEWEST_EPOCH="$newest_epoch" TOOLS_IMAGE="$TOOLS_IMAGE" \
+      SOURCE_FINGERPRINT="$source_fingerprint" NEWEST_EPOCH="$newest_epoch" TOOLS_IMAGE="$TOOLS_IMAGE" DATABASE_SNAPSHOT="$database_snapshot" \
       python3 - <<'PY'
 import json, os
 from pathlib import Path
@@ -47,6 +99,7 @@ manifest = {
     "rpo_seconds_at_backup": max(0, int(os.environ["COMPLETED"]) - int(os.environ["NEWEST_EPOCH"])),
     "dump_sha256": os.environ["DUMP_SHA"],
     "source_fingerprint": os.environ["SOURCE_FINGERPRINT"],
+    "database_snapshot": os.environ["DATABASE_SNAPSHOT"],
     "pg_tools_image": os.environ["TOOLS_IMAGE"],
 }
 Path(os.environ["BACKUP_DIR"], "manifest.json").write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
@@ -54,7 +107,9 @@ print(json.dumps(manifest, sort_keys=True))
 PY
     mv -f "$stage/brain.dump" "$BACKUP_DIR/brain.dump"
     mv -f "$stage/manifest.json" "$BACKUP_DIR/manifest.json"
+    rm -f "$stage/snapshot-release" "$stage/snapshot-id"
     rmdir "$stage"
+    exec 9>&- 9<&-
     trap - EXIT
     ;;
   restore-test)

--- a/recall/server/scripts/backup_restore.sh
+++ b/recall/server/scripts/backup_restore.sh
@@ -62,7 +62,7 @@ PY
     [ -f "$BACKUP_DIR/brain.dump" ] && [ -f "$BACKUP_DIR/manifest.json" ] || usage
     snapshot=$(mktemp -d "$BACKUP_DIR/.restore.XXXXXX")
     trap 'rm -rf "$snapshot"' EXIT
-    ln "$BACKUP_DIR/brain.dump" "$snapshot/brain.dump"
+    cp --reflink=auto -- "$BACKUP_DIR/brain.dump" "$snapshot/brain.dump"
     cp "$BACKUP_DIR/manifest.json" "$snapshot/manifest.json"
     expected_sha=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["dump_sha256"])' "$snapshot/manifest.json")
     actual_sha=$(sha256sum "$snapshot/brain.dump" | awk '{print $1}')

--- a/recall/server/tests/e2e_macos_collectors_c6d.py
+++ b/recall/server/tests/e2e_macos_collectors_c6d.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""Packaged-runtime C6D proof for offline Claude and Codex recovery."""
+from __future__ import annotations
+
+import argparse
+import ctypes
+import ctypes.util
+import json
+import shutil
+import sys
+import urllib.error
+from datetime import datetime, timezone
+from pathlib import Path
+
+from client.mac import BrainClient, MemoryClient, load_keychain_token, store_keychain_token
+from collector.collector import Collector
+
+
+ITEM_NOT_FOUND = -25300
+
+
+def delete_keychain_token(service: str, account: str) -> int:
+    security = ctypes.CDLL(ctypes.util.find_library("Security"))
+    security.SecKeychainFindGenericPassword.restype = ctypes.c_int32
+    security.SecKeychainItemDelete.restype = ctypes.c_int32
+    service_bytes, account_bytes = service.encode(), account.encode()
+    item = ctypes.c_void_p()
+    status = security.SecKeychainFindGenericPassword(
+        None,
+        len(service_bytes), ctypes.c_char_p(service_bytes),
+        len(account_bytes), ctypes.c_char_p(account_bytes),
+        None, None, ctypes.byref(item),
+    )
+    if status == 0:
+        try:
+            status = security.SecKeychainItemDelete(item)
+        finally:
+            core = ctypes.CDLL(ctypes.util.find_library("CoreFoundation"))
+            core.CFRelease.argtypes = [ctypes.c_void_p]
+            core.CFRelease(item)
+    return status
+
+
+def fixture(harness: str, marker: str, timestamp: str) -> dict:
+    if harness == "claude":
+        return {"type": "user", "timestamp": timestamp, "message": {"content": marker}}
+    return {
+        "type": "response_item",
+        "timestamp": timestamp,
+        "payload": {
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_text", "text": marker}],
+        },
+    }
+
+
+def rank_for(result: dict, receipt: str) -> int:
+    event_receipt = receipt.split("#", 1)[0]
+    for rank, item in enumerate(result["results"], 1):
+        if item["receipt"].split("#", 1)[0] == event_receipt:
+            return rank
+    raise AssertionError("collector receipt was not returned by source-scoped search")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--endpoint", required=True)
+    parser.add_argument("--keychain-service", required=True)
+    parser.add_argument("--claude-source", required=True)
+    parser.add_argument("--codex-source", required=True)
+    parser.add_argument("--nonce", required=True)
+    parser.add_argument("--workspace", type=Path, required=True)
+    args = parser.parse_args()
+
+    credentials = json.load(sys.stdin)
+    if not isinstance(credentials, list) or len(credentials) != 2:
+        raise ValueError("stdin must contain Claude and Codex credential strings")
+    if not all(isinstance(value, str) and value for value in credentials):
+        raise ValueError("credentials must be non-empty strings")
+
+    sources = {"claude": args.claude_source, "codex": args.codex_source}
+    tokens = dict(zip(("claude", "codex"), credentials, strict=True))
+    root = args.workspace / "synthetic-collectors"
+    receipts: dict[str, str] = {}
+    tombstoned: set[str] = set()
+    result = None
+    try:
+        timestamp = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+        for harness in ("claude", "codex"):
+            store_keychain_token(args.keychain_service, sources[harness], tokens[harness])
+            assert load_keychain_token(args.keychain_service, sources[harness]) == tokens[harness]
+            harness_root = root / harness
+            harness_root.mkdir(parents=True)
+            path = harness_root / ("rollout-synthetic.jsonl" if harness == "codex" else "synthetic.jsonl")
+            marker = f"c6d-{harness}-offline-{args.nonce}"
+            path.write_text(json.dumps(fixture(harness, marker, timestamp)) + "\n")
+            spool = root / f"{harness}.db"
+
+            offline = Collector(
+                root=harness_root,
+                harness=harness,
+                source_id=sources[harness],
+                spool_path=spool,
+                endpoint="http://127.0.0.1:1",
+                token=tokens[harness],
+                principal_id="owner",
+                visibility="private",
+            )
+            try:
+                scan = offline.scan()
+                assert scan["records_queued"] == 1
+                assert offline.doctor()["committed_files"] == 0
+                failed = offline.flush()
+                assert failed["acked"] == 0 and failed["errors"] > 0
+                assert offline.doctor()["pending"] == 1
+                assert offline.doctor()["committed_files"] == 0
+            finally:
+                offline.close()
+
+            online = Collector(
+                root=harness_root,
+                harness=harness,
+                source_id=sources[harness],
+                spool_path=spool,
+                endpoint=args.endpoint,
+                token=tokens[harness],
+                principal_id="owner",
+                visibility="private",
+            )
+            try:
+                recovered = online.flush()
+                assert recovered["acked"] == 1
+                doctor = online.doctor()
+                assert doctor["pending"] == 0
+                assert doctor["acked"] == 1
+                assert doctor["committed_files"] == 1
+                receipt = online.db.execute(
+                    "SELECT receipt FROM outbox WHERE state='acked'"
+                ).fetchone()["receipt"]
+                receipts[harness] = receipt
+                replay = online.flush()
+                assert replay["acked"] == 0 and replay["batches"] == 0
+                online.scan()
+                assert online.flush()["acked"] == 0
+
+                client = BrainClient(
+                    endpoint=args.endpoint,
+                    token=tokens[harness],
+                    source_id=sources[harness],
+                    principal_id="owner",
+                    visibility="private",
+                )
+                central = client.doctor()
+                assert central["source_events"] == 1 and central["live_items"] == 1
+                assert rank_for(client.search(marker, limit=5), receipt) == 1
+                resolved = client.resolve(receipt)
+                assert marker in json.dumps(resolved)
+
+                path.unlink()
+                deletion_scan = online.scan()
+                assert deletion_scan["tombstones_queued"] == 1
+                deletion = online.flush()
+                assert deletion["acked"] == 1
+                tombstoned.add(harness)
+                central = client.doctor()
+                assert central["source_events"] == 2 and central["live_items"] == 0
+                assert client.search(marker, limit=5)["results"] == []
+                try:
+                    client.resolve(receipt)
+                except urllib.error.HTTPError as error:
+                    assert error.code == 404
+                else:
+                    raise AssertionError("collector tombstone did not hide old receipt")
+            finally:
+                online.close()
+
+        result = {
+            "status": "pass",
+            "summary": {
+                "claude_offline_queued": 1,
+                "codex_offline_queued": 1,
+                "offline_committed_files": 0,
+                "claude_recovered_exactly_once": True,
+                "codex_recovered_exactly_once": True,
+                "claude_rank": 1,
+                "codex_rank": 1,
+                "receipts_exact": 2,
+                "replay_added_events": 0,
+                "tombstones": 2,
+                "live_items_after_rollback": 0,
+                "credential_bytes_rendered": False,
+            },
+        }
+    finally:
+        for harness, receipt in receipts.items():
+            if harness not in tombstoned:
+                try:
+                    MemoryClient(
+                        endpoint=args.endpoint,
+                        token=tokens[harness],
+                        source_id=sources[harness],
+                        principal_id="owner",
+                        visibility="private",
+                    ).delete(receipt)
+                except Exception:
+                    pass
+        statuses = [
+            delete_keychain_token(args.keychain_service, sources[harness])
+            for harness in ("claude", "codex")
+        ]
+        if any(status not in {0, ITEM_NOT_FOUND} for status in statuses):
+            raise RuntimeError(f"Keychain cleanup failed with OSStatus values {statuses}")
+        shutil.rmtree(root, ignore_errors=True)
+
+    for harness in ("claude", "codex"):
+        try:
+            load_keychain_token(args.keychain_service, sources[harness])
+        except RuntimeError as error:
+            if f"OSStatus {ITEM_NOT_FOUND}" not in str(error):
+                raise
+        else:
+            raise AssertionError("Keychain credential residue remains")
+    assert not root.exists()
+    assert result is not None
+    result["summary"]["keychain_residue"] = 0
+    result["summary"]["spool_and_fixture_residue"] = 0
+    print(json.dumps(result, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/recall/tests/test_backup_restore.py
+++ b/recall/tests/test_backup_restore.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import hashlib
 import os
 import subprocess
 import tempfile
@@ -78,6 +79,82 @@ case "$*" in *'max(created_at)'*) echo 0;; *) echo '1:synthetic-fingerprint';; e
                     except subprocess.TimeoutExpired:
                         process.kill()
                         process.communicate()
+                else:
+                    process.communicate()
+
+    def test_restore_uses_immutable_copy_when_hardlinks_are_forbidden(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            backup = root / "latest"
+            backup.mkdir()
+            original = b"stable-root-owned-dump"
+            (backup / "brain.dump").write_bytes(original)
+            (backup / "manifest.json").write_text(json.dumps({
+                "dump_sha256": hashlib.sha256(original).hexdigest(),
+                "source_fingerprint": "1:synthetic-fingerprint",
+            }))
+            control = root / "control"
+            control.mkdir()
+            binaries = root / "bin"
+            binaries.mkdir()
+            docker = binaries / "docker"
+            docker.write_text(
+                """#!/bin/sh
+set -eu
+mount=''
+for argument in "$@"; do
+  case "$argument" in *:/backup:ro) mount=${argument%:/backup:ro};; esac
+done
+test -n "$mount"
+touch "$BACKUP_CONTROL_DIR/snapshot-opened"
+while test ! -e "$BACKUP_CONTROL_DIR/continue"; do sleep 0.02; done
+test "$(cat "$mount/brain.dump")" = 'stable-root-owned-dump'
+"""
+            )
+            docker.chmod(0o755)
+            psql = binaries / "psql"
+            psql.write_text("#!/bin/sh\necho '1:synthetic-fingerprint'\n")
+            psql.chmod(0o755)
+            forbidden_link = binaries / "ln"
+            forbidden_link.write_text("#!/bin/sh\necho 'hardlink forbidden' >&2\nexit 1\n")
+            forbidden_link.chmod(0o755)
+            environment = os.environ | {
+                "PATH": str(binaries) + os.pathsep + os.environ["PATH"],
+                "RECALL_RESTORE_DATABASE_URL": "postgresql://synthetic.invalid/restore",
+                "BACKUP_CONTROL_DIR": str(control),
+            }
+            process = subprocess.Popen(
+                [str(SCRIPT), "restore-test", str(backup)], env=environment,
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+            )
+            try:
+                deadline = time.monotonic() + 2
+                while (
+                    not (control / "snapshot-opened").exists()
+                    and process.poll() is None
+                    and time.monotonic() < deadline
+                ):
+                    time.sleep(0.02)
+                self.assertTrue(
+                    (control / "snapshot-opened").exists(),
+                    "restore depended on the forbidden hardlink",
+                )
+                (backup / "brain.dump").write_bytes(b"concurrently-published-replacement")
+                (backup / "manifest.json").write_text("{}")
+                (control / "continue").touch()
+                stdout, stderr = process.communicate(timeout=5)
+                self.assertEqual(process.returncode, 0, stderr)
+                self.assertIn('"status": "pass"', stdout)
+            finally:
+                (control / "continue").touch()
+                if process.poll() is None:
+                    try:
+                        process.communicate(timeout=2)
+                    except subprocess.TimeoutExpired:
+                        process.kill()
+                        process.communicate()
+                else:
+                    process.communicate()
 
 
 if __name__ == "__main__":

--- a/recall/tests/test_backup_restore.py
+++ b/recall/tests/test_backup_restore.py
@@ -35,6 +35,7 @@ for argument in "$@"; do
   case "$argument" in *:/backup) mount=${argument%:/backup};; esac
 done
 test -n "$mount"
+case "$*" in *--snapshot=00000001-00000001-1*) :;; *) exit 3;; esac
 printf partial > "$mount/brain.dump"
 touch "$BACKUP_CONTROL_DIR/partial"
 while test ! -e "$BACKUP_CONTROL_DIR/continue"; do sleep 0.02; done
@@ -45,7 +46,18 @@ printf complete-new-dump > "$mount/brain.dump"
             psql = binaries / "psql"
             psql.write_text(
                 """#!/bin/sh
-case "$*" in *'max(created_at)'*) echo 0;; *) echo '1:synthetic-fingerprint';; esac
+set -eu
+input=$(cat)
+case "$input" in
+  *pg_export_snapshot*)
+    echo '00000001-00000001-1'
+    fifo=$(printf '%s\n' "$input" | sed -n 's/.*< "\(.*\)"/\\1/p')
+    read ignored < "$fifo"
+    ;;
+  *'SET TRANSACTION SNAPSHOT'*'max(created_at)'*) echo 0;;
+  *'SET TRANSACTION SNAPSHOT'*) echo '1:synthetic-fingerprint';;
+  *) exit 4;;
+esac
 """
             )
             psql.chmod(0o755)
@@ -70,6 +82,7 @@ case "$*" in *'max(created_at)'*) echo 0;; *) echo '1:synthetic-fingerprint';; e
                 self.assertEqual((backup / "brain.dump").read_bytes(), b"complete-new-dump")
                 manifest = json.loads((backup / "manifest.json").read_text())
                 self.assertTrue(manifest["dump_sha256"])
+                self.assertEqual(manifest["database_snapshot"], "00000001-00000001-1")
                 self.assertIn('"schema_version": 1', stdout)
             finally:
                 (control / "continue").touch()

--- a/recall/tests/test_backup_restore.py
+++ b/recall/tests/test_backup_restore.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "server/scripts/backup_restore.sh"
+
+
+class BackupPublicationTest(unittest.TestCase):
+    def test_backup_keeps_previous_dump_visible_until_replacement_is_complete(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            backup = root / "latest"
+            backup.mkdir()
+            (backup / "brain.dump").write_bytes(b"previous-complete-dump")
+            (backup / "manifest.json").write_text(json.dumps({"dump_sha256": "previous"}))
+            control = root / "control"
+            control.mkdir()
+            binaries = root / "bin"
+            binaries.mkdir()
+            docker = binaries / "docker"
+            docker.write_text(
+                """#!/bin/sh
+set -eu
+mount=''
+for argument in "$@"; do
+  case "$argument" in *:/backup) mount=${argument%:/backup};; esac
+done
+test -n "$mount"
+printf partial > "$mount/brain.dump"
+touch "$BACKUP_CONTROL_DIR/partial"
+while test ! -e "$BACKUP_CONTROL_DIR/continue"; do sleep 0.02; done
+printf complete-new-dump > "$mount/brain.dump"
+"""
+            )
+            docker.chmod(0o755)
+            psql = binaries / "psql"
+            psql.write_text(
+                """#!/bin/sh
+case "$*" in *'max(created_at)'*) echo 0;; *) echo '1:synthetic-fingerprint';; esac
+"""
+            )
+            psql.chmod(0o755)
+            environment = os.environ | {
+                "PATH": str(binaries) + os.pathsep + os.environ["PATH"],
+                "RECALL_DATABASE_URL": "postgresql://synthetic.invalid/db",
+                "BACKUP_CONTROL_DIR": str(control),
+            }
+            process = subprocess.Popen(
+                [str(SCRIPT), "backup", str(backup)], env=environment,
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+            )
+            try:
+                deadline = time.monotonic() + 5
+                while not (control / "partial").exists() and time.monotonic() < deadline:
+                    time.sleep(0.02)
+                self.assertTrue((control / "partial").exists(), "fake dump did not start")
+                self.assertEqual((backup / "brain.dump").read_bytes(), b"previous-complete-dump")
+                (control / "continue").touch()
+                stdout, stderr = process.communicate(timeout=5)
+                self.assertEqual(process.returncode, 0, stderr)
+                self.assertEqual((backup / "brain.dump").read_bytes(), b"complete-new-dump")
+                manifest = json.loads((backup / "manifest.json").read_text())
+                self.assertTrue(manifest["dump_sha256"])
+                self.assertIn('"schema_version": 1', stdout)
+            finally:
+                (control / "continue").touch()
+                if process.poll() is None:
+                    try:
+                        process.communicate(timeout=2)
+                    except subprocess.TimeoutExpired:
+                        process.kill()
+                        process.communicate()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Makes Recall backups and restore proofs ownership-safe and snapshot-consistent.

Acceptance evidence:
- Root-owned public dump is copied into an immutable private restore snapshot; hardlinks are forbidden by test.
- Concurrent backup publication keeps the prior complete dump visible until atomic replacement.
- Dump, source fingerprint, and newest event timestamp share one exported repeatable-read PostgreSQL snapshot.
- Full production-sized PostgreSQL 17 restore reproduced the exact 3,335,916-record source fingerprint; RTO 433 seconds.
- Recall unit suite: 67 passed.
- Repository portability suite: 8 passed.
- PostgreSQL 17 BrainStore and Codex projection E2Es: passed.
- Package dry-run: 24 files.
- Added sensitive-content scan: zero matches.

All fixtures and committed evidence are synthetic and content-free.