### PR TITLE
fix(recall): suppress acknowledged connector repeats

### DIFF
--- a/recall/client/cli.py
+++ b/recall/client/cli.py
@@ -28,7 +28,7 @@ from connectors.registry import (
     preview as registry_preview,
     validate_policy,
 )
-from connectors.sdk import ConnectorRunner
+from connectors.sdk import ConnectorContractError, ConnectorRunner, seed_acknowledged_records
 from connectors.supervisor import (
     SupervisorContractError,
     aggregate_supervisor_status,
@@ -138,6 +138,9 @@ def parser() -> argparse.ArgumentParser:
     registry_status.add_argument("--privacy-mode", choices=("off", "scrub", "drop"), required=True)
     registry_status.add_argument("--authority", choices=("brain", "source"), action="append", default=[])
     registry_status.add_argument("--spool")
+    seed_acknowledged = commands.add_parser("connector-spool-seed-acknowledged")
+    seed_acknowledged.add_argument("--spool", required=True)
+    seed_acknowledged.add_argument("--input", required=True)
     commands.add_parser("connector-supervisor-preview")
     supervisor_status = commands.add_parser("connector-supervisor-status")
     supervisor_status.add_argument("--state", required=True)
@@ -248,6 +251,15 @@ def main() -> None:
                 set(args.authority), Path(args.spool) if args.spool else None,
             )
         except ConnectorRegistryError as error:
+            raise SystemExit(str(error)) from None
+        print(json.dumps(result, sort_keys=True))
+        return
+    if args.command == "connector-spool-seed-acknowledged":
+        try:
+            result = seed_acknowledged_records(
+                spool_path=Path(args.spool), seed_path=Path(args.input),
+            )
+        except ConnectorContractError as error:
             raise SystemExit(str(error)) from None
         print(json.dumps(result, sort_keys=True))
         return

--- a/recall/connectors/README.md
+++ b/recall/connectors/README.md
@@ -106,6 +106,30 @@ boundary behind them so a later status transition is revisited.
 List absence, 404, retention, and authorization failure never infer deletion—forget
 an imported result explicitly with its Brain receipt.
 
+After a valid Brain acknowledgement, the runner keeps only the lowercase
+SHA-256 pair for the source-qualified native ID and canonical content. Exact
+versions encountered again on a reordered upstream page advance the cursor
+without another Brain request. Changed content and tombstones remain distinct
+versions and still ingest. A lost acknowledgement deliberately replays because
+the pair is not recorded until the acknowledgement transaction commits.
+
+When upgrading a spool whose records already exist centrally, stop its service
+and create a private hash-only seed manifest from canonical Brain events:
+
+```json
+{"schema_version":1,"records":[{"native_sha256":"<64 lowercase hex>","content_sha256":"<64 lowercase hex>"}]}
+```
+
+The manifest and existing spool must be absolute, regular non-symlink mode-0600
+files in mode-0700 non-symlink directories. The spool must have pinned identity
+and no pending work. The command validates the entire closed schema before one
+atomic, idempotent insert and emits counts only:
+
+```bash
+recall-brain connector-spool-seed-acknowledged \
+  --spool "$STATE/grep-ai.db" --input "$PRIVATE/grep-ai-ack-seed.json"
+```
+
 ## Declarative registry and content-free status
 
 `connectors.registry` is the closed inventory for Recall's installed input

--- a/recall/connectors/__init__.py
+++ b/recall/connectors/__init__.py
@@ -7,6 +7,7 @@ from .sdk import (
     ConnectorRecord,
     ConnectorRunError,
     ConnectorRunner,
+    seed_acknowledged_records,
 )
 from .export_inbox import ExportInboxConnector, ExportInboxError
 from .registry import ConnectorDefinition, ConnectorRegistryError, REGISTRY
