### PR TITLE
feat(recall): add explicit ChatGPT export inbox

### DIFF
--- a/recall/client/README.md
+++ b/recall/client/README.md
@@ -54,6 +54,14 @@ client and its spool with:
 ./uninstall.sh
 ```
 
+To continuously ingest only files deliberately copied into a flat export inbox,
+add `--export-inbox "$HOME/Recall Inbox"`. The installer creates a separate
+private LaunchAgent and uses Keychain account `chatgpt-export:mac:<host-id>`.
+This does not inspect the ChatGPT app, Cowork, Downloads, or browser storage.
+Re-run with `--disable-export-inbox` to unload only that LaunchAgent while
+preserving its content-free catalog/spool for recovery; full uninstall removes
+all Recall client state but never deletes the user-owned inbox.
+
 ## Supported exports and explicit memory
 
 Only files supplied on the command line are considered. JSON, JSONL, and ZIP

--- a/recall/client/cli.py
+++ b/recall/client/cli.py
@@ -16,6 +16,8 @@ from client.mac import (
     store_keychain_token,
 )
 from collector.collector import Collector
+from connectors.export_inbox import ExportInboxConnector
+from connectors.sdk import ConnectorRunner
 from privacy.policy import AgenticJudge, PrivacyPolicy, load_scoped_virtual_key
 
 
@@ -46,6 +48,11 @@ def _privacy(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--privacy-judge-key-file", default=os.environ.get("RECALL_PRIVACY_JUDGE_KEY_FILE"))
     parser.add_argument("--privacy-judge-model", default=os.environ.get("RECALL_PRIVACY_JUDGE_MODEL"))
     parser.add_argument("--privacy-judge-failure", choices=("drop", "ignore"), default="drop")
+
+
+def _export_inbox(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--inbox", required=True)
+    parser.add_argument("--catalog", required=True)
 
 
 def _privacy_policy(args) -> PrivacyPolicy:
@@ -94,6 +101,23 @@ def parser() -> argparse.ArgumentParser:
     preview = commands.add_parser("privacy-preview")
     _privacy(preview)
 
+    inbox_dry = commands.add_parser("export-inbox-dry-run")
+    _export_inbox(inbox_dry)
+    inbox_dry.add_argument("--privacy-mode", choices=("off", "scrub", "drop"), default=os.environ.get("RECALL_PRIVACY_MODE", "off"))
+
+    inbox_list = commands.add_parser("export-inbox-list")
+    _export_inbox(inbox_list)
+
+    inbox_remove = commands.add_parser("export-inbox-remove")
+    _export_inbox(inbox_remove)
+    inbox_remove.add_argument("export_id")
+
+    inbox_sync = commands.add_parser("export-inbox-sync")
+    _connection(inbox_sync)
+    _privacy(inbox_sync)
+    _export_inbox(inbox_sync)
+    inbox_sync.add_argument("--spool", required=True)
+
     delete = commands.add_parser("delete")
     _connection(delete)
     delete.add_argument("receipt")
@@ -134,6 +158,23 @@ def main() -> None:
             value = raw
         print(json.dumps(_privacy_policy(args).apply(value).receipt(), sort_keys=True))
         return
+    if args.command in {"export-inbox-dry-run", "export-inbox-list", "export-inbox-remove"}:
+        connector = ExportInboxConnector(
+            inbox=Path(args.inbox), catalog_path=Path(args.catalog),
+            source_id="chatgpt:export:local",
+            privacy_mode=getattr(args, "privacy_mode", "off"),
+        )
+        try:
+            if args.command == "export-inbox-dry-run":
+                result = connector.dry_run()
+            elif args.command == "export-inbox-list":
+                result = {"schema_version": 1, "exports": connector.exports()}
+            else:
+                result = connector.queue_remove(args.export_id)
+        finally:
+            connector.close()
+        print(json.dumps(result, sort_keys=True))
+        return
 
     if args.keychain_service and not args.keychain_account:
         raise SystemExit("--keychain-account is required with --keychain-service")
@@ -145,7 +186,7 @@ def main() -> None:
         "principal_id": args.principal_id,
         "visibility": args.visibility,
     }
-    privacy = _privacy_policy(args) if args.command in {"collect", "export", "put"} else PrivacyPolicy(mode="off")
+    privacy = _privacy_policy(args) if args.command in {"collect", "export", "put", "export-inbox-sync"} else PrivacyPolicy(mode="off")
     if args.command == "collect":
         collector = Collector(
             root=Path(args.root), harness=args.harness, source_id=args.source_id,
@@ -164,6 +205,26 @@ def main() -> None:
             result = {**inventory, "records": len(inventory["records"])}
         else:
             result = importer.import_with(BrainClient(**common, privacy=privacy), [Path(value) for value in args.inputs])
+    elif args.command == "export-inbox-sync":
+        if args.visibility != "private":
+            raise SystemExit("export inbox visibility must be private")
+        connector = ExportInboxConnector(
+            inbox=Path(args.inbox), catalog_path=Path(args.catalog),
+            source_id=args.source_id, privacy_mode=args.privacy_mode,
+        )
+        runner = ConnectorRunner(
+            connector=connector, brain=BrainClient(**common),
+            spool_path=Path(args.spool), privacy=privacy,
+        )
+        try:
+            result = {
+                "sync": runner.run_once(),
+                "doctor": runner.doctor(),
+                "exports": len(connector.exports()),
+            }
+        finally:
+            runner.close()
+            connector.close()
     elif args.command == "put":
         text = args.text if args.text is not None else sys.stdin.read()
         result = MemoryClient(**common, privacy=privacy).put(text, provenance={"uri": args.provenance_uri})

--- a/recall/client/macos/install.sh
+++ b/recall/client/macos/install.sh
@@ -12,6 +12,8 @@ CLAUDE_ROOT="$HOME/.claude/projects"
 CODEX_ROOT="$HOME/.codex/sessions"
 NO_LOAD=0
 PRIVACY_MODE="off"
+EXPORT_INBOX=""
+DISABLE_EXPORT_INBOX=0
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -25,8 +27,10 @@ while [ "$#" -gt 0 ]; do
     --claude-root) CLAUDE_ROOT=$2; shift 2 ;;
     --codex-root) CODEX_ROOT=$2; shift 2 ;;
     --privacy-mode) PRIVACY_MODE=$2; shift 2 ;;
+    --export-inbox) EXPORT_INBOX=$2; shift 2 ;;
+    --disable-export-inbox) DISABLE_EXPORT_INBOX=1; shift ;;
     --no-load) NO_LOAD=1; shift ;;
-    *) echo "usage: install.sh --endpoint URL --host-id ID --keychain-service SERVICE --visibility private|shared --sources claude,codex [--privacy-mode off|scrub|drop] [--claude-root PATH] [--codex-root PATH] [--prefix PATH] [--launch-agents PATH] [--no-load]" >&2; exit 2 ;;
+    *) echo "usage: install.sh --endpoint URL --host-id ID --keychain-service SERVICE --visibility private|shared [--sources claude,codex] [--export-inbox PATH | --disable-export-inbox] [--privacy-mode off|scrub|drop] [--claude-root PATH] [--codex-root PATH] [--prefix PATH] [--launch-agents PATH] [--no-load]" >&2; exit 2 ;;
   esac
 done
 
@@ -35,14 +39,22 @@ case "$HOST_ID" in ""|*[!A-Za-z0-9_.-]*) echo "invalid host id" >&2; exit 2 ;; e
 [ -n "$KEYCHAIN_SERVICE" ] || { echo "keychain service is required" >&2; exit 2; }
 case "$VISIBILITY" in private|shared) ;; *) echo "visibility must be private or shared" >&2; exit 2 ;; esac
 case "$PRIVACY_MODE" in off|scrub|drop) ;; *) echo "privacy mode must be off, scrub, or drop" >&2; exit 2 ;; esac
-case ",$SOURCES," in
-  *,claude,*|*,codex,*) ;;
-  *) echo "sources must select claude, codex, or claude,codex" >&2; exit 2 ;;
-esac
-case ",$SOURCES," in *,,*|*,claude,claude,*|*,codex,codex,*|*,claude,codex,claude,*|*,codex,claude,codex,*) echo "invalid duplicate or empty source selection" >&2; exit 2 ;; esac
+if [ -n "$EXPORT_INBOX" ] && [ "$DISABLE_EXPORT_INBOX" -eq 1 ]; then
+  echo "export inbox enable and disable options are mutually exclusive" >&2; exit 2
+fi
+if [ -z "$SOURCES" ] && [ -z "$EXPORT_INBOX" ] && [ "$DISABLE_EXPORT_INBOX" -eq 0 ]; then
+  echo "select at least one coding source or an explicit export inbox" >&2; exit 2
+fi
+if [ -n "$SOURCES" ]; then
+  case ",$SOURCES," in *,claude,*|*,codex,*) ;; *) echo "sources must select claude, codex, or claude,codex" >&2; exit 2 ;; esac
+  case ",$SOURCES," in *,,*|*,claude,claude,*|*,codex,codex,*|*,claude,codex,claude,*|*,codex,claude,codex,*) echo "invalid duplicate or empty source selection" >&2; exit 2 ;; esac
+fi
 for SOURCE_NAME in $(echo "$SOURCES" | tr ',' ' '); do
   case "$SOURCE_NAME" in claude|codex) ;; *) echo "unsupported source: $SOURCE_NAME" >&2; exit 2 ;; esac
 done
+if [ -n "$EXPORT_INBOX" ]; then
+  [ -d "$EXPORT_INBOX" ] && [ ! -L "$EXPORT_INBOX" ] || { echo "export inbox must be an explicit non-symlink directory" >&2; exit 2; }
+fi
 
 SOURCE=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 mkdir -p "$PREFIX" "$PREFIX/bin" "$PREFIX/lib" "$PREFIX/state" "$LAUNCH_AGENTS"
@@ -131,8 +143,58 @@ PY
   fi
 }
 
+write_export_inbox_plist() {
+  SOURCE_ID="chatgpt-export:mac:$HOST_ID"
+  LABEL="ai.parcha.recall.chatgpt-export"
+  PLIST="$LAUNCH_AGENTS/$LABEL.plist"
+  SPOOL="$PREFIX/state/chatgpt-export-runner.db"
+  CATALOG="$PREFIX/state/chatgpt-export-catalog.db"
+  if [ "$NO_LOAD" -eq 0 ] && command -v launchctl >/dev/null 2>&1; then
+    launchctl bootout "gui/$(id -u)/$LABEL" >/dev/null 2>&1 || true
+  fi
+  "$RUNTIME" - "$PLIST" "$LABEL" "$RUNTIME" "$PREFIX/lib" "$ENDPOINT" "$SOURCE_ID" "$EXPORT_INBOX" "$CATALOG" "$SPOOL" "$KEYCHAIN_SERVICE" "$PRIVACY_MODE" <<'PY'
+import plistlib
+import sys
+
+path, label, program, pythonpath, endpoint, source_id, inbox, catalog, spool, service, privacy_mode = sys.argv[1:]
+value = {
+    "Label": label,
+    "ProgramArguments": [
+        program, "-m", "client.cli", "export-inbox-sync", "--endpoint", endpoint,
+        "--source-id", source_id, "--principal-id", "owner", "--visibility", "private",
+        "--inbox", inbox, "--catalog", catalog, "--spool", spool,
+        "--keychain-service", service, "--keychain-account", source_id,
+        "--privacy-mode", privacy_mode,
+    ],
+    "EnvironmentVariables": {
+        "PYTHONPATH": pythonpath,
+        "RECALL_KEYCHAIN_REFERENCE": "Keychain service/account only",
+    },
+    "RunAtLoad": True,
+    "StartInterval": 30,
+    "ProcessType": "Background",
+    "StandardOutPath": spool + ".stdout.log",
+    "StandardErrorPath": spool + ".stderr.log",
+}
+with open(path, "wb") as output:
+    plistlib.dump(value, output, sort_keys=True)
+PY
+  chmod 600 "$PLIST"
+  if [ "$NO_LOAD" -eq 0 ] && command -v launchctl >/dev/null 2>&1; then
+    launchctl bootstrap "gui/$(id -u)" "$PLIST"
+  fi
+}
+
 case ",$SOURCES," in *,claude,*) write_plist claude "$CLAUDE_ROOT" ;; esac
 case ",$SOURCES," in *,codex,*) write_plist codex "$CODEX_ROOT" ;; esac
+if [ -n "$EXPORT_INBOX" ]; then write_export_inbox_plist; fi
+if [ "$DISABLE_EXPORT_INBOX" -eq 1 ]; then
+  LABEL="ai.parcha.recall.chatgpt-export"
+  if [ "$NO_LOAD" -eq 0 ] && command -v launchctl >/dev/null 2>&1; then
+    launchctl bootout "gui/$(id -u)/$LABEL" >/dev/null 2>&1 || true
+  fi
+  rm -f "$LAUNCH_AGENTS/$LABEL.plist"
+fi
 echo "installed Recall Brain Mac client in $PREFIX"
 echo "selected sources: $SOURCES; visibility: $VISIBILITY; privacy: $PRIVACY_MODE"
 echo "Keychain accounts use each selected source id as the account"

--- a/recall/client/macos/uninstall.sh
+++ b/recall/client/macos/uninstall.sh
@@ -13,7 +13,7 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 
-for HARNESS in claude codex; do
+for HARNESS in claude codex chatgpt-export; do
   LABEL="ai.parcha.recall.$HARNESS"
   if [ "$NO_LOAD" -eq 0 ] && command -v launchctl >/dev/null 2>&1; then
     launchctl bootout "gui/$(id -u)/$LABEL" >/dev/null 2>&1 || true

--- a/recall/connectors/README.md
+++ b/recall/connectors/README.md
@@ -48,3 +48,25 @@ External source credentials stay inside the connector. The Brain credential is
 source-scoped and stays inside its Brain client. Revoking either side leaves the
 pending page and cursor recoverable. Deletion records set `deleted: true`; their
 tombstones bypass contextual privacy-judge availability.
+
+## Explicit ChatGPT/Cowork export inbox
+
+`ExportInboxConnector` is the bundled, network-free adapter for user-supplied
+OpenAI-style `conversations.json`, JSONL, and ZIP exports. It never discovers
+Downloads, Desktop, application support, browser state, or private databases.
+The selected directory is flat: nested roots, symlinks, hard links, archive
+traversal, and malformed records fail closed.
+
+The catalog stores only hashes, stable native IDs, timestamps, and content-free
+provenance. Message bodies cross the shared privacy boundary before the durable
+runner spool or Brain network. Removing a file from the inbox does not delete
+central history. List its opaque export ID and explicitly queue removal instead:
+
+```bash
+recall-brain export-inbox-dry-run --inbox "$HOME/Recall Inbox" --catalog "$STATE/catalog.db"
+recall-brain export-inbox-list --inbox "$HOME/Recall Inbox" --catalog "$STATE/catalog.db"
+recall-brain export-inbox-remove --inbox "$HOME/Recall Inbox" --catalog "$STATE/catalog.db" exp_...
+```
+
+The next scheduled `export-inbox-sync` ACKs reference-safe tombstones. If another
+active export still owns the same upstream message, that message remains live.

--- a/recall/connectors/__init__.py
+++ b/recall/connectors/__init__.py
@@ -8,6 +8,7 @@ from .sdk import (
     ConnectorRunError,
     ConnectorRunner,
 )
+from .export_inbox import ExportInboxConnector, ExportInboxError
 
 __all__ = [
     "ConnectorContractError",
@@ -16,4 +17,6 @@ __all__ = [
     "ConnectorRecord",
     "ConnectorRunError",
     "ConnectorRunner",
+    "ExportInboxConnector",
+    "ExportInboxError",
 ]

--- a/recall/connectors/export_inbox.py
+++ b/recall/connectors/export_inbox.py
@@ -1,0 +1,586 @@
+"""Explicit, local-only ChatGPT/Cowork export inbox connector.
+
+The adapter reads only a directory named by the caller.  Its catalog contains
+content-free identities and provenance, never message bodies or local names.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sqlite3
+import stat
+import zipfile
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from .sdk import ConnectorPage, ConnectorRecord, MAX_PAGE_RECORDS
+
+
+SCHEMA_VERSION = 1
+CONNECTOR_ID = "openai.export-inbox"
+SUPPORTED_SUFFIXES = {".json": "json", ".jsonl": "jsonl", ".zip": "zip"}
+FORBIDDEN_ROOT_NAMES = {"desktop", "documents", "downloads", "library"}
+MAX_EXPORT_BYTES = 2_000_000_000
+MAX_ARCHIVE_MEMBERS = 10_000
+
+
+class ExportInboxError(ValueError):
+    """A content-free export validation error."""
+
+
+@dataclass(frozen=True)
+class _ParsedExport:
+    export_id: str
+    fingerprint: str
+    records: tuple[ConnectorRecord, ...]
+
+
+def _digest(value: str | bytes) -> str:
+    raw = value.encode("utf-8") if isinstance(value, str) else value
+    return hashlib.sha256(raw).hexdigest()
+
+
+def _native_id(conversation_id: str, message_id: str) -> str:
+    return "msg_" + _digest(f"{conversation_id}\0{message_id}")[:40]
+
+
+def _rfc3339(value: Any) -> str:
+    try:
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            parsed = datetime.fromtimestamp(value, timezone.utc)
+        elif isinstance(value, str):
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+            if parsed.tzinfo is None:
+                raise ValueError
+            parsed = parsed.astimezone(timezone.utc)
+        else:
+            raise ValueError
+    except (OverflowError, TypeError, ValueError) as error:
+        raise ExportInboxError("export contains an invalid timestamp") from error
+    return parsed.isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+def _required_string(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not value or len(value) > 10_000:
+        raise ExportInboxError(f"export contains an invalid {label}")
+    return value
+
+
+def _safe_message_content(value: Any) -> dict[str, Any]:
+    if isinstance(value, str):
+        return {"content_type": "text", "parts": [value], "attachment_count": 0}
+    if not isinstance(value, dict):
+        raise ExportInboxError("export contains invalid message content")
+    content_type = value.get("content_type", "text")
+    if not isinstance(content_type, str) or not content_type:
+        raise ExportInboxError("export contains invalid message content")
+    parts = value.get("parts", [])
+    if not isinstance(parts, list):
+        raise ExportInboxError("export contains invalid message content")
+    text_parts: list[str] = []
+    attachment_types: list[str] = []
+    for part in parts:
+        if isinstance(part, str):
+            text_parts.append(part)
+        elif isinstance(part, dict):
+            attachment_type = part.get("content_type", "attachment")
+            attachment_types.append(
+                attachment_type if isinstance(attachment_type, str) and attachment_type else "attachment"
+            )
+        else:
+            raise ExportInboxError("export contains invalid message content")
+    result: dict[str, Any] = {
+        "content_type": content_type,
+        "parts": text_parts,
+        "attachment_count": len(attachment_types),
+    }
+    if attachment_types:
+        result["attachment_types"] = sorted(set(attachment_types))
+    return result
+
+
+class ExportInboxConnector:
+    """Pull records from a caller-selected export inbox with ACK-gated cursors."""
+
+    connector_id = CONNECTOR_ID
+
+    def __init__(self, *, inbox: Path, catalog_path: Path, source_id: str,
+                 page_size: int = MAX_PAGE_RECORDS, privacy_mode: str = "off"):
+        self.inbox = Path(inbox)
+        self.catalog_path = Path(catalog_path)
+        self.source_id = source_id
+        if privacy_mode not in {"off", "scrub", "drop"}:
+            raise ExportInboxError("privacy mode is invalid")
+        self.privacy_mode = privacy_mode
+        if not isinstance(page_size, int) or isinstance(page_size, bool) or not 1 <= page_size <= MAX_PAGE_RECORDS:
+            raise ExportInboxError("page size is out of range")
+        self.page_size = page_size
+        self._validate_root()
+        self.catalog_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        self.db = sqlite3.connect(self.catalog_path)
+        self.db.row_factory = sqlite3.Row
+        os.chmod(self.catalog_path, 0o600)
+        self.db.execute("PRAGMA journal_mode=WAL")
+        self.db.execute("PRAGMA synchronous=FULL")
+        self.db.execute("PRAGMA secure_delete=ON")
+        self.db.executescript("""
+            CREATE TABLE IF NOT EXISTS exports(
+              export_id TEXT PRIMARY KEY,
+              fingerprint TEXT NOT NULL UNIQUE,
+              status TEXT NOT NULL CHECK(status IN ('active','removing','removed')),
+              record_count INTEGER NOT NULL,
+              removal_started INTEGER NOT NULL DEFAULT 0 CHECK(removal_started IN (0,1))
+            );
+            CREATE TABLE IF NOT EXISTS export_records(
+              export_id TEXT NOT NULL REFERENCES exports(export_id),
+              native_id TEXT NOT NULL,
+              occurred_at TEXT NOT NULL,
+              provenance_json TEXT NOT NULL,
+              PRIMARY KEY(export_id,native_id)
+            );
+        """)
+        if "removal_started" not in {
+            row["name"] for row in self.db.execute("PRAGMA table_info(exports)")
+        }:
+            self.db.execute(
+                "ALTER TABLE exports ADD COLUMN removal_started INTEGER NOT NULL DEFAULT 0"
+            )
+        self.db.commit()
+
+    def close(self) -> None:
+        self.db.close()
+
+    def _validate_root(self) -> None:
+        if ".." in self.inbox.parts:
+            raise ExportInboxError("explicit inbox traversal is not allowed")
+        if self.inbox.name.casefold() in FORBIDDEN_ROOT_NAMES:
+            raise ExportInboxError("explicit inbox must not be a broad personal directory")
+        if self.inbox.is_symlink():
+            raise ExportInboxError("explicit inbox root must not be a symlink")
+        if not self.inbox.exists() or not self.inbox.is_dir():
+            raise ExportInboxError("explicit inbox root is unavailable")
+
+    def _files(self) -> list[tuple[Path, str, int]]:
+        self._validate_root()
+        found: list[tuple[Path, str, int]] = []
+        try:
+            children = list(self.inbox.iterdir())
+        except OSError as error:
+            raise ExportInboxError("explicit inbox root is unavailable") from error
+        for path in children:
+            try:
+                mode = path.lstat().st_mode
+            except OSError as error:
+                raise ExportInboxError("inbox entry cannot be inspected") from error
+            if stat.S_ISLNK(mode):
+                raise ExportInboxError("inbox symlink entries are not allowed")
+            if stat.S_ISDIR(mode):
+                raise ExportInboxError("nested inbox directories are not allowed")
+            if not stat.S_ISREG(mode):
+                continue
+            if path.lstat().st_nlink != 1:
+                raise ExportInboxError("hard-linked inbox entries are not allowed")
+            try:
+                finder_info = os.getxattr(path, "com.apple.FinderInfo", follow_symlinks=False)
+            except (AttributeError, OSError):
+                finder_info = b""
+            if len(finder_info) >= 10 and int.from_bytes(finder_info[8:10], "big") & 0x8000:
+                raise ExportInboxError("Finder alias inbox entries are not allowed")
+            kind = SUPPORTED_SUFFIXES.get(path.suffix.casefold())
+            if kind:
+                size = path.stat().st_size
+                if size > MAX_EXPORT_BYTES:
+                    raise ExportInboxError("export exceeds the size limit")
+                found.append((path, kind, size))
+        return found
+
+    def dry_run(self) -> dict[str, Any]:
+        files = self._files()
+        types: dict[str, int] = {}
+        for _, kind, _ in files:
+            types[kind] = types.get(kind, 0) + 1
+        total_entries = sum(1 for child in self.inbox.iterdir() if child.is_file() or child.is_symlink())
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "mode": "export-inbox-inventory",
+            "files": len(files),
+            "bytes": sum(size for _, _, size in files),
+            "types": dict(sorted(types.items())),
+            "supported": len(files),
+            "ignored": total_entries - len(files),
+            "privacy_mode": self.privacy_mode,
+            "network_requests": 0,
+        }
+
+    def _read_file(self, path: Path) -> bytes:
+        descriptor = None
+        try:
+            before = path.lstat()
+            if stat.S_ISLNK(before.st_mode) or not stat.S_ISREG(before.st_mode):
+                raise ExportInboxError("inbox entry changed during inspection")
+            if before.st_nlink != 1:
+                raise ExportInboxError("hard-linked inbox entries are not allowed")
+            flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+            descriptor = os.open(path, flags)
+            opened = os.fstat(descriptor)
+            if not stat.S_ISREG(opened.st_mode) or (opened.st_dev, opened.st_ino) != (before.st_dev, before.st_ino):
+                raise ExportInboxError("inbox entry changed during inspection")
+            chunks: list[bytes] = []
+            remaining = MAX_EXPORT_BYTES + 1
+            while remaining:
+                chunk = os.read(descriptor, min(1024 * 1024, remaining))
+                if not chunk:
+                    break
+                chunks.append(chunk)
+                remaining -= len(chunk)
+            raw = b"".join(chunks)
+        except ExportInboxError:
+            raise
+        except OSError as error:
+            raise ExportInboxError("export cannot be read") from error
+        finally:
+            if descriptor is not None:
+                os.close(descriptor)
+        if len(raw) > MAX_EXPORT_BYTES:
+            raise ExportInboxError("export exceeds the size limit")
+        return raw
+
+    def _record(self, *, conversation_id: str, message_id: str, parent_message_id: str | None,
+                occurred_at: Any, role: Any, content: Any, provenance_root: str,
+                ordinal: int, title: Any = None, model: Any = None) -> ConnectorRecord:
+        conversation_id = _required_string(conversation_id, "conversation id")
+        message_id = _required_string(message_id, "message id")
+        role = _required_string(role, "role")
+        native_id = _native_id(conversation_id, message_id)
+        body = _safe_message_content(content)
+        body.update({"role": role, "conversation_id": conversation_id, "message_id": message_id})
+        if parent_message_id is not None:
+            parent_message_id = _required_string(parent_message_id, "parent message id")
+            body["parent_native_id"] = _native_id(conversation_id, parent_message_id)
+        if isinstance(title, str) and title:
+            body["conversation_title"] = title
+        if isinstance(model, str) and model:
+            body["model"] = model
+        return ConnectorRecord(
+            schema_version=SCHEMA_VERSION,
+            native_id=native_id,
+            occurred_at=_rfc3339(occurred_at),
+            content=body,
+            provenance={"uri": f"export://{provenance_root}/{ordinal}", "ordinal": ordinal},
+        )
+
+    def _official_records(self, value: Any, provenance_root: str) -> list[ConnectorRecord]:
+        if not isinstance(value, list):
+            raise ExportInboxError("JSON export must be an official conversation list")
+        records: list[ConnectorRecord] = []
+        ordinal = 0
+        for conversation in value:
+            if not isinstance(conversation, dict):
+                raise ExportInboxError("export contains an invalid conversation")
+            conversation_id = _required_string(conversation.get("id"), "conversation id")
+            mapping = conversation.get("mapping")
+            if not isinstance(mapping, dict):
+                raise ExportInboxError("export contains an invalid conversation tree")
+            node_messages: dict[str, str] = {}
+            for node_id, node in mapping.items():
+                if not isinstance(node_id, str) or not isinstance(node, dict):
+                    raise ExportInboxError("export contains an invalid conversation node")
+                message = node.get("message")
+                if message is not None:
+                    if not isinstance(message, dict):
+                        raise ExportInboxError("export contains an invalid message")
+                    node_messages[node_id] = _required_string(message.get("id"), "message id")
+            pending: list[tuple[str, str, dict[str, Any], str | None]] = []
+            for node_id, node in mapping.items():
+                message = node.get("message")
+                if message is None:
+                    continue
+                parent_node = node.get("parent")
+                if parent_node is not None and not isinstance(parent_node, str):
+                    raise ExportInboxError("export contains an invalid parent reference")
+                parent_message = node_messages.get(parent_node) if parent_node else None
+                timestamp = (
+                    message.get("create_time")
+                    if message.get("create_time") is not None
+                    else conversation.get("create_time", conversation.get("update_time"))
+                )
+                pending.append((
+                    _rfc3339(timestamp),
+                    _required_string(message.get("id"), "message id"), message, parent_message,
+                ))
+            for timestamp, message_id, message, parent_message in sorted(pending, key=lambda item: (item[0], item[1])):
+                author = message.get("author")
+                if not isinstance(author, dict):
+                    raise ExportInboxError("export contains an invalid message author")
+                metadata = message.get("metadata", {})
+                if not isinstance(metadata, dict):
+                    raise ExportInboxError("export contains invalid message metadata")
+                records.append(self._record(
+                    conversation_id=conversation_id, message_id=message_id,
+                    parent_message_id=parent_message, occurred_at=timestamp,
+                    role=author.get("role"), content=message.get("content"),
+                    provenance_root=provenance_root, ordinal=ordinal,
+                    title=conversation.get("title"), model=metadata.get("model_slug"),
+                ))
+                ordinal += 1
+        return records
+
+    def _jsonl_records(self, raw: bytes, provenance_root: str) -> list[ConnectorRecord]:
+        try:
+            lines = raw.decode("utf-8").splitlines()
+        except UnicodeDecodeError as error:
+            raise ExportInboxError("JSONL export is not UTF-8") from error
+        records: list[ConnectorRecord] = []
+        for ordinal, line in enumerate(lines):
+            if not line.strip():
+                continue
+            try:
+                value = json.loads(line)
+            except json.JSONDecodeError as error:
+                raise ExportInboxError("JSONL export is malformed") from error
+            if not isinstance(value, dict):
+                raise ExportInboxError("JSONL export contains an invalid record")
+            records.append(self._record(
+                conversation_id=value.get("conversation_id"), message_id=value.get("message_id"),
+                parent_message_id=value.get("parent_message_id"), occurred_at=value.get("create_time"),
+                role=value.get("role"), content=value.get("content"),
+                provenance_root=provenance_root, ordinal=ordinal,
+            ))
+        return records
+
+    def _json_records(self, raw: bytes, provenance_root: str) -> list[ConnectorRecord]:
+        try:
+            value = json.loads(raw)
+        except (UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise ExportInboxError("JSON export is malformed") from error
+        return self._official_records(value, provenance_root)
+
+    def _archive_records(self, raw: bytes, fingerprint: str) -> list[ConnectorRecord]:
+        import io
+
+        try:
+            archive = zipfile.ZipFile(io.BytesIO(raw))
+        except (OSError, zipfile.BadZipFile) as error:
+            raise ExportInboxError("ZIP export is malformed") from error
+        records: list[ConnectorRecord] = []
+        with archive:
+            members = archive.infolist()
+            if len(members) > MAX_ARCHIVE_MEMBERS:
+                raise ExportInboxError("ZIP export has too many members")
+            expanded_bytes = 0
+            for info in members:
+                member_path = PurePosixPath(info.filename)
+                if member_path.is_absolute() or ".." in member_path.parts or info.filename.startswith(("/", "\\")):
+                    raise ExportInboxError("ZIP export contains an unsafe member")
+                member_mode = (info.external_attr >> 16) & 0o170000
+                if member_mode == stat.S_IFLNK:
+                    raise ExportInboxError("ZIP export contains an unsafe symlink")
+                if info.is_dir():
+                    continue
+                suffix = member_path.suffix.casefold()
+                if suffix not in {".json", ".jsonl"}:
+                    continue
+                if info.file_size > MAX_EXPORT_BYTES or info.compress_size > MAX_EXPORT_BYTES:
+                    raise ExportInboxError("ZIP member exceeds the size limit")
+                expanded_bytes += info.file_size
+                if expanded_bytes > MAX_EXPORT_BYTES:
+                    raise ExportInboxError("ZIP export exceeds the expansion limit")
+                try:
+                    member = archive.read(info)
+                except (OSError, RuntimeError, zipfile.BadZipFile) as error:
+                    raise ExportInboxError("ZIP member cannot be read") from error
+                member_root = f"{fingerprint}/{_digest(member)[:24]}"
+                if suffix == ".json":
+                    try:
+                        value = json.loads(member)
+                    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+                        raise ExportInboxError("ZIP JSON member is malformed") from error
+                    conversation_shaped = (
+                        isinstance(value, list)
+                        and any(isinstance(item, dict) and "mapping" in item for item in value)
+                    )
+                    if conversation_shaped:
+                        records.extend(self._official_records(value, member_root))
+                else:
+                    try:
+                        lines = [line for line in member.decode("utf-8").splitlines() if line.strip()]
+                        first = json.loads(lines[0]) if lines else None
+                    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+                        raise ExportInboxError("ZIP JSONL member is malformed") from error
+                    if isinstance(first, dict) and {"conversation_id", "message_id"} <= set(first):
+                        records.extend(self._jsonl_records(member, member_root))
+        return records
+
+    def _parse(self, path: Path, kind: str) -> _ParsedExport:
+        raw = self._read_file(path)
+        fingerprint = _digest(raw)
+        export_id = "exp_" + fingerprint[:32]
+        provenance_root = f"{fingerprint}/{fingerprint[:24]}"
+        if kind == "json":
+            records = self._json_records(raw, provenance_root)
+        elif kind == "jsonl":
+            records = self._jsonl_records(raw, provenance_root)
+        else:
+            records = self._archive_records(raw, fingerprint)
+        unique: dict[str, ConnectorRecord] = {}
+        for record in records:
+            existing = unique.get(record.native_id)
+            if existing is not None and (
+                existing.occurred_at != record.occurred_at or existing.content != record.content
+            ):
+                raise ExportInboxError("export contains conflicting message identities")
+            if existing is None or json.dumps(record.provenance, sort_keys=True) < json.dumps(existing.provenance, sort_keys=True):
+                unique[record.native_id] = record
+        ordered = tuple(sorted(unique.values(), key=lambda record: (record.occurred_at, record.native_id)))
+        return _ParsedExport(export_id, fingerprint, ordered)
+
+    def _scan(self) -> list[_ParsedExport]:
+        parsed: dict[str, _ParsedExport] = {}
+        for path, kind, _ in self._files():
+            raw_fingerprint: str | None = None
+            # Parsing is deliberately completed for every novel file before any
+            # catalog transaction, so malformed input leaves no partial state.
+            item = self._parse(path, kind)
+            raw_fingerprint = item.fingerprint
+            existing = self.db.execute(
+                "SELECT status FROM exports WHERE fingerprint=?", (raw_fingerprint,)
+            ).fetchone()
+            if existing and existing["status"] == "removed":
+                continue
+            parsed.setdefault(raw_fingerprint, item)
+        with self.db:
+            for item in parsed.values():
+                self.db.execute(
+                    "INSERT OR IGNORE INTO exports(export_id,fingerprint,status,record_count) VALUES (?,?, 'active',?)",
+                    (item.export_id, item.fingerprint, len(item.records)),
+                )
+                for record in item.records:
+                    self.db.execute(
+                        "INSERT OR IGNORE INTO export_records(export_id,native_id,occurred_at,provenance_json) VALUES (?,?,?,?)",
+                        (item.export_id, record.native_id, record.occurred_at,
+                         json.dumps(record.provenance, sort_keys=True, separators=(",", ":"))),
+                    )
+        return list(parsed.values())
+
+    def exports(self) -> list[dict[str, Any]]:
+        return [
+            {"export_id": row["export_id"], "status": row["status"], "records": row["record_count"]}
+            for row in self.db.execute(
+                "SELECT export_id,status,record_count FROM exports ORDER BY export_id"
+            )
+        ]
+
+    def queue_remove(self, export_id: str) -> dict[str, str]:
+        if not isinstance(export_id, str) or not export_id.startswith("exp_"):
+            raise ExportInboxError("export identity is invalid")
+        row = self.db.execute("SELECT status FROM exports WHERE export_id=?", (export_id,)).fetchone()
+        if row is None:
+            raise ExportInboxError("export identity is unknown")
+        if row["status"] == "removed":
+            return {"export_id": export_id, "status": "already_removed"}
+        if row["status"] == "removing":
+            return {"export_id": export_id, "status": "already_queued"}
+        if self.db.execute(
+            "SELECT 1 FROM exports WHERE status='removing' AND removal_started=1 LIMIT 1"
+        ).fetchone():
+            raise ExportInboxError("another export removal is in progress")
+        with self.db:
+            self.db.execute(
+                "UPDATE exports SET status='removing',removal_started=0 WHERE export_id=?",
+                (export_id,),
+            )
+        return {"export_id": export_id, "status": "queued"}
+
+    def _removing_export(self) -> str | None:
+        row = self.db.execute(
+            "SELECT export_id FROM exports WHERE status='removing' ORDER BY export_id LIMIT 1"
+        ).fetchone()
+        return row["export_id"] if row else None
+
+    def _removal_records(self, export_id: str) -> list[ConnectorRecord]:
+        rows = self.db.execute("""
+            SELECT own.native_id,own.occurred_at,own.provenance_json
+            FROM export_records own
+            WHERE own.export_id=? AND NOT EXISTS (
+              SELECT 1 FROM export_records other
+              JOIN exports e ON e.export_id=other.export_id
+              WHERE other.native_id=own.native_id AND other.export_id<>own.export_id
+                AND e.status IN ('active','removing')
+            )
+            ORDER BY own.occurred_at,own.native_id
+        """, (export_id,)).fetchall()
+        return [ConnectorRecord(
+            schema_version=SCHEMA_VERSION, native_id=row["native_id"],
+            occurred_at=row["occurred_at"], content={},
+            provenance={**json.loads(row["provenance_json"]), "removal": "explicit"},
+            deleted=True,
+        ) for row in rows]
+
+    @staticmethod
+    def _removal_cursor(cursor: str | None) -> tuple[str, int, int] | None:
+        if not isinstance(cursor, str) or not cursor.startswith("v1:remove:"):
+            return None
+        pieces = cursor.split(":")
+        if len(pieces) != 5:
+            return None
+        try:
+            offset, total = int(pieces[3]), int(pieces[4])
+        except ValueError:
+            return None
+        if offset < 0 or total < 0:
+            return None
+        return pieces[2], offset, total
+
+    def _pull_removal(self, cursor: str | None) -> ConnectorPage | None:
+        committed = self._removal_cursor(cursor)
+        if committed and committed[1] == committed[2]:
+            with self.db:
+                self.db.execute(
+                    "UPDATE exports SET status='removed' WHERE export_id=? AND status='removing'",
+                    (committed[0],),
+                )
+        export_id = self._removing_export()
+        if export_id is None:
+            return None
+        with self.db:
+            self.db.execute(
+                "UPDATE exports SET removal_started=1 WHERE export_id=?", (export_id,)
+            )
+        records = self._removal_records(export_id)
+        offset = committed[1] if committed and committed[0] == export_id and committed[1] < committed[2] else 0
+        page_records = tuple(records[offset:offset + self.page_size])
+        next_offset = offset + len(page_records)
+        next_cursor = f"v1:remove:{export_id}:{next_offset}:{len(records)}"
+        return ConnectorPage(records=page_records, next_cursor=next_cursor, has_more=next_offset < len(records))
+
+    def pull(self, cursor: str | None) -> ConnectorPage:
+        removal = self._pull_removal(cursor)
+        if removal is not None:
+            return removal
+        exports = self._scan()
+        unique: dict[str, ConnectorRecord] = {}
+        for item in sorted(exports, key=lambda value: value.fingerprint):
+            for record in item.records:
+                unique.setdefault(record.native_id, record)
+        records = sorted(unique.values(), key=lambda record: (record.occurred_at, record.native_id))
+        snapshot = _digest("\n".join(
+            [item.fingerprint for item in sorted(exports, key=lambda item: item.fingerprint)]
+            + [record.native_id for record in records]
+        ))[:32]
+        prefix = f"v1:data:{snapshot}:"
+        offset = 0
+        if isinstance(cursor, str) and cursor.startswith(prefix):
+            try:
+                offset = int(cursor[len(prefix):])
+            except ValueError:
+                offset = 0
+            if not 0 <= offset <= len(records):
+                offset = 0
+        page_records = tuple(records[offset:offset + self.page_size])
+        next_offset = offset + len(page_records)
+        next_cursor = f"{prefix}{next_offset}"
+        return ConnectorPage(records=page_records, next_cursor=next_cursor, has_more=next_offset < len(records))

--- a/recall/scripts/build_macos_package.py
+++ b/recall/scripts/build_macos_package.py
@@ -154,6 +154,7 @@ def application_payloads(source_root: Path, runtime_lock_data: bytes) -> dict[st
         source_root / "collector" / "collector.py": "lib/collector/collector.py",
         source_root / "collector" / "__init__.py": "lib/collector/__init__.py",
         source_root / "connectors" / "sdk.py": "lib/connectors/sdk.py",
+        source_root / "connectors" / "export_inbox.py": "lib/connectors/export_inbox.py",
         source_root / "connectors" / "__init__.py": "lib/connectors/__init__.py",
         source_root / "privacy" / "policy.py": "lib/privacy/policy.py",
         source_root / "privacy" / "__init__.py": "lib/privacy/__init__.py",

--- a/recall/server/tests/e2e_export_inbox.py
+++ b/recall/server/tests/e2e_export_inbox.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Fresh-PostgreSQL proof for the explicit ChatGPT/Cowork export inbox."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(ROOT / "recall"))
+sys.path.insert(0, str(ROOT / "recall/server"))
+
+from connectors.export_inbox import ExportInboxConnector
+from connectors.sdk import ConnectorRunner
+from privacy.policy import PrivacyPolicy
+from recall_server.db import BrainStore
+from recall_server.projectors import canonical_json
+
+
+SOURCE = "synthetic:export-inbox:postgres"
+FIXTURES = ROOT / "recall/tests/export_inbox_v1"
+
+
+class StoreWriter:
+    def __init__(self, store: BrainStore):
+        self.store = store
+
+    def ingest(self, events):
+        key = "export-inbox-e2e-" + hashlib.sha256(canonical_json(events)).hexdigest()
+        acknowledgement, replay = self.store.ingest(key, events)
+        return {**acknowledgement, "replay": replay}
+
+
+def truncate(store: BrainStore) -> None:
+    with store.connect() as connection:
+        connection.execute(
+            "TRUNCATE chunks,items,sessions,projection_watermarks,source_events,"
+            "ingest_batches,source_grants,sources,dead_letters,audit_events RESTART IDENTITY CASCADE"
+        )
+
+
+def main() -> None:
+    store = BrainStore(os.environ["RECALL_DATABASE_URL"])
+    store.migrate()
+    truncate(store)
+    try:
+        with tempfile.TemporaryDirectory(prefix="recall-export-inbox-e2e-") as temporary:
+            root = Path(temporary)
+            inbox = root / "explicit-inbox"
+            inbox.mkdir()
+            shutil.copy(FIXTURES / "conversations.json", inbox / "renamed.json")
+            shutil.copy(FIXTURES / "cowork.jsonl", inbox / "renamed.jsonl")
+            catalog = root / "state" / "catalog.db"
+            spool = root / "state" / "spool.db"
+            connector = ExportInboxConnector(
+                inbox=inbox, catalog_path=catalog, source_id=SOURCE, page_size=2,
+                privacy_mode="scrub",
+            )
+            runner = ConnectorRunner(
+                connector=connector, brain=StoreWriter(store), spool_path=spool,
+                privacy=PrivacyPolicy(mode="scrub"),
+            )
+            for _ in range(3):
+                assert runner.run_once()["acked"] == 2
+            assert store.search("Plan the synthetic cobalt release", authorized_source=SOURCE)["results"]
+            assert store.search("Synthetic Cowork beta decision", authorized_source=SOURCE)["results"]
+            for canary in (
+                "synthetic-chatgpt-secret-canary-91",
+                "synthetic-cowork-secret-canary-92",
+            ):
+                assert store.search(canary, authorized_source=SOURCE)["results"] == []
+                assert canary.encode() not in spool.read_bytes()
+
+            before = store.doctor(SOURCE)
+            assert before["source_events"] == 6 and before["live_items"] == 6
+            for path in tuple(inbox.iterdir()):
+                path.unlink()
+            unchanged = connector.pull(runner._cursor())
+            assert not any(record.deleted for record in unchanged.records)
+            assert store.doctor(SOURCE)["live_items"] == 6
+
+            for item in connector.exports():
+                assert connector.queue_remove(item["export_id"])["status"] == "queued"
+            for _ in range(12):
+                runner.run_once()
+                if all(item["status"] == "removed" for item in connector.exports()):
+                    break
+            else:
+                raise AssertionError("explicit removals did not converge")
+            after = store.doctor(SOURCE)
+            assert after["source_events"] == 12 and after["live_items"] == 0
+            assert store.search("synthetic cobalt", authorized_source=SOURCE)["results"] == []
+            assert runner.doctor()["pending"] == 0
+            runner.close()
+            connector.close()
+            for database in (catalog, spool):
+                payload = database.read_bytes()
+                assert b"synthetic-chatgpt-secret-canary-91" not in payload
+                assert b"synthetic-cowork-secret-canary-92" not in payload
+            print(json.dumps({
+                "status": "pass", "ingested": 6, "tombstoned": 6,
+                "live_items_after_removal": 0, "canary_search_hits": 0,
+                "local_canary_hits": 0, "pending": 0,
+            }, sort_keys=True))
+    finally:
+        truncate(store)
+
+
+if __name__ == "__main__":
+    main()

--- a/recall/server/tests/e2e_macos_export_inbox_c8b.py
+++ b/recall/server/tests/e2e_macos_export_inbox_c8b.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Packaged Darwin/arm64 proof for the explicit export-inbox lifecycle."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+import urllib.error
+from pathlib import Path
+
+from client.mac import BrainClient
+from connectors.export_inbox import ExportInboxConnector
+from connectors.sdk import ConnectorRunError, ConnectorRunner
+from privacy.policy import PrivacyPolicy
+
+
+def conversation(nonce: str, canary: str) -> list[dict]:
+    return [{
+        "id": f"synthetic-conversation-{nonce}",
+        "title": "Synthetic export inbox proof",
+        "mapping": {
+            "root": {"id": "root", "parent": None, "children": ["user"], "message": None},
+            "user": {
+                "id": "user", "parent": "root", "children": ["assistant"],
+                "message": {
+                    "id": f"synthetic-user-{nonce}", "author": {"role": "user"},
+                    "create_time": "2026-07-14T12:00:00Z",
+                    "content": {"content_type": "text", "parts": [f"c8b-safe-marker-{nonce}"]},
+                    "metadata": {},
+                },
+            },
+            "assistant": {
+                "id": "assistant", "parent": "user", "children": [],
+                "message": {
+                    "id": f"synthetic-assistant-{nonce}", "author": {"role": "assistant"},
+                    "create_time": "2026-07-14T12:00:01Z",
+                    "content": {
+                        "content_type": "multimodal_text",
+                        "parts": [
+                            f"keep aftermath api_key={canary}",
+                            {"content_type": "image_asset_pointer", "asset_pointer": "file-service://synthetic", "name": "synthetic.png"},
+                        ],
+                    },
+                    "metadata": {"model_slug": "synthetic-model"},
+                },
+            },
+        },
+    }]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--endpoint", required=True)
+    parser.add_argument("--source-id", required=True)
+    parser.add_argument("--nonce", required=True)
+    parser.add_argument("--workspace", type=Path, required=True)
+    args = parser.parse_args()
+    token = json.load(sys.stdin)
+    if not isinstance(token, str) or not token:
+        raise ValueError("stdin must contain one scoped credential")
+
+    root = args.workspace / "synthetic-export-inbox-c8b"
+    inbox = root / "explicit-inbox"
+    catalog = root / "state" / "catalog.db"
+    spool = root / "state" / "spool.db"
+    canary = f"c8b-{args.nonce}-secret-canary"
+    marker = f"c8b-safe-marker-{args.nonce}"
+    result = None
+    connector = None
+    runner = None
+    try:
+        inbox.mkdir(parents=True)
+        (inbox / "renamed.json").write_text(json.dumps(conversation(args.nonce, canary)))
+        (inbox / "renamed.jsonl").write_text(json.dumps({
+            "conversation_id": f"synthetic-cowork-{args.nonce}",
+            "message_id": f"synthetic-cowork-message-{args.nonce}",
+            "parent_message_id": None,
+            "create_time": "2026-07-14T12:00:02Z",
+            "role": "assistant",
+            "content": {"content_type": "text", "parts": [f"c8b-cowork-marker-{args.nonce}"]},
+        }) + "\n")
+        connector = ExportInboxConnector(
+            inbox=inbox, catalog_path=catalog, source_id=args.source_id,
+            privacy_mode="scrub",
+        )
+        inventory = connector.dry_run()
+        assert inventory["files"] == 2 and inventory["network_requests"] == 0
+        assert inventory["privacy_mode"] == "scrub"
+        assert canary not in json.dumps(inventory)
+
+        offline = BrainClient(
+            endpoint="http://127.0.0.1:1", token=token, source_id=args.source_id,
+            principal_id="owner", visibility="private",
+        )
+        runner = ConnectorRunner(
+            connector=connector, brain=offline, spool_path=spool,
+            privacy=PrivacyPolicy(mode="scrub"),
+        )
+        try:
+            runner.run_once()
+        except ConnectorRunError as error:
+            assert error.error_code == "brain_unavailable"
+        else:
+            raise AssertionError("offline ingest unexpectedly acknowledged")
+        assert runner.doctor()["pending"] == 3
+        assert canary.encode() not in spool.read_bytes()
+        runner.close()
+        runner = None
+
+        unavailable = root / "inbox-temporarily-unavailable"
+        inbox.rename(unavailable)
+        online = BrainClient(
+            endpoint=args.endpoint, token=token, source_id=args.source_id,
+            principal_id="owner", visibility="private",
+        )
+        runner = ConnectorRunner(
+            connector=connector, brain=online, spool_path=spool,
+            privacy=PrivacyPolicy(mode="scrub"),
+        )
+        recovered = runner.run_once()
+        assert recovered["acked"] == 3 and recovered["replayed"] == 1
+        unavailable.rename(inbox)
+        assert online.doctor()["source_events"] == 3
+        safe = online.search(marker, limit=5)
+        cowork = online.search(f"c8b-cowork-marker-{args.nonce}", limit=5)
+        assert safe["results"] and cowork["results"]
+        receipt = safe["results"][0]["receipt"].split("#", 1)[0]
+        resolved = online.resolve(receipt)
+        assert marker in json.dumps(resolved)
+        assert canary not in json.dumps(resolved)
+        assert online.search(canary, limit=5)["results"] == []
+
+        for path in tuple(inbox.iterdir()):
+            path.unlink()
+        no_delete = connector.pull(runner._cursor())
+        assert not any(record.deleted for record in no_delete.records)
+        assert online.search(marker, limit=5)["results"]
+
+        for item in connector.exports():
+            assert connector.queue_remove(item["export_id"])["status"] == "queued"
+        for _ in range(8):
+            runner.run_once()
+            if all(item["status"] == "removed" for item in connector.exports()):
+                break
+        else:
+            raise AssertionError("explicit removal did not converge")
+        assert online.doctor()["live_items"] == 0
+        assert online.search(marker, limit=5)["results"] == []
+        try:
+            online.resolve(receipt)
+        except urllib.error.HTTPError as error:
+            assert error.code == 404
+        else:
+            raise AssertionError("removed export receipt still resolved")
+        for database in (catalog, spool):
+            assert canary.encode() not in database.read_bytes()
+        result = {
+            "status": "pass",
+            "summary": {
+                "inventory_files": 2, "inventory_network_requests": 0,
+                "offline_staged": 3, "replayed_pages": 1,
+                "searchable_records": 3, "canary_search_hits": 0,
+                "spool_canary_hits": 0, "explicit_tombstones": 3,
+                "live_items_after_removal": 0,
+            },
+        }
+    finally:
+        if runner is not None:
+            runner.close()
+        if connector is not None:
+            connector.close()
+        shutil.rmtree(root, ignore_errors=True)
+    assert not root.exists()
+    assert result is not None
+    result["summary"]["local_residue"] = 0
+    print(json.dumps(result, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/recall/skills/recall/SKILL.md
+++ b/recall/skills/recall/SKILL.md
@@ -59,6 +59,24 @@ transcript; deletion still requires the canonical receipt. Never enable the
 optional contextual-PII judge without consent, and route it only through staging
 LiteLLM with a short-lived scoped virtual key—never a master key or direct provider.
 
+## Consented ChatGPT/Cowork exports
+
+When the packaged Brain client is installed, use its explicit export inbox for
+ChatGPT/Cowork history. Never scrape application databases, caches, browser
+storage, Desktop, or Downloads. Inventory only the directory the user selected:
+
+```bash
+recall-brain export-inbox-dry-run --inbox "$HOME/Recall Inbox" \
+  --catalog "$HOME/Library/Application Support/RecallBrain/state/chatgpt-export-catalog.db" \
+  --privacy-mode scrub
+```
+
+`export-inbox-list` returns opaque export IDs. `export-inbox-remove ... exp_...`
+queues reference-safe tombstones; deleting a local file alone deliberately does
+not delete central memory. Use `--export-inbox` during Mac package installation
+to opt into scheduled sync, and `--disable-export-inbox` to unload that agent
+without destroying its recoverable catalog/spool.
+
 ## First: pick the outcome
 
 1. **Find / verify** — answer "did we…", "which session…", "how did we…".

--- a/recall/tests/export_inbox_v1/conversations.json
+++ b/recall/tests/export_inbox_v1/conversations.json
@@ -1,0 +1,78 @@
+[
+  {
+    "id": "synthetic-conversation-alpha",
+    "title": "Synthetic cobalt planning",
+    "create_time": 1783987200,
+    "mapping": {
+      "root-alpha": {
+        "id": "root-alpha",
+        "parent": null,
+        "children": ["user-alpha"],
+        "message": null
+      },
+      "user-alpha": {
+        "id": "user-alpha",
+        "parent": "root-alpha",
+        "children": ["assistant-alpha", "assistant-alpha-branch"],
+        "message": {
+          "id": "message-user-alpha",
+          "author": {"role": "user"},
+          "create_time": 1783987201,
+          "content": {
+            "content_type": "text",
+            "parts": ["Plan the synthetic cobalt release and keep this context"]
+          },
+          "metadata": {}
+        }
+      },
+      "assistant-alpha": {
+        "id": "assistant-alpha",
+        "parent": "user-alpha",
+        "children": ["tool-alpha"],
+        "message": {
+          "id": "message-assistant-alpha",
+          "author": {"role": "assistant"},
+          "create_time": 1783987202,
+          "content": {
+            "content_type": "code",
+            "parts": ["print('synthetic cobalt')"]
+          },
+          "metadata": {"model_slug": "synthetic-model"}
+        }
+      },
+      "assistant-alpha-branch": {
+        "id": "assistant-alpha-branch",
+        "parent": "user-alpha",
+        "children": [],
+        "message": {
+          "id": "message-assistant-alpha-branch",
+          "author": {"role": "assistant"},
+          "create_time": 1783987203,
+          "content": {
+            "content_type": "text",
+            "parts": ["Alternate synthetic branch"]
+          },
+          "metadata": {}
+        }
+      },
+      "tool-alpha": {
+        "id": "tool-alpha",
+        "parent": "assistant-alpha",
+        "children": [],
+        "message": {
+          "id": "message-tool-alpha",
+          "author": {"role": "tool"},
+          "create_time": 1783987204,
+          "content": {
+            "content_type": "multimodal_text",
+            "parts": [
+              "tool result api_key=synthetic-chatgpt-secret-canary-91 keep aftermath",
+              {"content_type": "image_asset_pointer", "asset_pointer": "file-service://synthetic-private-pointer", "name": "private-name.png"}
+            ]
+          },
+          "metadata": {"invoked_by": "synthetic-tool"}
+        }
+      }
+    }
+  }
+]

--- a/recall/tests/export_inbox_v1/cowork.jsonl
+++ b/recall/tests/export_inbox_v1/cowork.jsonl
@@ -1,0 +1,2 @@
+{"conversation_id":"synthetic-cowork-beta","message_id":"cowork-user-beta","parent_message_id":null,"create_time":"2026-07-14T00:10:00Z","role":"user","content":{"content_type":"text","parts":["Synthetic Cowork beta decision"]}}
+{"conversation_id":"synthetic-cowork-beta","message_id":"cowork-assistant-beta","parent_message_id":"cowork-user-beta","create_time":"2026-07-14T00:10:01Z","role":"assistant","content":{"content_type":"text","parts":["Safe before password=synthetic-cowork-secret-canary-92 safe after"]}}

--- a/recall/tests/export_inbox_v1/manifest.json
+++ b/recall/tests/export_inbox_v1/manifest.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 1,
+  "sha256": {
+    "conversations.json": "4f9499c5c63eeec2ec66bfd9ddd22860d45c6af13d0320cddf445fde5bdc409c",
+    "cowork.jsonl": "d0ef5b4fcc9f4622805a9603a6d594848c8276ee4195ccefbd1fdb51241a54ff"
+  },
+  "expected": {
+    "attachments": 1,
+    "branches": 1,
+    "conversations": 2,
+    "messages": 6,
+    "privacy_canaries": 2
+  }
+}

--- a/recall/tests/test_export_inbox.py
+++ b/recall/tests/test_export_inbox.py
@@ -1,0 +1,308 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+from unittest import mock
+
+from connectors.export_inbox import ExportInboxConnector, ExportInboxError
+from connectors.sdk import ConnectorRunner, ConnectorRunError
+from privacy.policy import PrivacyPolicy
+
+
+FIXTURES = Path(__file__).with_name("export_inbox_v1")
+MANIFEST = FIXTURES / "manifest.json"
+
+
+class FakeBrain:
+    def __init__(self):
+        self.calls = 0
+        self.events: dict[tuple[str, str, str], dict] = {}
+        self.fail_after_commit = False
+
+    def ingest(self, events):
+        self.calls += 1
+        receipts = []
+        for event in events:
+            key = (event["source_id"], event["native_id"], event["content_sha256"])
+            self.events[key] = event
+            receipts.append(f"recall://{event['source_id']}/{event['native_id']}?rev=1")
+        if self.fail_after_commit:
+            self.fail_after_commit = False
+            raise OSError("synthetic lost acknowledgement with private payload")
+        return {"status": "committed", "receipts": receipts, "inserted": len(events)}
+
+
+class ExportInboxTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.root = Path(self.temporary.name)
+        self.inbox = self.root / "Recall Inbox"
+        self.inbox.mkdir()
+        self.catalog = self.root / "state" / "exports.db"
+        self.spool = self.root / "state" / "runner.db"
+
+    def copy_fixtures(self) -> None:
+        shutil.copy(FIXTURES / "conversations.json", self.inbox / "renamed-private-export.json")
+        shutil.copy(FIXTURES / "cowork.jsonl", self.inbox / "another-private-name.jsonl")
+
+    def connector(self, *, page_size: int = 500) -> ExportInboxConnector:
+        return ExportInboxConnector(
+            inbox=self.inbox, catalog_path=self.catalog,
+            source_id="chatgpt:export:synthetic", page_size=page_size,
+        )
+
+    def test_frozen_synthetic_manifest(self) -> None:
+        manifest = json.loads(MANIFEST.read_text())
+        for name, digest in manifest["sha256"].items():
+            self.assertEqual(hashlib.sha256((FIXTURES / name).read_bytes()).hexdigest(), digest)
+        self.assertEqual(manifest["expected"], {
+            "attachments": 1, "branches": 1, "conversations": 2,
+            "messages": 6, "privacy_canaries": 2,
+        })
+
+    def test_dry_run_is_explicit_content_free_and_fail_closed(self) -> None:
+        self.copy_fixtures()
+        connector = self.connector()
+        inventory = connector.dry_run()
+        self.assertEqual(inventory, {
+            "schema_version": 1, "mode": "export-inbox-inventory",
+            "files": 2, "bytes": sum(path.stat().st_size for path in self.inbox.iterdir()),
+            "types": {"json": 1, "jsonl": 1}, "supported": 2,
+            "ignored": 0, "privacy_mode": "off", "network_requests": 0,
+        })
+        rendered = json.dumps(inventory)
+        self.assertNotIn("private-name", rendered)
+        self.assertNotIn(str(self.inbox), rendered)
+
+        symlink = self.inbox / "escape.json"
+        symlink.symlink_to(FIXTURES / "conversations.json")
+        with self.assertRaisesRegex(ExportInboxError, "symlink"):
+            connector.dry_run()
+        symlink.unlink()
+
+        nested = self.inbox / "nested"
+        nested.mkdir()
+        with self.assertRaisesRegex(ExportInboxError, "nested"):
+            connector.dry_run()
+        nested.rmdir()
+
+        hard_link = self.inbox / "hard-link.json"
+        os.link(self.inbox / "renamed-private-export.json", hard_link)
+        with self.assertRaisesRegex(ExportInboxError, "hard-linked"):
+            connector.dry_run()
+        hard_link.unlink()
+
+        alias_flag = b"\0" * 8 + b"\x80\x00" + b"\0" * 22
+        with mock.patch("os.getxattr", return_value=alias_flag):
+            with self.assertRaisesRegex(ExportInboxError, "Finder alias"):
+                connector.dry_run()
+
+        linked_root = self.root / "linked-inbox"
+        linked_root.symlink_to(self.inbox, target_is_directory=True)
+        with self.assertRaises(ExportInboxError):
+            ExportInboxConnector(
+                inbox=linked_root, catalog_path=self.catalog,
+                source_id="chatgpt:export:synthetic",
+            )
+        with self.assertRaises(ExportInboxError):
+            ExportInboxConnector(
+                inbox=self.root / "Downloads", catalog_path=self.catalog,
+                source_id="chatgpt:export:synthetic",
+            )
+
+    def test_official_tree_jsonl_zip_and_privacy_use_stable_filename_free_records(self) -> None:
+        self.copy_fixtures()
+        with zipfile.ZipFile(self.inbox / "third-private-name.zip", "w") as archive:
+            archive.write(FIXTURES / "conversations.json", "nested/conversations.json")
+            archive.writestr("account/user.json", json.dumps({"email": "synthetic-metadata-only@example.invalid"}))
+        connector = self.connector(page_size=20)
+        page = connector.pull(None)
+        self.assertEqual(len(page.records), 6)  # duplicate JSON and ZIP content dedupe by upstream IDs
+        rendered = json.dumps([record.__dict__ for record in page.records], sort_keys=True)
+        self.assertNotIn("renamed-private-export", rendered)
+        self.assertNotIn("another-private-name", rendered)
+        self.assertNotIn("third-private-name", rendered)
+        self.assertNotIn("private-name.png", rendered)
+        self.assertNotIn("file-service", rendered)
+        self.assertIn('"attachment_count": 1', rendered)
+        self.assertIn("parent_native_id", rendered)
+        self.assertEqual(len({record.native_id for record in page.records}), 6)
+
+        brain = FakeBrain()
+        runner = ConnectorRunner(
+            connector=connector, brain=brain, spool_path=self.spool,
+            privacy=PrivacyPolicy(mode="scrub"),
+        )
+        result = runner.run_once()
+        self.assertEqual(result["acked"], 6)
+        payload = json.dumps(list(brain.events.values()), sort_keys=True)
+        for canary in ("synthetic-chatgpt-secret-canary-91", "synthetic-cowork-secret-canary-92"):
+            self.assertNotIn(canary, payload)
+            self.assertNotIn(canary.encode(), self.spool.read_bytes())
+        self.assertIn("keep aftermath", payload)
+        self.assertIn("safe after", payload)
+        runner.close()
+
+    def test_official_null_message_timestamp_uses_conversation_timestamp(self) -> None:
+        value = json.loads((FIXTURES / "conversations.json").read_text())
+        value[0]["mapping"]["user-alpha"]["message"]["create_time"] = None
+        (self.inbox / "null-time.json").write_text(json.dumps(value))
+        page = self.connector().pull(None)
+        user = next(record for record in page.records if record.content["role"] == "user")
+        self.assertEqual(user.occurred_at, "2026-07-14T00:00:00.000Z")
+
+    def test_lost_ack_restart_replays_without_repull_or_duplicate(self) -> None:
+        self.copy_fixtures()
+        connector = self.connector(page_size=20)
+        brain = FakeBrain(); brain.fail_after_commit = True
+        runner = ConnectorRunner(
+            connector=connector, brain=brain, spool_path=self.spool,
+            privacy=PrivacyPolicy(mode="drop"),
+        )
+        with self.assertRaisesRegex(ConnectorRunError, "brain_unavailable"):
+            runner.run_once()
+        first_count = len(brain.events)
+        runner.close()
+        self.inbox.rename(self.root / "inbox-temporarily-unavailable")
+        recovered = ConnectorRunner(
+            connector=connector, brain=brain, spool_path=self.spool,
+            privacy=PrivacyPolicy(mode="drop"),
+        )
+        result = recovered.run_once()
+        self.assertEqual(result["replayed"], 1)
+        self.assertEqual(len(brain.events), first_count)
+        recovered.close()
+
+    def test_explicit_removal_is_reference_safe_and_file_deletion_is_not(self) -> None:
+        shutil.copy(FIXTURES / "conversations.json", self.inbox / "first.json")
+        shutil.copy(FIXTURES / "conversations.json", self.inbox / "duplicate.json")
+        connector = self.connector(page_size=20)
+        brain = FakeBrain()
+        runner = ConnectorRunner(connector=connector, brain=brain, spool_path=self.spool)
+        runner.run_once()
+        exports = connector.exports()
+        self.assertEqual(len(exports), 1)
+        export_id = exports[0]["export_id"]
+        (self.inbox / "first.json").unlink()
+        (self.inbox / "duplicate.json").unlink()
+        no_delete = connector.pull(runner._cursor())
+        self.assertFalse(any(record.deleted for record in no_delete.records))
+        queued = connector.queue_remove(export_id)
+        self.assertEqual(queued["status"], "queued")
+        removal = connector.pull(runner._cursor())
+        self.assertTrue(removal.records)
+        self.assertTrue(all(record.deleted for record in removal.records))
+        runner.run_once()
+        runner.run_once()  # observe committed removal cursor and finalize catalog state
+        self.assertEqual(connector.queue_remove(export_id)["status"], "already_removed")
+        self.assertEqual(connector.exports()[0]["status"], "removed")
+        runner.close()
+
+    def test_removing_one_changed_export_preserves_shared_message_references(self) -> None:
+        original = json.loads((FIXTURES / "conversations.json").read_text())
+        shortened = json.loads(json.dumps(original))
+        shortened[0]["mapping"].pop("assistant-alpha-branch")
+        shortened[0]["mapping"]["user-alpha"]["children"].remove("assistant-alpha-branch")
+        (self.inbox / "complete.json").write_text(json.dumps(original))
+        (self.inbox / "shortened.json").write_text(json.dumps(shortened))
+        connector = self.connector(page_size=20)
+        first = connector.pull(None)
+        self.assertEqual(len(first.records), 4)
+        exports = connector.exports()
+        complete_id = next(item["export_id"] for item in exports if item["records"] == 4)
+        connector.queue_remove(complete_id)
+        removal = connector.pull(first.next_cursor)
+        self.assertEqual(len(removal.records), 1)
+        branch = next(record for record in first.records if "Alternate synthetic branch" in json.dumps(record.content))
+        self.assertEqual(removal.records[0].native_id, branch.native_id)
+
+    def test_multi_page_ingest_and_removal_cursors_are_ack_gated(self) -> None:
+        shutil.copy(FIXTURES / "conversations.json", self.inbox / "conversation.json")
+        connector = self.connector(page_size=2)
+        brain = FakeBrain()
+        runner = ConnectorRunner(connector=connector, brain=brain, spool_path=self.spool)
+        first = runner.run_once()
+        second = runner.run_once()
+        self.assertEqual((first["acked"], second["acked"]), (2, 2))
+        self.assertEqual(len(brain.events), 4)
+        export_id = connector.exports()[0]["export_id"]
+        connector.queue_remove(export_id)
+        deletion_one = runner.run_once()
+        deletion_two = runner.run_once()
+        self.assertEqual((deletion_one["acked"], deletion_two["acked"]), (2, 2))
+        runner.run_once()  # committed terminal removal cursor finalizes the export
+        self.assertEqual(connector.exports()[0]["status"], "removed")
+        self.assertEqual(len([event for event in brain.events.values() if event["kind"] == "tombstone"]), 4)
+        runner.close()
+
+    def test_new_removal_cannot_change_an_in_flight_removal_record_set(self) -> None:
+        original = json.loads((FIXTURES / "conversations.json").read_text())
+        shortened = json.loads(json.dumps(original))
+        shortened[0]["mapping"].pop("assistant-alpha-branch")
+        shortened[0]["mapping"]["user-alpha"]["children"].remove("assistant-alpha-branch")
+        (self.inbox / "complete.json").write_text(json.dumps(original))
+        (self.inbox / "shortened.json").write_text(json.dumps(shortened))
+        connector = self.connector(page_size=1)
+        page = connector.pull(None)
+        exports = connector.exports()
+        complete_id = next(item["export_id"] for item in exports if item["records"] == 4)
+        shortened_id = next(item["export_id"] for item in exports if item["records"] == 3)
+        connector.queue_remove(complete_id)
+        removal = connector.pull(page.next_cursor)
+        self.assertTrue(removal.records)
+        with self.assertRaisesRegex(ExportInboxError, "in progress"):
+            connector.queue_remove(shortened_id)
+
+    def test_content_free_cli_inventory_list_and_explicit_remove(self) -> None:
+        self.copy_fixtures()
+        environment = {**os.environ, "PYTHONPATH": str(Path(__file__).resolve().parents[1])}
+
+        def invoke(*arguments: str) -> dict:
+            result = subprocess.run(
+                [sys.executable, "-m", "client.cli", *arguments],
+                cwd=Path(__file__).resolve().parents[1], env=environment,
+                check=True, text=True, capture_output=True,
+            )
+            self.assertEqual(result.stderr, "")
+            return json.loads(result.stdout)
+
+        common = ("--inbox", str(self.inbox), "--catalog", str(self.catalog))
+        inventory = invoke("export-inbox-dry-run", *common)
+        self.assertEqual(inventory["mode"], "export-inbox-inventory")
+        self.assertNotIn("private-name", json.dumps(inventory))
+        connector = self.connector()
+        connector.pull(None)
+        export_id = connector.exports()[0]["export_id"]
+        connector.close()
+        listed = invoke("export-inbox-list", *common)
+        self.assertTrue(listed["exports"])
+        queued = invoke("export-inbox-remove", *common, export_id)
+        self.assertEqual(queued["status"], "queued")
+
+    def test_malformed_and_malicious_archives_fail_before_catalog_or_spool(self) -> None:
+        malformed = [{"id": "broken", "mapping": {"node": {"message": {"author": {"role": "user"}}}}}]
+        (self.inbox / "malformed.json").write_text(json.dumps(malformed))
+        connector = self.connector()
+        with self.assertRaises(ExportInboxError):
+            connector.pull(None)
+        self.assertEqual(connector.exports(), [])
+        (self.inbox / "malformed.json").unlink()
+        with zipfile.ZipFile(self.inbox / "malicious.zip", "w") as archive:
+            archive.writestr("../escape.json", "[]")
+        with self.assertRaisesRegex(ExportInboxError, "unsafe"):
+            connector.pull(None)
+        self.assertEqual(connector.exports(), [])
+        self.assertFalse(self.spool.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/recall/tests/test_mac_package.py
+++ b/recall/tests/test_mac_package.py
@@ -158,17 +158,31 @@ class MacPackageTest(unittest.TestCase):
         packaged_paths = {entry["path"] for entry in manifest["files"]}
         self.assertIn("lib/connectors/sdk.py", packaged_paths)
         self.assertIn("lib/connectors/__init__.py", packaged_paths)
+        self.assertIn("lib/connectors/export_inbox.py", packaged_paths)
 
         wrapper = (package / "bin" / "recall-brain").read_text()
         self.assertIn('exec "$HERE/runtime/bin/python3" -m client.cli', wrapper)
         self.assertNotIn("exec python3", wrapper)
         installer = (package / "install.sh").read_text()
+        subprocess.run(["sh", "-n", str(package / "install.sh")], check=True)
+        subprocess.run(["sh", "-n", str(package / "uninstall.sh")], check=True)
         self.assertIn('$PREFIX/runtime/bin/python3', installer)
         self.assertNotRegex(installer, r"(?m)(?:^|[ ;])python3(?:[ ;]|$)")
         self.assertIn('RUNTIME_LOCK.json', installer)
         self.assertIn('ssl.get_default_verify_paths()', installer)
         self.assertIn('get_ca_certs()', installer)
         self.assertIn('cp -R "$SOURCE/lib/connectors"', installer)
+        self.assertIn('"client.cli", "export-inbox-sync"', installer)
+        self.assertIn('--export-inbox', installer)
+        self.assertIn('--disable-export-inbox', installer)
+        invalid = subprocess.run([
+            "sh", str(package / "install.sh"),
+            "--endpoint", "https://example.invalid", "--host-id", "test",
+            "--keychain-service", "synthetic", "--visibility", "private",
+            "--export-inbox", str(self.root), "--disable-export-inbox", "--no-load",
+        ], text=True, capture_output=True)
+        self.assertEqual(invalid.returncode, 2)
+        self.assertIn("mutually exclusive", invalid.stderr)
 
         home = self.root / "home"
         home.mkdir()


### PR DESCRIPTION
Adds a consent-scoped, flat export-inbox connector for official-style ChatGPT/Cowork JSON, JSONL, and ZIP exports.

- stable message identities and filename-free provenance
- privacy before spool/network with ACK-gated replay
- explicit, reference-safe export removal tombstones
- packaged Mac CLI and opt-in LaunchAgent with recoverable disable
- wholly synthetic fixtures and E2E proofs only

Gates: 106 Recall tests, 8 portability tests, fresh PostgreSQL 17 matrix, reproducible arm64 package, and real Darwin/arm64 lifecycle.