### PR TITLE
fix(recall): allow explicit HTTPS endpoint ports

### DIFF
--- a/recall/connectors/host.py
+++ b/recall/connectors/host.py
@@ -220,9 +220,19 @@ class HostedJobDefinition:
 def _endpoint(value: Any) -> str:
     if not isinstance(value, str) or len(value) > 2048:
         raise ConnectorHostError("invalid_endpoint")
-    parsed = urlparse(value)
-    production = parsed.scheme == "https" and bool(parsed.hostname) and parsed.port is None
-    loopback = parsed.scheme == "http" and parsed.hostname in {"127.0.0.1", "localhost"} and parsed.port is not None
+    try:
+        parsed = urlparse(value)
+        port = parsed.port
+    except ValueError as error:
+        raise ConnectorHostError("invalid_endpoint") from error
+    valid_port = port is None or 1 <= port <= 65535
+    production = parsed.scheme == "https" and bool(parsed.hostname) and valid_port
+    loopback = (
+        parsed.scheme == "http"
+        and parsed.hostname in {"127.0.0.1", "localhost"}
+        and port is not None
+        and valid_port
+    )
     if not (production or loopback) or parsed.username or parsed.password or parsed.query or parsed.fragment:
         raise ConnectorHostError("invalid_endpoint")
     if parsed.path not in {"", "/"}:

--- a/recall/tests/test_connector_host.py
+++ b/recall/tests/test_connector_host.py
@@ -28,6 +28,22 @@ MANIFEST = ROOT / "manifest.json"
 
 
 class FrozenHostConfigTest(unittest.TestCase):
+    def test_https_endpoint_accepts_explicit_tailnet_port_and_rejects_bad_ports(self) -> None:
+        value = json.loads(CORPUS.read_text().splitlines()[0])["config"]
+        value["jobs"][0]["endpoint"] = "https://brain.example.test:9443"
+        configured = ConnectorHostConfig.from_mapping(value)
+        self.assertEqual(configured.jobs[0].endpoint, "https://brain.example.test:9443")
+
+        for endpoint in (
+            "https://brain.example.test:0",
+            "https://brain.example.test:65536",
+            "https://brain.example.test:not-a-port",
+        ):
+            with self.subTest(endpoint=endpoint):
+                value["jobs"][0]["endpoint"] = endpoint
+                with self.assertRaisesRegex(ConnectorHostError, "invalid_endpoint"):
+                    ConnectorHostConfig.from_mapping(value)
+
     def test_manifest_and_closed_config_thresholds(self) -> None:
         manifest = json.loads(MANIFEST.read_text())
         rows = [json.loads(line) for line in CORPUS.read_text().splitlines()]


### PR DESCRIPTION
## Summary
- accept valid explicit ports on production HTTPS connector endpoints
- keep malformed, zero, and out-of-range ports fail-closed
- cover the live Tailnet `:9443` shape with a regression test

## Verification
- Recall: 181 passed
- portability: 8 passed
- Mac config preview: 2 jobs, zero credential/source/network reads and zero writes
- live Mac: 5 endpoint occurrences on `:9443`, 3/3 MCP profiles healthy, supervisor running, 2/2 jobs ready with latest success
- Gitleaks and public diff scan: clean

No credentials, transcripts, private configuration, live content, paths, databases, logs, or Cascade evidence are included.