@@ -26,6 +27,7 @@ __all__ = [
     "ConnectorRecord",
     "ConnectorRunError",
     "ConnectorRunner",
+    "seed_acknowledged_records",
     "ExportInboxConnector",
     "ExportInboxError",
     "ConnectorDefinition",

--- a/recall/connectors/sdk.py
+++ b/recall/connectors/sdk.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import re
 import secrets
 import sqlite3
+import stat
 import time
 from dataclasses import dataclass
 from datetime import datetime
@@ -23,7 +25,10 @@ MAX_PAGE_BYTES = 8_000_000
 IDENTITY = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.:@/=-]{1,255}\Z")
 CONNECTOR_ID = re.compile(r"[a-z][a-z0-9_.-]{2,63}\Z")
 SOURCE_ID = re.compile(r"[A-Za-z0-9_.:@-]{3,160}\Z")
+SHA256 = re.compile(r"[0-9a-f]{64}\Z")
 ALLOWED_PROVENANCE_SCHEMES = {"https", "export", "connector", "manual"}
+MAX_ACK_SEED_BYTES = 16_000_000
+MAX_ACK_SEED_RECORDS = 250_000
 
 
 class ConnectorContractError(ValueError):
@@ -52,6 +57,158 @@ class ConnectorUpstreamError(RuntimeError):
             raise ConnectorContractError("upstream error code is invalid")
         self.error_code = error_code
         super().__init__(error_code)
