### PR TITLE
feat(recall): bind capture provenance to MCP hosts

### DIFF
--- a/recall/client/README.md
+++ b/recall/client/README.md
@@ -129,25 +129,33 @@ See `connectors/README.md` before adding a source.
 
 ## Deliberate agent capture over MCP
 
-The bundled stdio MCP server lets Codex, Claude Code, ChatGPT/Cowork, or another
-MCP host deliberately save one selected evidence item without giving the model a
-Brain credential. Preview a config object; Recall does not edit harness config:
+The bundled stdio MCP server lets Codex, Claude Code, Claude Desktop, or another
+local MCP host deliberately save one selected evidence item without giving the
+model a Brain credential. Preview one source-scoped config per host; Recall does
+not edit harness config:
 
 ```bash
 recall-brain mcp-config-preview \
   --endpoint https://brain.example.ts.net \
-  --source-id capture:mac:my-mac \
+  --source-id capture:mac:my-mac:codex \
+  --capture-origin openai-codex \
   --visibility private \
   --keychain-service ai.parcha.recall \
-  --keychain-account capture:mac:my-mac \
+  --keychain-account capture:mac:my-mac:codex \
   --privacy-mode scrub
 ```
 
-Review the JSON and install it through the host's normal MCP settings. The
-process resolves Keychain only after launch; stdout carries newline-delimited
-MCP JSON-RPC and never logs arguments. The tools are `recall_capture`,
-`recall_forget`, and content-free `recall_doctor`. Capture retries are
-content-identity stable and return the same receipt. `shared` visibility is
-available only when explicitly selected in the process config, never in a tool
-call. The current stable MCP revision is `2025-11-25`, with negotiation support
-for `2025-06-18` clients.
+Review the JSON and install it through the host's normal MCP settings. Give each
+host its own source-scoped Brain credential and fixed `--capture-origin`; the
+model cannot set or override origin in a tool call. The process resolves
+Keychain only after launch; stdout carries newline-delimited MCP JSON-RPC and
+never logs arguments. The tools are `recall_capture`, `recall_forget`, and
+content-free `recall_doctor`. Capture retries are content-identity stable and
+return the same receipt. `shared` visibility is available only when explicitly
+selected in the process config, never in a tool call. The current stable MCP
+revision is `2025-11-25`, with negotiation support for `2025-06-18` clients.
+
+ChatGPT does not connect directly to a local MCP server. Use an approved remote
+MCP deployment or OpenAI's Secure MCP Tunnel adapter instead; do not reuse a
+local host's source credential for that bridge. See OpenAI's
+[developer mode and MCP documentation](https://help.openai.com/en/articles/12584461-developer-mode-and-mcp-apps-in-chatgpt).

--- a/recall/client/cli.py
+++ b/recall/client/cli.py
@@ -17,7 +17,7 @@ from client.mac import (
     store_keychain_token,
 )
 from collector.collector import Collector
-from client.capture import CaptureClient
+from client.capture import CaptureClient, ORIGIN
 from client.mcp import McpServer, serve as serve_mcp
 from connectors.export_inbox import ExportInboxConnector
 from connectors.grep_ai import GrepAIConnector, load_private_api_key, validate_api_key
@@ -72,6 +72,12 @@ def _mcp_connection(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--principal-id", default="owner")
     parser.add_argument("--visibility", choices=("private", "shared"), default="private")
     _auth(parser)
+
+
+def _capture_origin(value: str) -> str:
+    if not ORIGIN.fullmatch(value):
+        raise argparse.ArgumentTypeError("capture origin is invalid")
+    return value
 
 
 def _privacy(parser: argparse.ArgumentParser, *, choices=("off", "scrub", "drop"), default=None) -> None:
@@ -213,11 +219,13 @@ def parser() -> argparse.ArgumentParser:
     mcp_preview = commands.add_parser("mcp-config-preview")
     _mcp_connection(mcp_preview)
     _privacy(mcp_preview)
+    mcp_preview.add_argument("--capture-origin", required=True, type=_capture_origin)
     mcp_preview.add_argument("--executable", default="recall-brain")
 
     mcp_serve = commands.add_parser("mcp-serve")
     _mcp_connection(mcp_serve)
     _privacy(mcp_serve)
+    mcp_serve.add_argument("--capture-origin", required=True, type=_capture_origin)
 
     delete = commands.add_parser("delete")
     _connection(delete)
@@ -343,6 +351,7 @@ def main() -> None:
         command_args = [
             "mcp-serve", "--endpoint", args.endpoint,
             "--source-id", args.source_id, "--principal-id", args.principal_id,
+            "--capture-origin", args.capture_origin,
             "--visibility", args.visibility, *auth,
             "--privacy-mode", args.privacy_mode,
             "--privacy-judge-failure", args.privacy_judge_failure,
@@ -429,7 +438,10 @@ def main() -> None:
     privacy = _privacy_policy(args) if args.command in {"collect", "export", "put", "export-inbox-sync", "mcp-serve", "grep-ai-sync"} else PrivacyPolicy(mode="off")
     if args.command == "mcp-serve":
         backend = CaptureClient(**common, privacy=privacy)
-        serve_mcp(McpServer(backend), sys.stdin, sys.stdout, sys.stderr)
+        serve_mcp(
+            McpServer(backend, capture_origin=args.capture_origin),
+            sys.stdin, sys.stdout, sys.stderr,
+        )
         return
     if args.command == "collect":
         collector = Collector(

--- a/recall/client/mcp.py
+++ b/recall/client/mcp.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from typing import Any, TextIO
 
-from client.capture import CaptureContractError, validate_capture
+from client.capture import CaptureContractError, ORIGIN, validate_capture
 
 
 PROTOCOL_VERSION = "2025-11-25"
@@ -22,12 +22,11 @@ class McpProtocolError(ValueError):
 CAPTURE_SCHEMA = {
     "type": "object",
     "additionalProperties": False,
-    "required": ["schema_version", "title", "body", "origin", "occurred_at", "provenance"],
+    "required": ["schema_version", "title", "body", "occurred_at", "provenance"],
     "properties": {
         "schema_version": {"const": 1},
         "title": {"type": "string", "minLength": 1, "maxLength": 500},
         "body": {"type": "string", "minLength": 1, "maxLength": 1000000},
-        "origin": {"type": "string", "pattern": "^[a-z][a-z0-9_.-]{1,63}$"},
         "occurred_at": {"type": "string", "format": "date-time"},
         "tags": {"type": "array", "maxItems": 20, "uniqueItems": True, "items": {"type": "string"}},
         "provenance": {
@@ -68,8 +67,11 @@ def _result(value: dict[str, Any]) -> dict[str, Any]:
 
 
 class McpServer:
-    def __init__(self, backend):
+    def __init__(self, backend, *, capture_origin: str):
+        if not isinstance(capture_origin, str) or not ORIGIN.fullmatch(capture_origin):
+            raise CaptureContractError("capture origin is invalid")
         self.backend = backend
+        self.capture_origin = capture_origin
 
     def handle(self, request: Any) -> dict[str, Any] | None:
         if not isinstance(request, dict) or request.get("jsonrpc") != "2.0":
@@ -105,7 +107,11 @@ class McpServer:
         arguments = params["arguments"]
         try:
             if name == "recall_capture":
-                value = self.backend.capture(validate_capture(arguments))
+                if not isinstance(arguments, dict) or "origin" in arguments:
+                    raise CaptureContractError("capture schema is invalid")
+                value = self.backend.capture(validate_capture({
+                    **arguments, "origin": self.capture_origin,
+                }))
             elif name == "recall_forget":
                 if not isinstance(arguments, dict) or set(arguments) != {"receipt"} or not isinstance(arguments["receipt"], str):
                     raise CaptureContractError("forget schema is invalid")

--- a/recall/server/tests/e2e_capture_mcp.py
+++ b/recall/server/tests/e2e_capture_mcp.py
@@ -18,12 +18,17 @@ from privacy.policy import PrivacyPolicy
 from recall_server.db import BrainStore
 
 
-SOURCE = "synthetic:capture:postgres"
+PROFILES = (
+    ("synthetic:capture:codex", "openai-codex"),
+    ("synthetic:capture:claude-code", "anthropic-claude-code"),
+    ("synthetic:capture:claude-desktop", "anthropic-claude-desktop"),
+    ("synthetic:capture:chatgpt-remote", "openai-chatgpt-remote"),
+)
 FIXTURE = ROOT / "recall/tests/capture_v1/corpus.jsonl"
 
 
 class StoreCapture(CaptureClient):
-    def __init__(self, store: BrainStore, *, source_id: str = SOURCE, mode: str = "scrub"):
+    def __init__(self, store: BrainStore, *, source_id: str = PROFILES[0][0], mode: str = "scrub"):
         super().__init__(
             endpoint="https://synthetic.invalid", token="synthetic-token",
             source_id=source_id, principal_id="owner", visibility="private",
@@ -66,46 +71,84 @@ def main() -> None:
     try:
         rows = [json.loads(line) for line in FIXTURE.read_text().splitlines()]
         valid = [row["capture"] for row in rows if row["valid"]]
-        server = McpServer(StoreCapture(store))
+        servers = {
+            source_id: McpServer(
+                StoreCapture(store, source_id=source_id), capture_origin=origin,
+            )
+            for source_id, origin in PROFILES
+        }
         receipts = []
-        for index, capture in enumerate(valid, 1):
-            outcome = result_text(call(server, index, "recall_capture", capture))
+        for index, ((source_id, origin), capture) in enumerate(zip(PROFILES, valid, strict=True), 1):
+            arguments = {key: value for key, value in capture.items() if key != "origin"}
+            arguments["title"] = f"Synthetic {origin} profile"
+            arguments["body"] = f"bounded cobalt queue {origin}"
+            arguments["provenance"] = {"uri": f"manual://{origin}"}
+            outcome = result_text(call(servers[source_id], index, "recall_capture", arguments))
             receipts.append(outcome["receipt"])
         assert len(set(receipts)) == 4
-        before_retry = store.doctor(SOURCE)
-        replay = result_text(call(server, 10, "recall_capture", valid[0]))
+        first_source, first_origin = PROFILES[0]
+        first_arguments = {key: value for key, value in valid[0].items() if key != "origin"}
+        first_arguments.update({
+            "title": f"Synthetic {first_origin} profile",
+            "body": f"bounded cobalt queue {first_origin}",
+            "provenance": {"uri": f"manual://{first_origin}"},
+        })
+        before_retry = store.doctor(first_source)
+        replay = result_text(call(servers[first_source], 10, "recall_capture", first_arguments))
         assert replay["receipt"] == receipts[0] and replay["replay"] is True
-        after_retry = store.doctor(SOURCE)
-        assert before_retry["source_events"] == after_retry["source_events"] == 4
-        assert before_retry["live_items"] == after_retry["live_items"] == 4
+        after_retry = store.doctor(first_source)
+        assert before_retry["source_events"] == after_retry["source_events"] == 1
+        assert before_retry["live_items"] == after_retry["live_items"] == 1
 
-        assert store.search("bounded cobalt queue", authorized_source=SOURCE)["results"]
-        assert store.search("Keep safe Cowork context", authorized_source=SOURCE)["results"]
-        assert store.search("synthetic-capture-secret-canary-101", authorized_source=SOURCE)["results"] == []
+        for (source_id, origin), receipt in zip(PROFILES, receipts, strict=True):
+            assert store.search(origin, authorized_source=source_id)["results"]
+            resolved = store.resolve(receipt)
+            assert resolved and resolved["event"]["source_id"] == source_id
+            with store.connect() as connection:
+                envelope = connection.execute(
+                    "SELECT envelope FROM source_events WHERE source_id=%s AND native_id=%s",
+                    (source_id, resolved["event"]["native_id"]),
+                ).fetchone()["envelope"]
+            assert envelope["content"]["origin"] == origin
+        assert store.search("synthetic-capture-secret-canary-101")["results"] == []
 
-        deleted = result_text(call(server, 11, "recall_forget", {"receipt": receipts[0]}))
-        assert deleted["receipt"].endswith("?rev=2")
-        assert store.search("bounded cobalt queue", authorized_source=SOURCE)["results"] == []
-        assert store.doctor(SOURCE)["live_items"] == 3
-
-        drop_server = McpServer(StoreCapture(store, mode="drop"))
-        dropped = result_text(call(drop_server, 12, "recall_capture", valid[2]))
-        assert dropped["status"] == "privacy_filtered"
-        assert store.doctor(SOURCE)["source_events"] == 5
-
-        wrong = McpServer(StoreCapture(store, source_id="synthetic:capture:other"))
+        spoof = {**first_arguments, "origin": PROFILES[1][1]}
         try:
-            call(wrong, 13, "recall_forget", {"receipt": receipts[1]})
+            call(servers[first_source], 11, "recall_capture", spoof)
+        except McpProtocolError as error:
+            assert error.message == "capture_invalid"
+        else:
+            raise AssertionError("caller-controlled origin was accepted")
+
+        deleted = result_text(call(servers[first_source], 12, "recall_forget", {"receipt": receipts[0]}))
+        assert deleted["receipt"].endswith("?rev=2")
+        assert store.search(first_origin, authorized_source=first_source)["results"] == []
+        assert store.doctor(first_source)["live_items"] == 0
+
+        drop_server = McpServer(
+            StoreCapture(store, source_id=first_source, mode="drop"),
+            capture_origin=first_origin,
+        )
+        sensitive_arguments = {
+            key: value for key, value in valid[2].items() if key != "origin"
+        }
+        dropped = result_text(call(drop_server, 13, "recall_capture", sensitive_arguments))
+        assert dropped["status"] == "privacy_filtered"
+        assert store.doctor(first_source)["source_events"] == 2
+
+        try:
+            call(servers[first_source], 14, "recall_forget", {"receipt": receipts[1]})
         except McpProtocolError as error:
             assert error.message == "capture_unavailable"
         else:
             raise AssertionError("cross-source receipt was accepted")
-        assert store.doctor(SOURCE)["live_items"] == 3
+        assert store.doctor(PROFILES[1][0])["live_items"] == 1
         print(json.dumps({
-            "status": "pass", "origins": 4, "live_after_capture": 4,
+            "status": "pass", "host_profiles": 4, "bound_origins": 4,
+            "live_after_capture": 4,
             "retry_added_events": 0, "same_receipt": True,
             "canary_search_hits": 0, "live_after_forget": 3,
-            "cross_source_deletes": 0,
+            "origin_spoofs": 0, "cross_source_deletes": 0,
         }, sort_keys=True))
     finally:
         truncate(store)

--- a/recall/server/tests/e2e_macos_capture_mcp_c8c.py
+++ b/recall/server/tests/e2e_macos_capture_mcp_c8c.py
@@ -33,15 +33,14 @@ def call(process: subprocess.Popen, request_id: int, name: str, arguments: dict)
     return json.loads(response["result"]["content"][0]["text"])
 
 
-def capture(origin: str, nonce: str, index: int, body: str) -> dict:
+def capture(label: str, nonce: str, index: int, body: str) -> dict:
     return {
         "schema_version": 1,
-        "title": f"Synthetic {origin} capture",
+        "title": f"Synthetic {label} capture",
         "body": body,
-        "origin": origin,
         "occurred_at": f"2026-07-14T14:0{index}:00Z",
         "tags": ["synthetic", "c8c"],
-        "provenance": {"uri": f"manual://c8c-{origin}"},
+        "provenance": {"uri": f"manual://c8c-{label}"},
     }
 
 
@@ -71,6 +70,7 @@ def main() -> None:
         preview = subprocess.run([
             str(args.wrapper), "mcp-config-preview",
             "--endpoint", args.endpoint, "--source-id", args.source_id,
+            "--capture-origin", "synthetic-c8c",
             "--visibility", "private", "--token-file", str(token_file),
             "--privacy-mode", "scrub",
         ], check=True, text=True, capture_output=True)
@@ -81,6 +81,7 @@ def main() -> None:
         process = subprocess.Popen([
             str(args.wrapper), "mcp-serve",
             "--endpoint", args.endpoint, "--source-id", args.source_id,
+            "--capture-origin", "synthetic-c8c",
             "--visibility", "private", "--token-file", str(token_file),
             "--privacy-mode", "scrub",
         ], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
@@ -150,7 +151,7 @@ def main() -> None:
             "status": "pass",
             "summary": {
                 "protocol_version": "2025-11-25", "tools": 3,
-                "origins": 4, "retry_added_events": 0,
+                "source_labels": 4, "bound_origins": 1, "retry_added_events": 0,
                 "same_retry_receipt": True, "canary_search_hits": 0,
                 "resolved_canary_hits": 0, "forgotten": 4,
                 "live_items_after_forget": 0,

--- a/recall/server/tests/e2e_macos_capture_mcp_c8i.py
+++ b/recall/server/tests/e2e_macos_capture_mcp_c8i.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Packaged Darwin/arm64 proof for host-attested federated MCP capture."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import urllib.error
+from pathlib import Path
+
+from client.mac import BrainClient
+
+
+PROFILES = (
+    ("codex", "openai-codex"),
+    ("claude-code", "anthropic-claude-code"),
+    ("claude-desktop", "anthropic-claude-desktop"),
+    ("chatgpt-remote", "openai-chatgpt-remote"),
+)
+
+
+def rpc(process: subprocess.Popen, request: dict) -> dict:
+    process.stdin.write(json.dumps(request, separators=(",", ":")) + "\n")
+    process.stdin.flush()
+    line = process.stdout.readline()
+    if not line:
+        raise AssertionError("MCP process ended before response")
+    return json.loads(line)
+
+
+def tool(process: subprocess.Popen, request_id: int, name: str, arguments: dict) -> dict:
+    return rpc(process, {
+        "jsonrpc": "2.0", "id": request_id, "method": "tools/call",
+        "params": {"name": name, "arguments": arguments},
+    })
+
+
+def value(response: dict) -> dict:
+    assert "error" not in response, response.get("error")
+    return json.loads(response["result"]["content"][0]["text"])
+
+
+def private_file(path: Path, payload: dict) -> None:
+    descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    with os.fdopen(descriptor, "w") as output:
+        json.dump(payload, output, separators=(",", ":"))
+    assert path.stat().st_mode & 0o777 == 0o600
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--endpoint", required=True)
+    parser.add_argument("--nonce", required=True)
+    parser.add_argument("--workspace", type=Path, required=True)
+    parser.add_argument("--wrapper", type=Path, required=True)
+    args = parser.parse_args()
+    credentials = json.load(__import__("sys").stdin)
+    if not isinstance(credentials, dict) or set(credentials) != {name for name, _ in PROFILES}:
+        raise ValueError("stdin must contain the four closed profile authorities")
+
+    root = args.workspace / "synthetic-capture-c8i"
+    processes: dict[str, subprocess.Popen] = {}
+    clients: dict[str, BrainClient] = {}
+    receipts: dict[str, str] = {}
+    markers: dict[str, str] = {}
+    result = None
+    try:
+        root.mkdir(parents=True, mode=0o700)
+        assert root.stat().st_mode & 0o777 == 0o700
+        for index, (name, origin) in enumerate(PROFILES, 1):
+            authority = credentials[name]
+            if (
+                not isinstance(authority, dict) or set(authority) != {"source_id", "token"}
+                or not isinstance(authority["source_id"], str)
+                or not isinstance(authority["token"], str) or not authority["token"]
+            ):
+                raise ValueError("profile authority is invalid")
+            token_file = root / f"{name}.json"
+            private_file(token_file, {"token": authority["token"]})
+            command = [
+                str(args.wrapper), "mcp-serve",
+                "--endpoint", args.endpoint,
+                "--source-id", authority["source_id"],
+                "--capture-origin", origin,
+                "--visibility", "private",
+                "--token-file", str(token_file),
+                "--privacy-mode", "scrub",
+            ]
+            preview = subprocess.run(
+                [str(args.wrapper), "mcp-config-preview", *command[2:]],
+                check=True, text=True, capture_output=True,
+            )
+            rendered = json.loads(preview.stdout)
+            assert rendered["network_requests"] == 0 and rendered["writes"] == 0
+            assert origin in rendered["mcpServers"]["recall"]["args"]
+            assert authority["token"] not in preview.stdout and preview.stderr == ""
+
+            process = subprocess.Popen(
+                command, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE, text=True,
+            )
+            processes[name] = process
+            initialized = rpc(process, {
+                "jsonrpc": "2.0", "id": 1, "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-11-25", "capabilities": {},
+                    "clientInfo": {"name": f"synthetic-{name}", "version": "1.0.0"},
+                },
+            })
+            assert initialized["result"]["protocolVersion"] == "2025-11-25"
+            listed = rpc(process, {
+                "jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {},
+            })
+            tools = {item["name"]: item for item in listed["result"]["tools"]}
+            assert set(tools) == {"recall_capture", "recall_forget", "recall_doctor"}
+            schema = tools["recall_capture"]["inputSchema"]
+            assert "origin" not in schema["properties"] and "origin" not in schema["required"]
+
+            marker = f"c8i-safe-{name}-{args.nonce}"
+            markers[name] = marker
+            capture = {
+                "schema_version": 1,
+                "title": f"Synthetic {name} capture",
+                "body": marker,
+                "occurred_at": f"2026-07-14T15:0{index}:00Z",
+                "tags": ["synthetic", "c8i"],
+                "provenance": {"uri": f"manual://c8i-{name}"},
+            }
+            captured = value(tool(process, 10, "recall_capture", capture))
+            assert marker not in json.dumps(captured)
+            receipts[name] = captured["receipt"]
+            replay = value(tool(process, 11, "recall_capture", capture))
+            assert replay["receipt"] == receipts[name] and replay["replay"] is True
+
+            spoofed = tool(process, 12, "recall_capture", {**capture, "origin": "spoofed-host"})
+            assert spoofed["error"] == {"code": -32602, "message": "capture_invalid"}
+            clients[name] = BrainClient(
+                endpoint=args.endpoint, token=authority["token"],
+                source_id=authority["source_id"], principal_id="owner",
+                visibility="private",
+            )
+
+        for name, _origin in PROFILES:
+            assert clients[name].doctor()["live_items"] == 1
+            assert clients[name].search(markers[name], limit=5)["results"]
+        assert clients[PROFILES[0][0]].search(markers[PROFILES[1][0]], limit=5)["results"] == []
+
+        cross_delete = tool(
+            processes[PROFILES[0][0]], 20, "recall_forget",
+            {"receipt": receipts[PROFILES[1][0]]},
+        )
+        assert cross_delete["error"] == {"code": -32000, "message": "capture_unavailable"}
+        assert clients[PROFILES[1][0]].doctor()["live_items"] == 1
+
+        for index, (name, _origin) in enumerate(PROFILES, 30):
+            forgotten = value(tool(
+                processes[name], index, "recall_forget", {"receipt": receipts[name]},
+            ))
+            assert forgotten["receipt"].endswith("?rev=2")
+            assert clients[name].doctor()["live_items"] == 0
+            assert clients[name].search(markers[name], limit=5)["results"] == []
+            try:
+                clients[name].resolve(receipts[name])
+            except urllib.error.HTTPError as error:
+                assert error.code == 404
+            else:
+                raise AssertionError("forgotten receipt still resolved")
+
+        result = {
+            "status": "pass",
+            "summary": {
+                "host_profiles": 4, "bound_origins": 4,
+                "origin_spoofs": 0, "cross_source_deletes": 0,
+                "retry_added_events": 0, "forgotten": 4,
+                "live_items_after_forget": 0,
+            },
+        }
+    finally:
+        for process in processes.values():
+            if process.stdin:
+                process.stdin.close()
+            process.wait(timeout=10)
+            stderr = process.stderr.read() if process.stderr else ""
+            if result is not None:
+                assert process.returncode == 0 and stderr == ""
+        shutil.rmtree(root, ignore_errors=True)
+    assert not root.exists() and result is not None
+    result["summary"]["credential_file_residue"] = 0
+    result["summary"]["local_residue"] = 0
+    print(json.dumps(result, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/recall/skills/recall/SKILL.md
+++ b/recall/skills/recall/SKILL.md
@@ -112,12 +112,16 @@ without destroying its recoverable catalog/spool.
 
 Prefer the packaged `recall_capture` MCP tool when the user wants an agent to
 remember a selected decision, result, or external finding. Capture one concise
-evidence object with a truthful `origin`, timestamp, title/body, tags, and a
-non-secret provenance URI. Return its canonical receipt. Do not capture whole
+evidence object with a timestamp, title/body, tags, and a non-secret provenance
+URI; the host configuration supplies the truthful, fixed origin. Return its
+canonical receipt. Do not capture whole
 transcripts, hidden reasoning, ambient context, secrets, or third-party results
-the user did not select. The MCP process—not the model—owns the source-scoped
-credential and privacy policy. Use `recall_forget` only with the exact receipt;
-never approximate identity from search text.
+the user did not select. The MCP process—not the model—owns origin, the
+source-scoped credential, and privacy policy. Use one source profile per host;
+never reuse another host's authority or try to send `origin` in the tool call.
+Use `recall_forget` only with the exact receipt; never approximate identity from
+search text. ChatGPT needs a remote MCP or Secure MCP Tunnel adapter rather than
+the local stdio configuration.
 
 ## First: pick the outcome
 

--- a/recall/tests/test_capture_mcp.py
+++ b/recall/tests/test_capture_mcp.py
@@ -10,7 +10,7 @@ from unittest import mock
 
 from client import cli as client_cli
 from client.capture import CaptureClient, CaptureContractError
-from client.mcp import McpServer, serve
+from client.mcp import McpProtocolError, McpServer, serve
 from privacy.policy import PrivacyPolicy
 
 
@@ -152,7 +152,7 @@ class McpProtocolTest(unittest.TestCase):
 
     def test_initialize_list_and_three_tools_are_closed(self) -> None:
         backend = FakeCapture()
-        server = McpServer(backend)
+        server = McpServer(backend, capture_origin="synthetic-client")
         initialized = server.handle(self.initialize())
         self.assertEqual(initialized["result"]["protocolVersion"], "2025-11-25")
         compatible = server.handle(self.initialize(9, "2025-06-18"))
@@ -163,13 +163,67 @@ class McpProtocolTest(unittest.TestCase):
         self.assertFalse(tools["recall_capture"]["inputSchema"].get("additionalProperties", True))
 
         capture = json.loads((FIXTURES / "corpus.jsonl").read_text().splitlines()[0])["capture"]
+        arguments = {key: value for key, value in capture.items() if key != "origin"}
         called = server.handle({
             "jsonrpc": "2.0", "id": 3, "method": "tools/call",
-            "params": {"name": "recall_capture", "arguments": capture},
+            "params": {"name": "recall_capture", "arguments": arguments},
         })
         rendered = json.dumps(called)
         self.assertIn("recall://", rendered)
         self.assertNotIn(capture["body"], rendered)
+
+    def test_capture_origin_is_bound_by_host_and_cannot_be_spoofed(self) -> None:
+        backend = FakeCapture()
+        server = McpServer(backend, capture_origin="openai-codex")
+        listed = server.handle({
+            "jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {},
+        })
+        schema = next(
+            tool["inputSchema"] for tool in listed["result"]["tools"]
+            if tool["name"] == "recall_capture"
+        )
+        self.assertNotIn("origin", schema["properties"])
+        self.assertNotIn("origin", schema["required"])
+
+        capture = json.loads((FIXTURES / "corpus.jsonl").read_text().splitlines()[0])["capture"]
+        arguments = {key: value for key, value in capture.items() if key != "origin"}
+        server.handle({
+            "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+            "params": {"name": "recall_capture", "arguments": arguments},
+        })
+        self.assertEqual(backend.calls[-1][1]["origin"], "openai-codex")
+
+        with self.assertRaisesRegex(McpProtocolError, "capture_invalid"):
+            server.handle({
+                "jsonrpc": "2.0", "id": 3, "method": "tools/call",
+                "params": {
+                    "name": "recall_capture",
+                    "arguments": {**arguments, "origin": "anthropic-claude"},
+                },
+            })
+        self.assertEqual(len(backend.calls), 1)
+
+    def test_invalid_bound_origin_fails_before_authority_or_network(self) -> None:
+        with self.assertRaises(CaptureContractError):
+            McpServer(FakeCapture(), capture_origin="caller supplied origin")
+        arguments = [
+            "recall-brain", "mcp-serve",
+            "--endpoint", "https://brain.example.ts.net",
+            "--source-id", "capture:mac:synthetic",
+            "--capture-origin", "caller supplied origin",
+            "--visibility", "private",
+            "--token-file", "/synthetic/private-reference.json",
+            "--privacy-mode", "drop",
+        ]
+        errors = io.StringIO()
+        with mock.patch("sys.argv", arguments), mock.patch("sys.stderr", errors), \
+             mock.patch("client.cli.load_file_token") as loaded, \
+             mock.patch("urllib.request.urlopen") as opened, \
+             self.assertRaises(SystemExit):
+            client_cli.main()
+        loaded.assert_not_called()
+        opened.assert_not_called()
+        self.assertNotIn("/synthetic/private-reference.json", errors.getvalue())
 
     def test_stdio_protocol_never_echoes_invalid_sensitive_arguments(self) -> None:
         canary = "synthetic-mcp-invalid-canary-102"
@@ -182,7 +236,10 @@ class McpProtocolTest(unittest.TestCase):
         ]) + "\n"
         output = io.StringIO()
         errors = io.StringIO()
-        serve(McpServer(FakeCapture()), io.StringIO(requests), output, errors)
+        serve(
+            McpServer(FakeCapture(), capture_origin="synthetic-client"),
+            io.StringIO(requests), output, errors,
+        )
         lines = [json.loads(line) for line in output.getvalue().splitlines()]
         self.assertEqual(len(lines), 2)
         self.assertIn("error", lines[1])
@@ -194,6 +251,7 @@ class McpProtocolTest(unittest.TestCase):
             "recall-brain", "mcp-config-preview",
             "--endpoint", "https://brain.example.ts.net",
             "--source-id", "capture:mac:synthetic",
+            "--capture-origin", "openai-codex",
             "--keychain-service", "ai.parcha.recall.synthetic",
             "--keychain-account", "capture:mac:synthetic",
             "--privacy-mode", "scrub",
@@ -212,6 +270,7 @@ class McpProtocolTest(unittest.TestCase):
         rendered = json.dumps(server)
         self.assertIn("mcp-serve", rendered)
         self.assertIn("capture:mac:synthetic", rendered)
+        self.assertIn("openai-codex", rendered)
         self.assertIn("ai.parcha.recall.synthetic", rendered)
         self.assertIn("private", rendered)
         self.assertNotIn("synthetic-transport-token", rendered)
@@ -221,6 +280,7 @@ class McpProtocolTest(unittest.TestCase):
             "recall-brain", "mcp-serve",
             "--endpoint", "https://brain.example.ts.net",
             "--source-id", "capture:mac:synthetic",
+            "--capture-origin", "openai-codex",
             "--visibility", "private",
             "--token-file", "/synthetic/private-reference.json",
             "--privacy-mode", "drop",
@@ -234,6 +294,7 @@ class McpProtocolTest(unittest.TestCase):
         self.assertEqual(backend.source_id, "capture:mac:synthetic")
         self.assertEqual(backend.visibility, "private")
         self.assertEqual(backend.privacy.mode, "drop")
+        self.assertEqual(served.call_args.args[0].capture_origin, "openai-codex")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- bind capture origin at MCP process launch and remove it from model-controlled tool arguments
- require one source-scoped profile per host with fail-closed launch validation
- document the honest local-host boundary and the remote ChatGPT adapter path
- add synthetic PostgreSQL and packaged Darwin/arm64 E2E coverage for four distinct profiles

## Verification
- `npm test`
- fresh PostgreSQL 16 E2E: 4 profiles, 4 bound origins, 0 spoofed origins, 0 cross-source deletes
- two independent production package builds were byte-identical
- packaged Darwin/arm64 E2E: 4 profiles, retry/forget/isolation green, 0 credential residue
- installed-profile probe: 3 supported local hosts, 3 scoped authorities, 3 bound origins, all healthy
- secret/privacy audit: no credentials, transcripts, host paths, private evidence, or runtime state in the diff