+
+
+def _create_acknowledged_records_table(db: sqlite3.Connection) -> None:
+    db.execute("""
+        CREATE TABLE IF NOT EXISTS acknowledged_records(
+          native_sha256 TEXT NOT NULL
+            CHECK(length(native_sha256)=64 AND native_sha256 NOT GLOB '*[^0-9a-f]*'),
+          content_sha256 TEXT NOT NULL
+            CHECK(length(content_sha256)=64 AND content_sha256 NOT GLOB '*[^0-9a-f]*'),
+          acknowledged_at REAL NOT NULL,
+          PRIMARY KEY(native_sha256,content_sha256)
+        ) WITHOUT ROWID
+    """)
+    columns = [
+        (row[1], row[2], row[3], row[5])
+        for row in db.execute("PRAGMA table_info(acknowledged_records)")
+    ]
+    expected = [
+        ("native_sha256", "TEXT", 1, 1),
+        ("content_sha256", "TEXT", 1, 2),
+        ("acknowledged_at", "REAL", 1, 0),
+    ]
+    if columns != expected:
+        raise ConnectorContractError("acknowledged-record ledger schema is invalid")
+    table_sql = db.execute(
+        "SELECT sql FROM sqlite_master WHERE type='table' AND name='acknowledged_records'"
+    ).fetchone()[0]
+    if "WITHOUT ROWID" not in table_sql.upper():
+        raise ConnectorContractError("acknowledged-record ledger schema is invalid")
+
+
+def _native_sha256(source_id: str, native_id: str) -> str:
+    return hashlib.sha256(f"{source_id}\0{native_id}".encode()).hexdigest()
+
+
+def _strict_private_file(path: Path, *, label: str, max_bytes: int | None = None,
+                         read_data: bool = True) -> bytes:
+    path = Path(path)
+    if not path.is_absolute():
+        raise ConnectorContractError(f"{label} path must be absolute")
+    try:
+        parent = path.parent.lstat()
+        details = path.lstat()
+    except OSError as error:
+        raise ConnectorContractError(f"{label} path is unavailable") from error
+    if not stat.S_ISDIR(parent.st_mode) or stat.S_ISLNK(parent.st_mode):
+        raise ConnectorContractError(f"{label} parent must be a non-symlink directory")
+    if stat.S_IMODE(parent.st_mode) != 0o700:
+        raise ConnectorContractError(f"{label} parent must have mode 0700")
+    if stat.S_ISLNK(details.st_mode) or not stat.S_ISREG(details.st_mode):
+        raise ConnectorContractError(f"{label} must be a regular non-symlink file")
+    if stat.S_IMODE(details.st_mode) != 0o600:
+        raise ConnectorContractError(f"{label} must have mode 0600")
+    if max_bytes is not None and details.st_size > max_bytes:
+        raise ConnectorContractError(f"{label} exceeds maximum byte count")
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(path, flags)
+        try:
+            opened = os.fstat(descriptor)
+            if (opened.st_dev, opened.st_ino) != (details.st_dev, details.st_ino):
+                raise ConnectorContractError(f"{label} changed during validation")
+            if not read_data:
+                return b""
+            chunks = []
+            remaining = details.st_size + 1
+            while remaining:
+                chunk = os.read(descriptor, min(1_048_576, remaining))
+                if not chunk:
+                    break
+                chunks.append(chunk)
+                remaining -= len(chunk)
+            return b"".join(chunks)
+        finally:
+            os.close(descriptor)
+    except ConnectorContractError:
+        raise
+    except OSError as error:
+        raise ConnectorContractError(f"{label} could not be read safely") from error
+
+
+def seed_acknowledged_records(*, spool_path: Path, seed_path: Path) -> dict[str, int]:
+    """Seed an existing spool from a strict, hash-only acknowledged-record manifest."""
+    raw = _strict_private_file(Path(seed_path), label="seed", max_bytes=MAX_ACK_SEED_BYTES)
+    try:
+        manifest = json.loads(raw, parse_constant=lambda _value: (_ for _ in ()).throw(ValueError()))
+    except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as error:
+        raise ConnectorContractError("seed must be finite JSON") from error
+    if not isinstance(manifest, dict) or set(manifest) != {"schema_version", "records"}:
+        raise ConnectorContractError("seed must be a closed versioned object")
+    records = manifest["records"]
+    if manifest["schema_version"] != 1 or not isinstance(records, list):
+        raise ConnectorContractError("seed schema is invalid")
+    if len(records) > MAX_ACK_SEED_RECORDS:
+        raise ConnectorContractError("seed exceeds maximum record count")
+    pairs: list[tuple[str, str]] = []
+    for record in records:
+        if not isinstance(record, dict) or set(record) != {"native_sha256", "content_sha256"}:
+            raise ConnectorContractError("seed record must be a closed object")
+        native_sha256 = record["native_sha256"]
+        content_sha256 = record["content_sha256"]
+        if not isinstance(native_sha256, str) or not SHA256.fullmatch(native_sha256):
+            raise ConnectorContractError("seed native hash is invalid")
+        if not isinstance(content_sha256, str) or not SHA256.fullmatch(content_sha256):
+            raise ConnectorContractError("seed content hash is invalid")
+        pairs.append((native_sha256, content_sha256))
+    if len(pairs) != len(set(pairs)):
+        raise ConnectorContractError("seed contains duplicate records")
+
+    spool_path = Path(spool_path)
+    _strict_private_file(spool_path, label="spool", read_data=False)
+    try:
+        db = sqlite3.connect(f"file:{spool_path}?mode=rw", uri=True)
+        db.row_factory = sqlite3.Row
+        tables = {row[0] for row in db.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        )}
+        if not {"meta", "pages", "outbox"}.issubset(tables):
+            raise ConnectorContractError("spool schema is invalid")
+        identity = dict(db.execute(
+            "SELECT key,value FROM meta WHERE key IN ('connector_id','source_id')"
+        ))
+        if set(identity) != {"connector_id", "source_id"}:
+            raise ConnectorContractError("spool identity is incomplete")
+        db.execute("BEGIN IMMEDIATE")
+        try:
+            pending = db.execute("SELECT count(*) FROM pages").fetchone()[0]
+            pending += db.execute("SELECT count(*) FROM outbox").fetchone()[0]
+            if pending:
+                raise ConnectorContractError("spool must have no pending work before seeding")
+            _create_acknowledged_records_table(db)
+            before = db.execute("SELECT count(*) FROM acknowledged_records").fetchone()[0]
+            acknowledged_at = time.time()
+            db.executemany(
+                "INSERT OR IGNORE INTO acknowledged_records"
+                "(native_sha256,content_sha256,acknowledged_at) VALUES (?,?,?)",
+                [(native, content, acknowledged_at) for native, content in pairs],
+            )
+            after = db.execute("SELECT count(*) FROM acknowledged_records").fetchone()[0]
+            db.commit()
+        except Exception:
+            db.rollback()
+            raise
+    except ConnectorContractError:
+        raise
+    except sqlite3.Error as error:
+        raise ConnectorContractError("spool could not be seeded") from error
+    finally:
+        if "db" in locals():
+            db.close()
+    seeded = after - before
+    return {"schema_version": 1, "seeded": seeded, "already_acknowledged": len(pairs) - seeded}
 
 
 def _json_copy(value: Any, label: str) -> Any:
@@ -196,6 +353,7 @@ class ConnectorRunner:
               envelope_json TEXT NOT NULL, state TEXT NOT NULL CHECK(state='pending')
             );
         """)
+        _create_acknowledged_records_table(self.db)
         self._pin_identity()
 
     def _pin_identity(self) -> None:
@@ -245,11 +403,19 @@ class ConnectorRunner:
             occurred_at=record.occurred_at, provenance=provenance,
         )
 
+    def _acknowledged(self, event: dict[str, Any]) -> bool:
+        return self.db.execute(
+            "SELECT 1 FROM acknowledged_records WHERE native_sha256=? AND content_sha256=?",
+            (_native_sha256(self.source_id, event["native_id"]), event["content_sha256"]),
+        ).fetchone() is not None
+
     def _stage(self, page: ConnectorPage, cursor: str | None) -> dict[str, Any]:
         if page.next_cursor == cursor and (page.records or page.has_more):
             raise ConnectorContractError("connector cursor did not advance")
         receipts = []
         events = []
+        dropped = 0
+        deduplicated = 0
         for record in page.records:
             provenance_decision = PrivacyPolicy(mode="scrub").apply(record.provenance)
             safe_provenance = provenance_decision.value
@@ -262,7 +428,11 @@ class ConnectorRunner:
                     record, decision.value["content"], decision.value["provenance"]
                 )
             receipts.append(decision.receipt())
-            if event is not None:
+            if event is None:
+                dropped += 1
+            elif self._acknowledged(event):
+                deduplicated += 1
+            else:
                 events.append(event)
         privacy = summarize_receipts(receipts, self.privacy.mode)
         with self.db:
@@ -276,7 +446,10 @@ class ConnectorRunner:
             )
             if not events:
                 self._commit_page(page_id, page.next_cursor)
-        return {"privacy": privacy, "staged": len(events), "dropped": len(page.records) - len(events)}
+        return {
+            "privacy": privacy, "staged": len(events), "dropped": dropped,
+            "deduplicated": deduplicated,
+        }
 
     def _commit_page(self, page_id: int, cursor: str | None) -> None:
         self.db.execute("DELETE FROM outbox WHERE page_id=?", (page_id,))
@@ -317,6 +490,15 @@ class ConnectorRunner:
             raise ConnectorRunError("brain_invalid_acknowledgement")
         replayed = int(bool(self._get_meta("last_error_code") == "brain_unavailable"))
         with self.db:
+            acknowledged_at = time.time()
+            self.db.executemany(
+                "INSERT OR IGNORE INTO acknowledged_records"
+                "(native_sha256,content_sha256,acknowledged_at) VALUES (?,?,?)",
+                [
+                    (_native_sha256(self.source_id, event["native_id"]), event["content_sha256"], acknowledged_at)
+                    for event in events
+                ],
+            )
             self._commit_page(page["id"], json.loads(page["cursor_after"]))
         self._purge_acknowledged_bytes()
         return {"acked": len(events), "replayed": replayed}

--- a/recall/server/tests/e2e_connector_sdk.py
+++ b/recall/server/tests/e2e_connector_sdk.py
@@ -41,10 +41,14 @@ class Pages:
             None: ConnectorPage(records=(
                 value("safe-one", "connector postgres exact safe marker"),
                 value("scrub-one", "keep context api_key=connector-postgres-secret-canary after"),
-            ), next_cursor="page-1", has_more=False),
+            ), next_cursor="page-1", has_more=True),
             "page-1": ConnectorPage(records=(
+                value("scrub-one", "keep context api_key=connector-postgres-secret-canary after"),
                 value("safe-one", "deletion bypass content", deleted=True),
-            ), next_cursor="page-2", has_more=False),
+            ), next_cursor="page-2", has_more=True),
+            "page-2": ConnectorPage(records=(
+                value("safe-one", "connector postgres exact safe marker"),
+            ), next_cursor="done", has_more=False),
         }
 
     def pull(self, cursor):
@@ -85,12 +89,18 @@ def main() -> None:
             assert connection.execute("SELECT count(*) AS n FROM items WHERE deleted_at IS NULL").fetchone()["n"] == 2
         second = runner.run_once()
         assert second["acked"] == 1
+        assert second["deduplicated"] == 1
+        assert store.search("connector postgres exact safe marker", authorized_source=SOURCE)["results"] == []
+        third = runner.run_once()
+        assert third["acked"] == 0
+        assert third["deduplicated"] == 1
         assert store.search("connector postgres exact safe marker", authorized_source=SOURCE)["results"] == []
         assert runner.doctor()["pending"] == 0
         runner.close()
         assert b"connector-postgres-secret-canary" not in spool.read_bytes()
         print(json.dumps({
-            "status": "pass", "records_acked": 3, "searchable_before_delete": 1,
+            "status": "pass", "records_acked": 3, "exact_repeats_suppressed": 2,
+            "searchable_before_delete": 1,
             "searchable_after_delete": 0, "canary_search_hits": 0,
             "spool_canary_hits": 0, "pending": 0,
         }, sort_keys=True))

--- a/recall/tests/test_connector_sdk.py
+++ b/recall/tests/test_connector_sdk.py
@@ -1,10 +1,16 @@
 from __future__ import annotations
 
+import hashlib
+import io
 import json
+import os
+import sqlite3
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
+from client import cli as client_cli
 from connectors.sdk import (
     ConnectorContractError,
     ConnectorPage,
@@ -12,6 +18,7 @@ from connectors.sdk import (
     ConnectorRecord,
     ConnectorRunError,
     ConnectorRunner,
+    seed_acknowledged_records,
 )
 from privacy.policy import PrivacyPolicy
 
@@ -34,6 +41,7 @@ class FakeBrain:
     def __init__(self):
         self.calls = 0
         self.events: dict[tuple[str, str, str], dict] = {}
+        self.duplicate_events = 0
         self.fail_after_commit = False
         self.unauthorized = False
 
@@ -42,16 +50,22 @@ class FakeBrain:
         if self.unauthorized:
             raise PermissionError("synthetic unauthorized response with payload that must stay private")
         receipts = []
+        inserted = duplicates = 0
         for event in events:
             key = (event["source_id"], event["native_id"], event["content_sha256"])
-            self.events[key] = event
+            if key in self.events:
+                duplicates += 1
+            else:
+                self.events[key] = event
+                inserted += 1
             receipts.append(f"recall://{event['source_id']}/{event['native_id']}?rev=1")
+        self.duplicate_events += duplicates
         if self.fail_after_commit:
             self.fail_after_commit = False
             raise OSError("synthetic lost acknowledgement")
         return {
-            "status": "committed", "inserted": len(events),
-            "duplicate_events": 0, "receipts": receipts, "replay": False,
+            "status": "committed", "inserted": inserted,
+            "duplicate_events": duplicates, "receipts": receipts, "replay": False,
         }
 
 
@@ -131,6 +145,9 @@ class ConnectorRunnerTest(unittest.TestCase):
         runner = self.runner(connector, brain)
         with self.assertRaisesRegex(ConnectorRunError, "brain_unavailable"):
             runner.run_once()
+        self.assertEqual(
+            runner.db.execute("SELECT count(*) FROM acknowledged_records").fetchone()[0], 0,
+        )
         self.assertFalse(runner.doctor()["checkpointed"])
         self.assertEqual(runner.doctor()["pending"], 1)
         runner.close()
@@ -140,10 +157,84 @@ class ConnectorRunnerTest(unittest.TestCase):
         self.assertEqual(result["replayed"], 1)
         self.assertTrue(recovered.doctor()["checkpointed"])
         self.assertEqual(len(brain.events), 1)
+        self.assertEqual(
+            recovered.db.execute("SELECT count(*) FROM acknowledged_records").fetchone()[0], 1,
+        )
         self.assertEqual(connector.pulls, [None])
         recovered.run_once()
         self.assertEqual(connector.pulls, [None, "page-1"])
         recovered.close()
+
+    def test_reordered_acknowledged_record_is_not_resubmitted(self) -> None:
+        repeated = record("reordered-one", "same acknowledged content")
+        connector = SyntheticConnector({
+            None: ConnectorPage(records=(repeated,), next_cursor="first", has_more=True),
+            "first": ConnectorPage(records=(repeated,), next_cursor="second", has_more=False),
+        })
+        brain = FakeBrain()
+        runner = self.runner(connector, brain)
+        self.assertEqual(runner.run_once()["acked"], 1)
+        second = runner.run_once()
+        self.assertEqual(second["acked"], 0)
+        self.assertEqual(brain.calls, 1)
+        self.assertEqual(brain.duplicate_events, 0)
+        self.assertEqual(second["deduplicated"], 1)
+        runner.close()
+
+    def test_changed_content_and_tombstone_ingest_but_old_versions_stay_suppressed(self) -> None:
+        connector = SyntheticConnector({
+            None: ConnectorPage(
+                records=(record("versioned-one", "first version"),),
+                next_cursor="first", has_more=True,
+            ),
+            "first": ConnectorPage(
+                records=(record("versioned-one", "second version"),),
+                next_cursor="second", has_more=True,
+            ),
+            "second": ConnectorPage(
+                records=(record("versioned-one", "deleted", deleted=True),),
+                next_cursor="deleted", has_more=True,
+            ),
+            "deleted": ConnectorPage(
+                records=(record("versioned-one", "first version"),),
+                next_cursor="done", has_more=False,
+            ),
+        })
+        brain = FakeBrain()
+        runner = self.runner(connector, brain)
+        self.assertEqual(runner.run_once()["acked"], 1)
+        self.assertEqual(runner.run_once()["acked"], 1)
+        self.assertEqual(runner.run_once()["acked"], 1)
+        final = runner.run_once()
+        self.assertEqual(final["acked"], 0)
+        self.assertEqual(final["deduplicated"], 1)
+        self.assertEqual(brain.calls, 3)
+        self.assertEqual(brain.duplicate_events, 0)
+        self.assertEqual(
+            runner.db.execute("SELECT count(*) FROM acknowledged_records").fetchone()[0], 3,
+        )
+        runner.close()
+
+    def test_acknowledged_ledger_contains_hashes_only(self) -> None:
+        native_id = "ledger-native-marker-73"
+        content_marker = "ledger-content-marker-84"
+        connector = SyntheticConnector({None: ConnectorPage(
+            records=(record(native_id, content_marker),), next_cursor="done", has_more=False,
+        )})
+        runner = self.runner(connector, FakeBrain())
+        runner.run_once()
+        row = runner.db.execute(
+            "SELECT native_sha256,content_sha256 FROM acknowledged_records"
+        ).fetchone()
+        self.assertEqual(
+            row["native_sha256"],
+            hashlib.sha256(f"{runner.source_id}\0{native_id}".encode()).hexdigest(),
+        )
+        self.assertRegex(row["native_sha256"], r"\A[0-9a-f]{64}\Z")
+        self.assertRegex(row["content_sha256"], r"\A[0-9a-f]{64}\Z")
+        self.assertNotIn(native_id.encode(), self.spool_bytes())
+        self.assertNotIn(content_marker.encode(), self.spool_bytes())
+        runner.close()
 
     def test_pending_payload_is_durable_but_acknowledged_bytes_are_purged(self) -> None:
         marker = "synthetic-ack-purge-marker-91"
@@ -290,6 +381,131 @@ class ConnectorRunnerTest(unittest.TestCase):
         self.assertNotIn(cursor, rendered_doctor)
         self.assertTrue(runner.doctor()["checkpointed"])
         runner.close()
+
+
+class AcknowledgedSeedTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        os.chmod(self.root, 0o700)
+        self.spool = self.root / "connector.db"
+        connector = SyntheticConnector({})
+        runner = ConnectorRunner(connector=connector, brain=FakeBrain(), spool_path=self.spool)
+        runner.close()
+        self.seed = self.root / "seed.json"
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def write_seed(self, value: object, *, path: Path | None = None, mode: int = 0o600) -> Path:
+        target = path or self.seed
+        target.write_text(json.dumps(value))
+        os.chmod(target, mode)
+        return target
+
+    @staticmethod
+    def pair(native: str = "a", content: str = "b") -> dict[str, str]:
+        return {
+            "native_sha256": hashlib.sha256(native.encode()).hexdigest(),
+            "content_sha256": hashlib.sha256(content.encode()).hexdigest(),
+        }
+
+    def test_seed_is_idempotent_content_free_and_suppresses_first_upgraded_sweep(self) -> None:
+        native_id = "already-central"
+        repeated = record(native_id, "already central content")
+        connector = SyntheticConnector({None: ConnectorPage(
+            records=(repeated,), next_cursor="done", has_more=False,
+        )})
+        event_runner = ConnectorRunner(
+            connector=connector, brain=FakeBrain(), spool_path=self.root / "event.db",
+        )
+        event = event_runner._event(repeated, repeated.content, repeated.provenance)
+        event_runner.close()
+        pair = {
+            "native_sha256": hashlib.sha256(
+                f"{connector.source_id}\0{native_id}".encode()
+            ).hexdigest(),
+            "content_sha256": event["content_sha256"],
+        }
+        self.write_seed({"schema_version": 1, "records": [pair]})
+        result = seed_acknowledged_records(spool_path=self.spool, seed_path=self.seed)
+        self.assertEqual(result, {
+            "schema_version": 1, "seeded": 1, "already_acknowledged": 0,
+        })
+        again = seed_acknowledged_records(spool_path=self.spool, seed_path=self.seed)
+        self.assertEqual(again, {
+            "schema_version": 1, "seeded": 0, "already_acknowledged": 1,
+        })
+        brain = FakeBrain()
+        upgraded = ConnectorRunner(connector=connector, brain=brain, spool_path=self.spool)
+        synced = upgraded.run_once()
+        self.assertEqual(synced["deduplicated"], 1)
+        self.assertEqual(synced["acked"], 0)
+        self.assertEqual(brain.calls, 0)
+        upgraded.close()
+
+    def test_seed_rejects_non_hash_data_duplicates_uppercase_and_open_schema(self) -> None:
+        pair = self.pair()
+        invalid = [
+            {"schema_version": 1, "records": [{**pair, "native_sha256": "raw-id"}]},
+            {"schema_version": 1, "records": [{**pair, "native_sha256": pair["native_sha256"].upper()}]},
+            {"schema_version": 1, "records": [pair, pair]},
+            {"schema_version": 1, "records": [{**pair, "extra": "not-closed"}]},
+            {"schema_version": 1, "records": [pair], "extra": True},
+        ]
+        for index, value in enumerate(invalid):
+            with self.subTest(index=index):
+                self.write_seed(value)
+                with self.assertRaises(ConnectorContractError):
+                    seed_acknowledged_records(spool_path=self.spool, seed_path=self.seed)
+        with sqlite3.connect(self.spool) as db:
+            self.assertEqual(db.execute("SELECT count(*) FROM acknowledged_records").fetchone()[0], 0)
+
+    def test_seed_rejects_relative_paths_bad_modes_symlinks_and_unsafe_parent(self) -> None:
+        manifest = {"schema_version": 1, "records": [self.pair()]}
+        self.write_seed(manifest)
+        with self.assertRaisesRegex(ConnectorContractError, "absolute"):
+            seed_acknowledged_records(spool_path=self.spool, seed_path=Path("seed.json"))
+        self.write_seed(manifest, mode=0o644)
+        with self.assertRaisesRegex(ConnectorContractError, "0600"):
+            seed_acknowledged_records(spool_path=self.spool, seed_path=self.seed)
+        self.write_seed(manifest)
+        link = self.root / "seed-link.json"
+        link.symlink_to(self.seed)
+        with self.assertRaisesRegex(ConnectorContractError, "non-symlink"):
+            seed_acknowledged_records(spool_path=self.spool, seed_path=link)
+        os.chmod(self.root, 0o755)
+        with self.assertRaisesRegex(ConnectorContractError, "0700"):
+            seed_acknowledged_records(spool_path=self.spool, seed_path=self.seed)
+
+    def test_seed_cli_emits_counts_without_paths_or_hashes(self) -> None:
+        pair = self.pair("cli-native", "cli-content")
+        self.write_seed({"schema_version": 1, "records": [pair]})
+        output = io.StringIO()
+        with mock.patch("sys.argv", [
+            "recall-brain", "connector-spool-seed-acknowledged",
+            "--spool", str(self.spool), "--input", str(self.seed),
+        ]), mock.patch("sys.stdout", output):
+            client_cli.main()
+        rendered = output.getvalue()
+        self.assertEqual(json.loads(rendered)["seeded"], 1)
+        self.assertNotIn(str(self.spool), rendered)
+        self.assertNotIn(str(self.seed), rendered)
+        self.assertNotIn(pair["native_sha256"], rendered)
+        self.assertNotIn(pair["content_sha256"], rendered)
+
+    def test_seed_rejects_pending_work_without_modifying_ledger(self) -> None:
+        pair = self.pair("pending-native", "pending-content")
+        self.write_seed({"schema_version": 1, "records": [pair]})
+        with sqlite3.connect(self.spool) as db:
+            db.execute(
+                "INSERT INTO pages(cursor_before,cursor_after,has_more,created_at) VALUES (?,?,?,?)",
+                ("null", '"next"', 0, 1.0),
+            )
+        with self.assertRaisesRegex(ConnectorContractError, "no pending"):
+            seed_acknowledged_records(spool_path=self.spool, seed_path=self.seed)
+        with sqlite3.connect(self.spool) as db:
+            self.assertEqual(db.execute("SELECT count(*) FROM acknowledged_records").fetchone()[0], 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add an ACK-gated, hash-only connector ledger that suppresses exact reordered repeats before Brain transport
- preserve changed revisions, tombstones, privacy-before-spool, and lost-ACK replay
- add a strict mode-0600, hash-only seed CLI for already-centralized sources
- strengthen the PostgreSQL connector E2E against repetition and post-tombstone resurrection

## Test Results
- `cd recall && python -m unittest discover -s tests -v` — 174 passed
- `npm test` — 8 passed
- seven connector/capture E2Es on fresh PostgreSQL — passed
- `cd recall && npm run pack:check` — passed
- two production Darwin/arm64 package builds — byte-identical
- two full live reordered sweeps — 0 Brain batches, 0 duplicate events
- scoped search/resolve, credential-residue, and disable/re-enable gates — passed
- commit-range gitleaks scan — no findings

## Notes
No transcripts, conversations, prompts, tool traces, private exports, source content, credentials, identifying paths, or private cascade artifacts are included.