### PR TITLE
fix(tether): persist Slack thread participation

### DIFF
--- a/tether/runtime/bridge_runtime.py
+++ b/tether/runtime/bridge_runtime.py
@@ -327,6 +327,26 @@ class Store:
                 ).fetchone()
             return self.decode(row)
 
+    def replace_source(self, bridge_id: str, kind: str, raw_source: dict[str, Any]) -> Bridge:
+        if kind not in SOURCE_FIELDS:
+            raise ValueError("unsupported bridge source kind")
+        if not isinstance(raw_source, dict) or set(raw_source) - SOURCE_FIELDS[kind]:
+            raise ValueError("invalid bridge source")
+        if not all(isinstance(key, str) and isinstance(value, str) for key, value in raw_source.items()):
+            raise ValueError("bridge source values must be strings")
+        source = {key: value for key, value in raw_source.items() if value}
+        if any(len(value) > MAX_SOURCE_VALUE for value in source.values()):
+            raise ValueError("bridge source value is too large")
+        with self.connect() as db:
+            db.execute("BEGIN IMMEDIATE")
+            changed = db.execute(
+                "UPDATE bridges SET source_kind=?,source_json=? WHERE bridge_id=? AND status='active'",
+                (kind, json.dumps(source, separators=(",", ":")), bridge_id),
+            ).rowcount
+            if changed != 1:
+                raise ValueError("active bridge not found")
+            return self.decode(db.execute("SELECT * FROM bridges WHERE bridge_id=?", (bridge_id,)).fetchone())  # type: ignore[return-value]
+
     def mark_participation(self, team_id: str, channel_id: str, thread_ts: str) -> None:
         if not channel_id or not thread_ts:
             raise ValueError("channel and thread timestamp are required")
@@ -602,7 +622,7 @@ class Broker:
         status = {
             "ok": True,
             "implementation": "tether",
-            "protocol_version": 3,
+            "protocol_version": 4,
             "channel_configured": bool(effective_channel(config)),
             "owner_configured": bool(config.default_owner or allowed_users),
             "allowed_user_count": len(allowed_users),
@@ -718,6 +738,29 @@ class Broker:
             "deduplicated": False,
         }
 
+    def _rebind(self, request: BridgeRequest, config: Config) -> dict[str, Any]:
+        channel = str(request.get("channel_id") or effective_channel(config))
+        team = str(request.get("team_id") or config.team_id)
+        thread_ts = str(request.get("thread_ts") or "")
+        if not channel or not thread_ts:
+            raise ValueError("Slack channel and existing thread timestamp are required")
+        existing = self.store.find(team, channel, thread_ts)
+        if existing is None:
+            raise ValueError("active bridge not found for Slack thread")
+        kind = str(request.get("source_kind") or "")
+        source = request.get("source")
+        if kind != "zellij_pane" or not isinstance(source, dict):
+            raise ValueError("rebind requires the caller's live ambient Zellij pane")
+        bridge = self.store.replace_source(existing.bridge_id, kind, source)
+        self.store.mark_participation(bridge.team_id, bridge.channel_id, thread_ts)
+        return {
+            "ok": True,
+            "bridge_id": bridge.bridge_id,
+            "thread_ts": bridge.thread_ts,
+            "source_kind": bridge.source_kind,
+            "pane_id": bridge.source.get("pane_id", ""),
+        }
+
     def _history(self, request: BridgeRequest, config: Config) -> dict[str, Any]:
         limit = max(1, min(int(request.get("limit", 15)), 100))
         channel = str(request.get("channel_id") or effective_channel(config))
@@ -784,6 +827,9 @@ class Broker:
         if operation == "attach":
             with self._notify_lock:
                 return self._attach(request, config, allowed_users)
+        if operation == "rebind":
+            with self._notify_lock:
+                return self._rebind(request, config)
         if operation == "reply":
             return self._reply(request)
         if operation == "history":

--- a/tether/runtime/bridge_runtime.py
+++ b/tether/runtime/bridge_runtime.py
@@ -602,7 +602,7 @@ class Broker:
         status = {
             "ok": True,
             "implementation": "tether",
-            "protocol_version": 2,
+            "protocol_version": 3,
             "channel_configured": bool(effective_channel(config)),
             "owner_configured": bool(config.default_owner or allowed_users),
             "allowed_user_count": len(allowed_users),
@@ -683,6 +683,41 @@ class Broker:
             "message_ts": timestamp,
         }
 
+    def _attach(
+        self,
+        incoming: BridgeRequest,
+        config: Config,
+        allowed_users: tuple[str, ...],
+    ) -> dict[str, Any]:
+        request = BridgeRequest(incoming)
+        request["channel_id"] = str(request.get("channel_id") or effective_channel(config))
+        request["owner_user_id"] = str(
+            request.get("owner_user_id") or config.default_owner or ("*" if allowed_users else "")
+        )
+        request["team_id"] = str(request.get("team_id") or config.team_id)
+        thread_ts = str(request.get("thread_ts") or "")
+        if not request["channel_id"] or not thread_ts:
+            raise ValueError("Slack channel and existing thread timestamp are required")
+        existing = self.store.find(request["team_id"], request["channel_id"], thread_ts)
+        if existing is not None:
+            if existing.idempotency_key == str(request.get("idempotency_key") or ""):
+                return {
+                    "ok": True,
+                    "bridge_id": existing.bridge_id,
+                    "thread_ts": existing.thread_ts,
+                    "deduplicated": True,
+                }
+            raise ValueError("Slack thread already has an active Tether binding")
+        bridge = self.store.create(request)
+        bridge = self.store.bind(bridge.bridge_id, thread_ts)
+        self.store.mark_participation(bridge.team_id, bridge.channel_id, thread_ts)
+        return {
+            "ok": True,
+            "bridge_id": bridge.bridge_id,
+            "thread_ts": bridge.thread_ts,
+            "deduplicated": False,
+        }
+
     def _history(self, request: BridgeRequest, config: Config) -> dict[str, Any]:
         limit = max(1, min(int(request.get("limit", 15)), 100))
         channel = str(request.get("channel_id") or effective_channel(config))
@@ -746,6 +781,9 @@ class Broker:
         if operation == "notify":
             with self._notify_lock:
                 return self._notify(request, config, allowed_users)
+        if operation == "attach":
+            with self._notify_lock:
+                return self._attach(request, config, allowed_users)
         if operation == "reply":
             return self._reply(request)
         if operation == "history":

--- a/tether/runtime/bridge_runtime.py
+++ b/tether/runtime/bridge_runtime.py
@@ -34,6 +34,7 @@ CONFIG_PATH = Path(os.environ.get("TETHER_CONFIG", CONFIG_HOME / "tether" / "con
 DB_PATH = HERMES_HOME / "bridges.db"
 SOCKET_PATH = HERMES_HOME / "bridge.sock"
 ID_PATTERN = re.compile(r"^[A-Z][A-Z0-9]{7,}$")
+CHANNEL_ID_PATTERN = re.compile(r"^[CDG][A-Z0-9]{7,}$")
 SECRET_PATTERNS = (
     (re.compile(r"\bxox[baprs]-[A-Za-z0-9-]{10,}\b"), "[REDACTED_SLACK_TOKEN]"),
     (re.compile(r"\bxap[p]-[A-Za-z0-9-]{10,}\b"), "[REDACTED_SLACK_APP_TOKEN]"),
@@ -131,7 +132,7 @@ def load_config(path: Path = CONFIG_PATH) -> Config:
     default_channel = str(raw.get("default_channel") or "")
     default_owner = str(raw.get("default_owner") or "")
     team_id = str(raw.get("team_id") or "")
-    if default_channel and not ID_PATTERN.fullmatch(default_channel):
+    if default_channel and not CHANNEL_ID_PATTERN.fullmatch(default_channel):
         raise ValueError("default_channel is not a valid Slack channel ID")
     if default_owner and default_owner != "*" and not ID_PATTERN.fullmatch(default_owner):
         raise ValueError("default_owner is not a valid Slack member ID")
@@ -218,6 +219,12 @@ class Store:
                   event_id TEXT PRIMARY KEY, bridge_id TEXT NOT NULL,
                   created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
                 );
+                CREATE TABLE IF NOT EXISTS thread_participation (
+                  team_id TEXT NOT NULL DEFAULT '', channel_id TEXT NOT NULL,
+                  thread_ts TEXT NOT NULL,
+                  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                  PRIMARY KEY (team_id, channel_id, thread_ts)
+                );
                 """
             )
             columns = {row[1] for row in db.execute("PRAGMA table_info(bridge_events)")}
@@ -272,7 +279,7 @@ class Store:
         channel = str(request["channel_id"])
         owner = str(request["owner_user_id"])
         team = str(request.get("team_id") or "")
-        if not ID_PATTERN.fullmatch(channel) or (owner != "*" and not ID_PATTERN.fullmatch(owner)):
+        if not CHANNEL_ID_PATTERN.fullmatch(channel) or (owner != "*" and not ID_PATTERN.fullmatch(owner)):
             raise ValueError("invalid Slack channel or owner ID")
         if team and not ID_PATTERN.fullmatch(team):
             raise ValueError("invalid Slack workspace ID")
@@ -312,6 +319,35 @@ class Store:
                     (channel_id, thread_ts),
                 ).fetchone()
             return self.decode(row)
+
+    def mark_participation(self, team_id: str, channel_id: str, thread_ts: str) -> None:
+        if not channel_id or not thread_ts:
+            raise ValueError("channel and thread timestamp are required")
+        with self.connect() as db:
+            db.execute(
+                """
+                INSERT INTO thread_participation(team_id,channel_id,thread_ts)
+                VALUES(?,?,?)
+                ON CONFLICT(team_id,channel_id,thread_ts)
+                DO UPDATE SET updated_at=CURRENT_TIMESTAMP
+                """,
+                (team_id, channel_id, thread_ts),
+            )
+
+    def participates(self, team_id: str, channel_id: str, thread_ts: str) -> bool:
+        if not channel_id or not thread_ts:
+            return False
+        with self.connect() as db:
+            row = db.execute(
+                "SELECT 1 FROM thread_participation WHERE team_id=? AND channel_id=? AND thread_ts=?",
+                (team_id, channel_id, thread_ts),
+            ).fetchone()
+            if row is None and team_id:
+                row = db.execute(
+                    "SELECT 1 FROM thread_participation WHERE team_id='' AND channel_id=? AND thread_ts=?",
+                    (channel_id, thread_ts),
+                ).fetchone()
+            return row is not None
 
     def recent_active_bridges(self, hours: int = 24, limit: int = 100) -> list[Bridge]:
         hours = max(1, min(hours, 168))
@@ -569,6 +605,8 @@ class Broker:
             )
         else:
             timestamp = slack_post(self.token, bridge.channel_id, root_text, requested_thread)
+        if requested_thread:
+            self.store.mark_participation(bridge.team_id, bridge.channel_id, str(requested_thread))
         bridge = self.store.bind(bridge.bridge_id, str(requested_thread or timestamp))
         return {
             "ok": True,
@@ -583,6 +621,7 @@ class Broker:
             raise ValueError("active bridge not found")
         self._ensure_channel_membership(bridge.channel_id)
         timestamp = slack_post(self.token, bridge.channel_id, str(request.get("text") or ""), bridge.thread_ts)
+        self.store.mark_participation(bridge.team_id, bridge.channel_id, bridge.thread_ts)
         return {
             "ok": True,
             "bridge_id": bridge.bridge_id,
@@ -627,7 +666,7 @@ class Broker:
         ]
         return {"ok": True, "messages": messages}
 
-    def _thread_reply(self, request: BridgeRequest) -> dict[str, Any]:
+    def _thread_reply(self, request: BridgeRequest, config: Config) -> dict[str, Any]:
         channel = str(request.get("channel_id") or "")
         thread_ts = str(request.get("thread_ts") or "")
         text = str(request.get("text") or "")
@@ -637,6 +676,9 @@ class Broker:
             raise ValueError("thread reply text is empty or too large")
         self._ensure_channel_membership(channel)
         message_ts = slack_post(self.token, channel, text, thread_ts)
+        self.store.mark_participation(
+            str(request.get("team_id") or config.team_id), channel, thread_ts,
+        )
         return {"ok": True, "thread_ts": thread_ts, "message_ts": message_ts}
 
     def handle(self, request: BridgeRequest) -> dict[str, Any]:
@@ -657,7 +699,7 @@ class Broker:
         if operation == "thread_history":
             return self._thread_history(request, config)
         if operation == "thread_reply":
-            return self._thread_reply(request)
+            return self._thread_reply(request, config)
         raise ValueError("unsupported operation")
 
 

--- a/tether/runtime/bridge_runtime.py
+++ b/tether/runtime/bridge_runtime.py
@@ -76,6 +76,7 @@ SLACK_METHOD_PATHS = {
     "auth.test": "/api/auth.test",
     "chat.postMessage": "/api/chat.postMessage",
     "conversations.history": "/api/conversations.history",
+    "conversations.info": "/api/conversations.info",
     "conversations.join": "/api/conversations.join",
     "conversations.open": "/api/conversations.open",
     "conversations.replies": "/api/conversations.replies",

--- a/tether/runtime/bridge_runtime.py
+++ b/tether/runtime/bridge_runtime.py
@@ -76,7 +76,6 @@ SLACK_METHOD_PATHS = {
     "auth.test": "/api/auth.test",
     "chat.postMessage": "/api/chat.postMessage",
     "conversations.history": "/api/conversations.history",
-    "conversations.info": "/api/conversations.info",
     "conversations.join": "/api/conversations.join",
     "conversations.open": "/api/conversations.open",
     "conversations.replies": "/api/conversations.replies",
@@ -614,21 +613,18 @@ class Broker:
         if not channel.startswith("C") or channel in self._joined_channels:
             return
         try:
-            info = _slack_call(self.token, "conversations.info", {"channel": channel})
-            conversation = info.get("channel") if isinstance(info, dict) else None
-            if isinstance(conversation, dict) and any(
-                conversation.get(flag)
-                for flag in ("is_im", "is_mpim", "is_private", "is_member")
-            ):
-                self._joined_channels.add(channel)
-                return
-            _slack_call(self.token, "conversations.join", {"channel": channel})
+            _slack_call(self.token, "conversations.history", {"channel": channel, "limit": 1})
         except RuntimeError as exc:
-            raise RuntimeError(
-                "Tether could not join the public Slack destination. Grant the bot "
-                "channels:join or invite it to the channel before creating a resumable thread "
-                f"({exc})"
-            ) from exc
+            if "not_in_channel" not in str(exc):
+                raise
+            try:
+                _slack_call(self.token, "conversations.join", {"channel": channel})
+            except RuntimeError as join_exc:
+                raise RuntimeError(
+                    "Tether could not join the public Slack destination. Grant the bot "
+                    "channels:join or invite it to the channel before creating a resumable thread "
+                    f"({join_exc})"
+                ) from join_exc
         self._joined_channels.add(channel)
 
     def _status(self, config: Config, allowed_users: tuple[str, ...]) -> dict[str, Any]:

--- a/tether/runtime/bridge_runtime.py
+++ b/tether/runtime/bridge_runtime.py
@@ -614,9 +614,7 @@ class Broker:
         if not channel.startswith("C") or channel in self._joined_channels:
             return
         try:
-            info = _slack_call(
-                self.token, "conversations.info", {"channel": channel, "include_num_members": False},
-            )
+            info = _slack_call(self.token, "conversations.info", {"channel": channel})
             conversation = info.get("channel") if isinstance(info, dict) else None
             if isinstance(conversation, dict) and any(
                 conversation.get(flag)

--- a/tether/runtime/bridge_runtime.py
+++ b/tether/runtime/bridge_runtime.py
@@ -77,6 +77,7 @@ SLACK_METHOD_PATHS = {
     "chat.postMessage": "/api/chat.postMessage",
     "conversations.history": "/api/conversations.history",
     "conversations.join": "/api/conversations.join",
+    "conversations.open": "/api/conversations.open",
     "conversations.replies": "/api/conversations.replies",
 }
 class BridgeRequest(TypedDict, total=False):
@@ -92,6 +93,7 @@ class BridgeRequest(TypedDict, total=False):
     bridge_id: str
     file_path: str | None
     limit: int
+    user_ids: list[str]
 
 
 @dataclass(frozen=True)
@@ -645,6 +647,35 @@ class Broker:
             "user": str(result.get("user") or ""),
         }
 
+    def _dm_notify(
+        self,
+        incoming: BridgeRequest,
+        config: Config,
+        allowed_users: tuple[str, ...],
+    ) -> dict[str, Any]:
+        requested = incoming.get("user_ids")
+        if not isinstance(requested, list):
+            raise ValueError("DM recipients must be a Slack member ID list")
+        users = list(dict.fromkeys(str(value) for value in requested))
+        if not 1 <= len(users) <= 8 or any(not ID_PATTERN.fullmatch(value) for value in users):
+            raise ValueError("DM recipients must contain 1-8 valid Slack member IDs")
+        unauthorized = sorted(set(users) - set(allowed_users))
+        if unauthorized:
+            raise ValueError("DM recipients must all be explicitly allowlisted Hermes operators")
+        opened = _slack_call(
+            self.token,
+            "conversations.open",
+            {"users": ",".join(users), "return_im": True},
+        )
+        channel = opened.get("channel")
+        if not isinstance(channel, dict) or not ID_PATTERN.fullmatch(str(channel.get("id") or "")):
+            raise RuntimeError("Slack opened a DM without returning a valid channel")
+        request = BridgeRequest(incoming)
+        request["channel_id"] = str(channel["id"])
+        if not request.get("team_id"):
+            request["team_id"] = str(self._identity().get("team_id") or config.team_id)
+        return self._notify(request, config, allowed_users)
+
     def _notify(
         self,
         incoming: BridgeRequest,
@@ -826,6 +857,9 @@ class Broker:
         if operation == "notify":
             with self._notify_lock:
                 return self._notify(request, config, allowed_users)
+        if operation == "dm_notify":
+            with self._notify_lock:
+                return self._dm_notify(request, config, allowed_users)
         if operation == "attach":
             with self._notify_lock:
                 return self._attach(request, config, allowed_users)

--- a/tether/runtime/bridge_runtime.py
+++ b/tether/runtime/bridge_runtime.py
@@ -613,6 +613,16 @@ class Broker:
         if not channel.startswith("C") or channel in self._joined_channels:
             return
         try:
+            info = _slack_call(
+                self.token, "conversations.info", {"channel": channel, "include_num_members": False},
+            )
+            conversation = info.get("channel") if isinstance(info, dict) else None
+            if isinstance(conversation, dict) and any(
+                conversation.get(flag)
+                for flag in ("is_im", "is_mpim", "is_private", "is_member")
+            ):
+                self._joined_channels.add(channel)
+                return
             _slack_call(self.token, "conversations.join", {"channel": channel})
         except RuntimeError as exc:
             raise RuntimeError(
@@ -672,6 +682,7 @@ class Broker:
             raise RuntimeError("Slack opened a DM without returning a valid channel")
         request = BridgeRequest(incoming)
         request["channel_id"] = str(channel["id"])
+        self._joined_channels.add(request["channel_id"])
         request["_skip_channel_join"] = True
         if not request.get("team_id"):
             request["team_id"] = str(self._identity().get("team_id") or config.team_id)

--- a/tether/runtime/bridge_runtime.py
+++ b/tether/runtime/bridge_runtime.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import contextlib
+import datetime
 import hashlib
 import json
 import http.client
@@ -225,6 +226,12 @@ class Store:
                   updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
                   PRIMARY KEY (team_id, channel_id, thread_ts)
                 );
+                CREATE TABLE IF NOT EXISTS thread_ingress (
+                  event_id TEXT PRIMARY KEY,
+                  team_id TEXT NOT NULL DEFAULT '', channel_id TEXT NOT NULL,
+                  thread_ts TEXT NOT NULL,
+                  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+                );
                 """
             )
             columns = {row[1] for row in db.execute("PRAGMA table_info(bridge_events)")}
@@ -349,6 +356,52 @@ class Store:
                 ).fetchone()
             return row is not None
 
+    def recent_participating_threads(
+        self, hours: int = 168, limit: int = 500,
+    ) -> list[tuple[str, str, str, float]]:
+        hours = max(1, min(hours, 24 * 90))
+        limit = max(1, min(limit, 2_000))
+        with self.connect() as db:
+            rows = db.execute(
+                """
+                SELECT team_id,channel_id,thread_ts,updated_at FROM thread_participation
+                WHERE updated_at >= datetime('now', ?)
+                ORDER BY updated_at DESC LIMIT ?
+                """,
+                (f"-{hours} hours", limit),
+            ).fetchall()
+            return [
+                (
+                    row[0], row[1], row[2],
+                    datetime.datetime.fromisoformat(row[3]).replace(
+                        tzinfo=datetime.timezone.utc,
+                    ).timestamp(),
+                )
+                for row in rows
+            ]
+
+    def mark_thread_ingress(
+        self, event_id: str, team_id: str, channel_id: str, thread_ts: str,
+    ) -> bool:
+        if not event_id:
+            return False
+        with self.connect() as db:
+            try:
+                db.execute(
+                    "INSERT INTO thread_ingress(event_id,team_id,channel_id,thread_ts) VALUES(?,?,?,?)",
+                    (event_id, team_id, channel_id, thread_ts),
+                )
+                db.execute(
+                    """
+                    UPDATE thread_participation SET updated_at=CURRENT_TIMESTAMP
+                    WHERE team_id=? AND channel_id=? AND thread_ts=?
+                    """,
+                    (team_id, channel_id, thread_ts),
+                )
+                return True
+            except sqlite3.IntegrityError:
+                return False
+
     def recent_active_bridges(self, hours: int = 24, limit: int = 100) -> list[Bridge]:
         hours = max(1, min(hours, 168))
         limit = max(1, min(limit, 500))
@@ -384,6 +437,7 @@ class Store:
             return bool(
                 db.execute("SELECT 1 FROM bridge_ingress WHERE event_id=?", (event_id,)).fetchone()
                 or db.execute("SELECT 1 FROM bridge_events WHERE event_id=?", (event_id,)).fetchone()
+                or db.execute("SELECT 1 FROM thread_ingress WHERE event_id=?", (event_id,)).fetchone()
             )
 
     def claim_event(self, event_id: str, bridge_id: str) -> bool:

--- a/tether/runtime/bridge_runtime.py
+++ b/tether/runtime/bridge_runtime.py
@@ -31,6 +31,7 @@ HERMES_HOME = Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes")).expan
 DATA_HOME = Path(os.environ.get("XDG_DATA_HOME", Path.home() / ".local" / "share")).expanduser()
 CONFIG_HOME = Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config")).expanduser()
 RUNTIME_HOME = DATA_HOME / "tether"
+INBOX_HOME = RUNTIME_HOME / "inbox"
 CONFIG_PATH = Path(os.environ.get("TETHER_CONFIG", CONFIG_HOME / "tether" / "config.toml")).expanduser()
 DB_PATH = HERMES_HOME / "bridges.db"
 SOCKET_PATH = HERMES_HOME / "bridge.sock"
@@ -54,6 +55,7 @@ MAX_TEXT = 35_000
 MAX_NATIVE_OUTPUT = 35_000
 MAX_SOURCE_VALUE = 4_096
 MAX_IDEMPOTENCY_KEY = 256
+MAX_VISIBLE_PANE_INPUT = 800
 SOURCE_FIELDS = {
     "zellij_pane": frozenset({
         "session_name", "pane_id", "zellij_session", "zellij_pane_id", "cwd",
@@ -1137,6 +1139,26 @@ def deliver_zellij(bridge: Bridge, text: str) -> None:
         f"[Hermes Slack reply; {marker}] " + text + "\n\nAfter handling this, reply in the same Slack thread with: "
         f"python3 {notifier} reply --bridge-id {bridge.bridge_id} --text '<your response>'"
     )
+    if "\n" in text or len(instruction) > MAX_VISIBLE_PANE_INPUT:
+        INBOX_HOME.mkdir(mode=0o700, parents=True, exist_ok=True)
+        os.chmod(INBOX_HOME, 0o700)
+        payload = INBOX_HOME / f"{marker}.txt"
+        flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        fd = os.open(payload, flags, 0o600)
+        try:
+            with os.fdopen(fd, "w") as stream:
+                stream.write(instruction)
+                stream.flush()
+                os.fsync(stream.fileno())
+        except BaseException:
+            payload.unlink(missing_ok=True)
+            raise
+        instruction = (
+            f"[Hermes Slack reply; {marker}] Read and follow the complete request in {payload}. "
+            "Delete that file after reading it, then reply to the same Slack thread as instructed there."
+        )
     target = pane if pane.startswith(("terminal_", "plugin_")) else "terminal_" + pane
     zellij = _resolve_executable("zellij")
     # Absolute executable; session and pane are argv, never shell text.

--- a/tether/runtime/bridge_runtime.py
+++ b/tether/runtime/bridge_runtime.py
@@ -672,6 +672,7 @@ class Broker:
             raise RuntimeError("Slack opened a DM without returning a valid channel")
         request = BridgeRequest(incoming)
         request["channel_id"] = str(channel["id"])
+        request["_skip_channel_join"] = True
         if not request.get("team_id"):
             request["team_id"] = str(self._identity().get("team_id") or config.team_id)
         return self._notify(request, config, allowed_users)
@@ -701,7 +702,8 @@ class Broker:
             }
         root_text = with_origin(text, bridge)
         requested_thread = request.get("thread_ts")
-        self._ensure_channel_membership(bridge.channel_id)
+        if not request.get("_skip_channel_join"):
+            self._ensure_channel_membership(bridge.channel_id)
         if request.get("file_path"):
             timestamp = slack_upload(
                 self.token,

--- a/tether/runtime/plugin/__init__.py
+++ b/tether/runtime/plugin/__init__.py
@@ -256,7 +256,14 @@ def _install_slack_bridge_prefilter():
                 return None
             marked = _mark_bridge_thread_before_slack_gate(self, event)
             if not marked and event.get("thread_ts"):
-                await _discover_existing_thread_participation(self, event)
+                marked = await _discover_existing_thread_participation(self, event)
+            if marked and bridge is None and not event.get("_tether_polled"):
+                event_id = str(event.get("ts") or "")
+                thread_ts = str(event.get("thread_ts") or "")
+                if event_id and not store.mark_thread_ingress(
+                    event_id, team_id, channel_id, thread_ts,
+                ):
+                    return None
             if bridge is not None:
                 event_id = str(event.get("ts") or "")
                 if (
@@ -328,31 +335,45 @@ async def _poll_recent_replies(adapter) -> int:
     hours = _bounded_env_int("TETHER_REPLY_RECOVERY_HOURS", 24, 1, 168)
     batch_size = _bounded_env_int("TETHER_REPLY_POLL_BATCH", 10, 1, 25)
     bridges = store.recent_active_bridges(hours=hours, limit=100)
-    if not bridges:
+    bridge_keys = {(bridge.team_id, bridge.channel_id, bridge.thread_ts) for bridge in bridges}
+    participating = [
+        item for item in store.recent_participating_threads(hours=max(hours, 168), limit=500)
+        if item[:3] not in bridge_keys
+    ]
+    targets = [
+        (bridge, bridge.team_id, bridge.channel_id, str(bridge.thread_ts), None)
+        for bridge in bridges
+    ] + [(None, *item) for item in participating]
+    if not targets:
         return 0
-    start = state.poll_cursor % len(bridges)
-    batch = (bridges + bridges)[start:start + min(batch_size, len(bridges))]
-    state.poll_cursor = (start + len(batch)) % len(bridges)
+    start = state.poll_cursor % len(targets)
+    batch = (targets + targets)[start:start + min(batch_size, len(targets))]
+    state.poll_cursor = (start + len(batch)) % len(targets)
     oldest = f"{time.time() - hours * 3600:.6f}"
     recovered = 0
     succeeded = 0
-    for bridge in batch:
+    allowed_users = set(effective_allowed_users())
+    for bridge, team_id, channel_id, thread_ts, participation_since in batch:
         try:
-            client = adapter._get_client(bridge.channel_id)
-            channel_key = (bridge.team_id, bridge.channel_id)
-            if bridge.channel_id.startswith("C") and channel_key not in state.joined_channels:
-                await client.conversations_join(channel=bridge.channel_id)
+            client = adapter._get_client(channel_id)
+            channel_key = (team_id, channel_id)
+            if channel_id.startswith("C") and channel_key not in state.joined_channels:
+                await client.conversations_join(channel=channel_id)
                 state.joined_channels.add(channel_key)
             result = await client.conversations_replies(
-                channel=bridge.channel_id,
-                ts=bridge.thread_ts,
-                oldest=oldest,
+                channel=channel_id,
+                ts=thread_ts,
+                oldest=(
+                    f"{max(float(oldest), participation_since):.6f}"
+                    if participation_since is not None else oldest
+                ),
                 inclusive=False,
                 limit=100,
             )
             succeeded += 1
         except Exception as exc:
-            log.warning("Could not poll Tether thread %s: %s", bridge.bridge_id, type(exc).__name__)
+            target = bridge.bridge_id if bridge is not None else f"{channel_id}:{thread_ts}"
+            log.warning("Could not poll Tether thread %s: %s", target, type(exc).__name__)
             continue
         for message in result.get("messages", []):
             if not isinstance(message, dict):
@@ -360,26 +381,38 @@ async def _poll_recent_replies(adapter) -> int:
             event_id = str(message.get("ts") or "")
             user_id = str(message.get("user") or "")
             text = str(message.get("text") or "")
-            bot_allowed = _allows_bot_message(adapter, message, bridge.team_id)
+            bot_allowed = _allows_bot_message(adapter, message, team_id)
             if (
                 not event_id
-                or event_id == bridge.thread_ts
+                or event_id == thread_ts
                 or not text.strip()
                 or (_is_bot_message(message) and not bot_allowed)
-                or (not _is_bot_message(message) and not _authorized(bridge, user_id))
+                or (
+                    not _is_bot_message(message)
+                    and (
+                        user_id not in allowed_users
+                        or (bridge is not None and not _authorized(bridge, user_id))
+                    )
+                )
                 or store.has_ingress(event_id)
             ):
                 continue
+            if bridge is not None:
+                claimed = store.mark_ingress(event_id, bridge.bridge_id)
+            else:
+                claimed = store.mark_thread_ingress(
+                    event_id, team_id, channel_id, thread_ts,
+                )
+            if not claimed:
+                continue
             event = dict(message)
             event.update({
-                "channel": bridge.channel_id,
-                "team": bridge.team_id,
-                "thread_ts": bridge.thread_ts,
-                "channel_type": "im" if bridge.channel_id.startswith("D") else "channel",
+                "channel": channel_id,
+                "team": team_id,
+                "thread_ts": thread_ts,
+                "channel_type": "im" if channel_id.startswith("D") else "channel",
                 "_tether_polled": True,
             })
-            if _is_bot_message(message) and not store.mark_ingress(event_id, bridge.bridge_id):
-                continue
             await adapter._handle_slack_message(event)
             recovered += 1
     if batch and not succeeded:

--- a/tether/runtime/plugin/__init__.py
+++ b/tether/runtime/plugin/__init__.py
@@ -108,10 +108,56 @@ def _bridge_for_slack_event(adapter, event):
 
 def _mark_bridge_thread_before_slack_gate(adapter, event) -> bool:
     bridge = _bridge_for_slack_event(adapter, event)
-    if bridge is None:
+    thread_ts = str(event.get("thread_ts") or "")
+    channel_id = str(event.get("channel") or event.get("channel_id") or "")
+    team_id = str(
+        event.get("team") or event.get("team_id")
+        or getattr(adapter, "_channel_team", {}).get(channel_id, "") or ""
+    )
+    if bridge is None and not store.participates(team_id, channel_id, thread_ts):
         return False
-    adapter._bot_message_ts.add(bridge.thread_ts)
+    adapter._bot_message_ts.add(thread_ts)
     return True
+
+
+async def _discover_existing_thread_participation(adapter, event) -> bool:
+    """Recover participation for threads created before persistence existed."""
+    thread_ts = str(event.get("thread_ts") or "")
+    channel_id = str(event.get("channel") or event.get("channel_id") or "")
+    if not thread_ts or not channel_id:
+        return False
+    team_id = str(
+        event.get("team") or event.get("team_id")
+        or getattr(adapter, "_channel_team", {}).get(channel_id, "") or ""
+    )
+    key = (team_id, channel_id, thread_ts)
+    misses = getattr(adapter, "_tether_participation_misses", None)
+    if misses is None:
+        misses = adapter._tether_participation_misses = set()
+    if key in misses:
+        return False
+    bot_user_id = (
+        getattr(adapter, "_team_bot_user_ids", {}).get(team_id)
+        or getattr(adapter, "_bot_user_id", None)
+    )
+    if not bot_user_id:
+        return False
+    try:
+        result = await adapter._get_client(channel_id).conversations_replies(
+            channel=channel_id, ts=thread_ts, limit=200,
+        )
+    except Exception:
+        return False
+    participated = any(
+        isinstance(message, dict) and str(message.get("user") or "") == str(bot_user_id)
+        for message in result.get("messages", [])
+    )
+    if participated:
+        store.mark_participation(team_id, channel_id, thread_ts)
+        adapter._bot_message_ts.add(thread_ts)
+        return True
+    misses.add(key)
+    return False
 
 
 def _is_bot_message(event: dict[str, Any]) -> bool:
@@ -201,10 +247,17 @@ def _install_slack_bridge_prefilter():
         _ensure_reply_poller(self)
         try:
             bridge = _bridge_for_slack_event(self, event)
+            channel_id = str(event.get("channel") or event.get("channel_id") or "")
+            team_id = str(
+                event.get("team") or event.get("team_id")
+                or getattr(self, "_channel_team", {}).get(channel_id, "") or ""
+            )
+            if _is_bot_message(event) and not _allows_bot_message(self, event, team_id):
+                return None
+            marked = _mark_bridge_thread_before_slack_gate(self, event)
+            if not marked and event.get("thread_ts"):
+                await _discover_existing_thread_participation(self, event)
             if bridge is not None:
-                if _is_bot_message(event) and not _allows_bot_message(self, event, bridge.team_id):
-                    return None
-                self._bot_message_ts.add(bridge.thread_ts)
                 event_id = str(event.get("ts") or "")
                 if (
                     not event.get("_tether_polled")
@@ -237,7 +290,24 @@ def _install_slack_bridge_prefilter():
             if _is_silence_control_output(content):
                 log.info("Tether suppressed an internal silence control token at Slack egress")
                 return {"ok": True, "suppressed": True}
-            return await original_send(self, *args, **kwargs)
+            result = await original_send(self, *args, **kwargs)
+            succeeded = (
+                bool(result.get("ok", result.get("success", True)))
+                if isinstance(result, dict)
+                else bool(getattr(result, "success", True))
+            )
+            if not succeeded:
+                return result
+            channel_id = str(kwargs.get("chat_id") or kwargs.get("channel") or (args[0] if args else ""))
+            metadata = kwargs.get("metadata") or (args[3] if len(args) >= 4 else {}) or {}
+            reply_to = kwargs.get("reply_to") or (args[2] if len(args) >= 3 else "")
+            thread_ts = str(
+                metadata.get("thread_id") or metadata.get("thread_ts") or reply_to or ""
+            )
+            if channel_id and thread_ts:
+                team_id = str(getattr(self, "_channel_team", {}).get(channel_id, "") or "")
+                store.mark_participation(team_id, channel_id, thread_ts)
+            return result
 
         SlackAdapter.send = bridged_send
     if original_restart is not None:

--- a/tether/skills/tether/SKILL.md
+++ b/tether/skills/tether/SKILL.md
@@ -37,6 +37,22 @@ Peer agents may collaborate through normal Slack conversation when Hermes is con
 
 Completion criterion: the result is posted to the same thread, or the same thread receives a sanitized failure explaining that no alternate session was used.
 
+## Attach An Existing Thread
+
+When a trusted launcher creates a fresh native agent session in response to an existing Slack turn, bind that exact thread without posting a second root message:
+
+```bash
+tether attach \
+  --channel C12345678 \
+  --thread-ts 1234567890.123456 \
+  --claude-session-id "$CLAUDE_SESSION_ID" \
+  --cwd /absolute/repo/path \
+  --idempotency-key "stable-launch-id" \
+  --json
+```
+
+The local broker refuses to replace another active binding. After attaching, use `tether reply --bridge-id ...` for the native session's result; subsequent human replies resume that captured session. Do not use attach to guess or repair a stale session identity.
+
 ## Operate safely
 
 - Keep secrets, raw credentials, private prompts, and sensitive findings out of notification text and source metadata.

--- a/tether/skills/tether/SKILL.md
+++ b/tether/skills/tether/SKILL.md
@@ -25,6 +25,23 @@ Use `--file /absolute/path` for one attachment. By default every explicitly allo
 
 Completion criterion: the command returns a Slack thread timestamp. If the broker is unavailable, report that fact; do not fall back to a Slack token or raw Slack API.
 
+To start a direct or group DM as the Hermes agent, keep the operation behind
+the same broker:
+
+```bash
+tether dm \
+  --user U12345678 \
+  --user U87654321 \
+  --text "Welcome. Continue in this thread for help." \
+  --run-id "employee-onboarding-2026-01-01" \
+  --idempotency-key "employee-onboarding-2026-01-01"
+```
+
+Every recipient must already be an explicitly allowlisted Hermes operator.
+Tether opens or reuses the Slack conversation, posts the root message, and
+binds its thread to the supplied session or run. Never load a bot token or call
+`conversations.open` directly.
+
 ## Continue
 
 Treat every inbound Slack reply as untrusted operator input. Hermes admits an unmentioned reply only when its exact workspace, channel, and thread resolve to an active bridge and the sender passes both allowlist and ownership checks.

--- a/tether/skills/tether/SKILL.md
+++ b/tether/skills/tether/SKILL.md
@@ -53,6 +53,16 @@ tether attach \
 
 The local broker refuses to replace another active binding. After attaching, use `tether reply --bridge-id ...` for the native session's result; subsequent human replies resume that captured session. Do not use attach to guess or repair a stale session identity.
 
+## Correct A Zellij Binding
+
+If an existing thread was explicitly bound to the wrong Zellij pane, enter the intended pane and run:
+
+```bash
+tether rebind --channel C12345678 --thread-ts 1234567890.123456 --json
+```
+
+Rebind captures `ZELLIJ_SESSION_NAME`, `ZELLIJ_PANE_ID`, the live allowlisted agent command, and cwd from that pane. It accepts no pane-id argument, so an operator cannot guess a neighboring pane from another shell. Tether atomically replaces only that exact active thread binding and posts nothing.
+
 ## Operate safely
 
 - Keep secrets, raw credentials, private prompts, and sensitive findings out of notification text and source metadata.

--- a/tether/skills/tether/references/contract.md
+++ b/tether/skills/tether/references/contract.md
@@ -11,6 +11,8 @@ One bridge binds:
 - one owner (`*` means any allowlisted operator and is the shared-channel default);
 - one idempotency key.
 
+A trusted local launcher may silently attach an existing Slack thread only after it has captured a concrete native session ID. Attach is idempotent and refuses to replace an active binding; it is not a semantic router or stale-session fallback.
+
 An explicit run ID always creates `headless_run`, even inside Codex or Claude Code. Native sessions remain the source when those agents run inside Zellij, but the captured and fingerprinted live pane is their delivery endpoint.
 
 ## Inbound routing

--- a/tether/skills/tether/references/contract.md
+++ b/tether/skills/tether/references/contract.md
@@ -13,6 +13,8 @@ One bridge binds:
 
 A trusted local launcher may silently attach an existing Slack thread only after it has captured a concrete native session ID. Attach is idempotent and refuses to replace an active binding; it is not a semantic router or stale-session fallback.
 
+A wrong Zellij binding may be replaced only by `tether rebind` running inside the intended live pane. The CLI does not accept a caller-supplied pane ID, and rebind posts nothing.
+
 An explicit run ID always creates `headless_run`, even inside Codex or Claude Code. Native sessions remain the source when those agents run inside Zellij, but the captured and fingerprinted live pane is their delivery endpoint.
 
 ## Inbound routing

--- a/tether/skills/tether/references/contract.md
+++ b/tether/skills/tether/references/contract.md
@@ -11,6 +11,12 @@ One bridge binds:
 - one owner (`*` means any allowlisted operator and is the shared-channel default);
 - one idempotency key.
 
+Direct and group DMs use the same contract. The broker may open a conversation
+only when every requested recipient is already in the effective Hermes
+allowlist. Opening the conversation and posting its root message occur inside
+the credential-owning broker; local publishers receive only the channel/thread
+result.
+
 A trusted local launcher may silently attach an existing Slack thread only after it has captured a concrete native session ID. Attach is idempotent and refuses to replace an active binding; it is not a semantic router or stale-session fallback.
 
 A wrong Zellij binding may be replaced only by `tether rebind` running inside the intended live pane. The CLI does not accept a caller-supplied pane ID, and rebind posts nothing.

--- a/tether/skills/tether/scripts/tether_notify.py
+++ b/tether/skills/tether/scripts/tether_notify.py
@@ -77,6 +77,14 @@ def attached_source(args: argparse.Namespace) -> tuple[str, dict[str, str]]:
     return detected_source(args)
 
 
+def ambient_zellij_source() -> tuple[str, dict[str, str]]:
+    session = os.getenv("ZELLIJ_SESSION_NAME", "")
+    pane = os.getenv("ZELLIJ_PANE_ID", "")
+    if not session or not pane:
+        raise SystemExit("rebind must run inside the intended live Zellij pane")
+    return "zellij_pane", zellij_pane_identity(session, pane, str(Path.cwd()))
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Send or answer a resumable Hermes Slack thread")
     sub = parser.add_subparsers(dest="command", required=True)
@@ -103,6 +111,11 @@ def build_parser() -> argparse.ArgumentParser:
     attach.add_argument("--hermes-session-id")
     attach.add_argument("--cwd")
     attach.add_argument("--json", action="store_true")
+    rebind = sub.add_parser("rebind")
+    rebind.add_argument("--channel", required=True)
+    rebind.add_argument("--thread-ts", required=True)
+    rebind.add_argument("--team")
+    rebind.add_argument("--json", action="store_true")
     post = sub.add_parser("post")
     post.add_argument("--channel", required=True)
     post.add_argument("--thread-ts", required=True)
@@ -243,6 +256,16 @@ def main(argv: Sequence[str] | None = None) -> int:
             "owner_user_id": args.owner or "", "channel_id": args.channel,
             "team_id": args.team or "", "thread_ts": args.thread_ts,
             "idempotency_key": args.idempotency_key,
+        })
+        if args.json:
+            print(json.dumps(result, ensure_ascii=False))
+            return 0
+    elif args.command == "rebind":
+        kind, source = ambient_zellij_source()
+        result = broker_call({
+            "op": "rebind", "source_kind": kind, "source": source,
+            "channel_id": args.channel, "team_id": args.team or "",
+            "thread_ts": args.thread_ts,
         })
         if args.json:
             print(json.dumps(result, ensure_ascii=False))

--- a/tether/skills/tether/scripts/tether_notify.py
+++ b/tether/skills/tether/scripts/tether_notify.py
@@ -97,6 +97,15 @@ def build_parser() -> argparse.ArgumentParser:
     notify.add_argument("--run-id")
     notify.add_argument("--hermes-session-id")
     notify.add_argument("--file")
+    dm = sub.add_parser("dm")
+    dm.add_argument("--user", action="append", required=True, dest="users")
+    dm.add_argument("--text", required=True)
+    dm.add_argument("--owner")
+    dm.add_argument("--team")
+    dm.add_argument("--idempotency-key", default="")
+    dm.add_argument("--run-id")
+    dm.add_argument("--hermes-session-id")
+    dm.add_argument("--file")
     reply = sub.add_parser("reply")
     reply.add_argument("--bridge-id", required=True)
     reply.add_argument("--text", required=True)
@@ -249,6 +258,14 @@ def main(argv: Sequence[str] | None = None) -> int:
         return run_setup(args)
     if args.command == "reply":
         result = broker_call({"op": "reply", "bridge_id": args.bridge_id, "text": args.text})
+    elif args.command == "dm":
+        kind, source = detected_source(args)
+        result = broker_call({
+            "op": "dm_notify", "text": args.text, "source_kind": kind, "source": source,
+            "owner_user_id": args.owner or "", "team_id": args.team or "",
+            "idempotency_key": args.idempotency_key or str(uuid.uuid4()),
+            "file_path": args.file, "user_ids": args.users,
+        })
     elif args.command == "attach":
         kind, source = attached_source(args)
         result = broker_call({

--- a/tether/skills/tether/scripts/tether_notify.py
+++ b/tether/skills/tether/scripts/tether_notify.py
@@ -68,6 +68,15 @@ def detected_source(args: argparse.Namespace) -> tuple[str, dict[str, str]]:
     raise SystemExit("No resumable context found; pass --run-id for a headless run")
 
 
+def attached_source(args: argparse.Namespace) -> tuple[str, dict[str, str]]:
+    if args.claude_session_id:
+        return "claude_session", {
+            "session_id": args.claude_session_id,
+            "cwd": str(Path(args.cwd or Path.cwd()).resolve()),
+        }
+    return detected_source(args)
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Send or answer a resumable Hermes Slack thread")
     sub = parser.add_subparsers(dest="command", required=True)
@@ -83,6 +92,17 @@ def build_parser() -> argparse.ArgumentParser:
     reply = sub.add_parser("reply")
     reply.add_argument("--bridge-id", required=True)
     reply.add_argument("--text", required=True)
+    attach = sub.add_parser("attach")
+    attach.add_argument("--channel", required=True)
+    attach.add_argument("--thread-ts", required=True)
+    attach.add_argument("--owner")
+    attach.add_argument("--team")
+    attach.add_argument("--idempotency-key", required=True)
+    attach.add_argument("--claude-session-id")
+    attach.add_argument("--run-id")
+    attach.add_argument("--hermes-session-id")
+    attach.add_argument("--cwd")
+    attach.add_argument("--json", action="store_true")
     post = sub.add_parser("post")
     post.add_argument("--channel", required=True)
     post.add_argument("--thread-ts", required=True)
@@ -216,6 +236,17 @@ def main(argv: Sequence[str] | None = None) -> int:
         return run_setup(args)
     if args.command == "reply":
         result = broker_call({"op": "reply", "bridge_id": args.bridge_id, "text": args.text})
+    elif args.command == "attach":
+        kind, source = attached_source(args)
+        result = broker_call({
+            "op": "attach", "source_kind": kind, "source": source,
+            "owner_user_id": args.owner or "", "channel_id": args.channel,
+            "team_id": args.team or "", "thread_ts": args.thread_ts,
+            "idempotency_key": args.idempotency_key,
+        })
+        if args.json:
+            print(json.dumps(result, ensure_ascii=False))
+            return 0
     elif args.command == "post":
         result = broker_call({
             "op": "thread_reply", "channel_id": args.channel,

--- a/tether/tests/test_bridge.py
+++ b/tether/tests/test_bridge.py
@@ -246,7 +246,7 @@ class StoreTest(unittest.TestCase):
             {"SLACK_ALLOWED_USERS": "U12345678,U87654321"},
             clear=False,
         ), mock.patch.object(self.runtime, "_slack_call", side_effect=[
-            {"ok": True, "channel": {"id": "G12345678"}},
+            {"ok": True, "channel": {"id": "C12345678"}},
             {"ok": True, "team_id": "T12345678", "user_id": "U11111111", "user": "agent"},
         ]) as call, mock.patch.object(
             self.runtime, "slack_post", return_value="123.456",
@@ -257,9 +257,10 @@ class StoreTest(unittest.TestCase):
             "conversations.open",
             {"users": "U12345678,U87654321", "return_im": True},
         ))
+        self.assertEqual(len(call.call_args_list), 2)
         post.assert_called_once()
         bridge = self.store.get(result["bridge_id"])
-        self.assertEqual(bridge.channel_id, "G12345678")
+        self.assertEqual(bridge.channel_id, "C12345678")
         self.assertEqual(bridge.team_id, "T12345678")
         self.assertEqual(bridge.owner_user_id, "*")
 

--- a/tether/tests/test_bridge.py
+++ b/tether/tests/test_bridge.py
@@ -546,6 +546,46 @@ class CredentialBoundaryTest(unittest.TestCase):
         self.assertEqual(sum("dump-screen" in command for command in commands), 2)
         self.assertGreaterEqual(identity.call_count, 2)
 
+    def test_multiline_zellij_delivery_uses_private_file_and_visible_carrier(self):
+        bridge = self.runtime.Bridge(
+            "brg_test", "claude_session",
+            {
+                "session_id": "session-1", "zellij_session": "work",
+                "zellij_pane_id": "7", "cwd": "/tmp/project",
+                "pane_agent": "claude", "pane_command_hash": "expected",
+            },
+            "*", "T12345678", "C12345678", "123.456", "key", "active",
+        )
+        text = "investigate this bug\nfirst reproduction step\nsecond reproduction step"
+        marker = "tether-" + self.runtime.hashlib.sha256(
+            f"{bridge.bridge_id}\0{text}".encode()
+        ).hexdigest()[:12]
+
+        def run(command, **_kwargs):
+            if "dump-screen" in command:
+                return types.SimpleNamespace(stdout=f"prompt contains {marker}", stderr="", returncode=0)
+            return types.SimpleNamespace(stdout="", stderr="", returncode=0)
+
+        with tempfile.TemporaryDirectory() as temporary, mock.patch.object(
+            self.runtime, "INBOX_HOME", pathlib.Path(temporary) / "inbox"
+        ), mock.patch.object(
+            self.runtime, "zellij_pane_identity", return_value={"pane_command_hash": "expected"}
+        ), mock.patch.object(
+            self.runtime.subprocess, "run", side_effect=run
+        ) as invoked, mock.patch.object(self.runtime.time, "sleep"), mock.patch.object(
+            self.runtime, "_resolve_executable", return_value="/usr/bin/zellij"
+        ):
+            self.runtime.deliver_zellij(bridge, text)
+            payload = self.runtime.INBOX_HOME / f"{marker}.txt"
+            self.assertEqual(payload.stat().st_mode & 0o777, 0o600)
+            self.assertIn(text, payload.read_text())
+
+        write = next(call.args[0] for call in invoked.call_args_list if "write-chars" in call.args[0])
+        carrier = write[-1]
+        self.assertIn(marker, carrier)
+        self.assertIn("Read and follow the complete request", carrier)
+        self.assertNotIn("first reproduction step", carrier)
+
 
 class NotifierTest(unittest.TestCase):
     def setUp(self):

--- a/tether/tests/test_bridge.py
+++ b/tether/tests/test_bridge.py
@@ -231,6 +231,56 @@ class StoreTest(unittest.TestCase):
             "ok": True, "team_id": "T12345678", "user_id": "U12345678", "user": "agent",
         })
 
+    def test_group_dm_opens_inside_broker_and_creates_resumable_bridge(self):
+        broker = self.runtime.Broker("test-token", self.store)
+        request = {
+            "op": "dm_notify",
+            "text": "Welcome",
+            "source_kind": "headless_run",
+            "source": {"run_id": "onboarding-1", "cwd": "/tmp/project"},
+            "user_ids": ["U12345678", "U87654321"],
+            "idempotency_key": "onboarding-1",
+        }
+        with mock.patch.dict(
+            os.environ,
+            {"SLACK_ALLOWED_USERS": "U12345678,U87654321"},
+            clear=False,
+        ), mock.patch.object(self.runtime, "_slack_call", side_effect=[
+            {"ok": True, "channel": {"id": "G12345678"}},
+            {"ok": True, "team_id": "T12345678", "user_id": "U11111111", "user": "agent"},
+        ]) as call, mock.patch.object(
+            self.runtime, "slack_post", return_value="123.456",
+        ) as post:
+            result = broker.handle(request)
+        self.assertEqual(call.call_args_list[0], mock.call(
+            "test-token",
+            "conversations.open",
+            {"users": "U12345678,U87654321", "return_im": True},
+        ))
+        post.assert_called_once()
+        bridge = self.store.get(result["bridge_id"])
+        self.assertEqual(bridge.channel_id, "G12345678")
+        self.assertEqual(bridge.team_id, "T12345678")
+        self.assertEqual(bridge.owner_user_id, "*")
+
+    def test_group_dm_rejects_non_allowlisted_recipients_before_slack(self):
+        broker = self.runtime.Broker("test-token", self.store)
+        with mock.patch.dict(
+            os.environ,
+            {"SLACK_ALLOWED_USERS": "U12345678"},
+            clear=False,
+        ), mock.patch.object(self.runtime, "_slack_call") as call:
+            with self.assertRaisesRegex(ValueError, "explicitly allowlisted"):
+                broker.handle({
+                    "op": "dm_notify",
+                    "text": "Welcome",
+                    "source_kind": "headless_run",
+                    "source": {"run_id": "onboarding-2", "cwd": "/tmp/project"},
+                    "user_ids": ["U12345678", "U87654321"],
+                    "idempotency_key": "onboarding-2",
+                })
+        call.assert_not_called()
+
     def test_brokered_thread_post_does_not_create_a_second_bridge(self):
         broker = self.runtime.Broker("test-token", self.store)
         with mock.patch.object(broker, "_ensure_channel_membership"), mock.patch.object(

--- a/tether/tests/test_bridge.py
+++ b/tether/tests/test_bridge.py
@@ -120,6 +120,16 @@ class StoreTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.store.create(request)
 
+    def test_user_id_cannot_be_stored_as_a_channel(self):
+        with self.assertRaisesRegex(ValueError, "invalid Slack channel"):
+            self.store.create({
+                "source_kind": "headless_run",
+                "source": {"run_id": "run-1"},
+                "owner_user_id": "U12345678",
+                "channel_id": "U12345678",
+                "idempotency_key": "bad-user-destination",
+            })
+
     def test_source_metadata_rejects_unknown_or_oversized_values(self):
         request = self.request()
         request["source"]["prompt"] = "should never be persisted"
@@ -233,6 +243,13 @@ class StoreTest(unittest.TestCase):
         post.assert_called_once_with("test-token", "C12345678", "progress", "123.456")
         self.assertEqual(result["thread_ts"], "123.456")
         self.assertEqual(self.store.recent_active_bridges(), [])
+        self.assertTrue(self.store.participates("", "C12345678", "123.456"))
+
+    def test_thread_participation_survives_store_reopen_and_team_lookup(self):
+        self.store.mark_participation("T12345678", "C12345678", "123.456")
+        reopened = self.runtime.Store(self.store.path)
+        self.assertTrue(reopened.participates("T12345678", "C12345678", "123.456"))
+        self.assertFalse(reopened.participates("T99999999", "C12345678", "123.456"))
 
     def test_concurrent_idempotent_notifications_post_one_root_message(self):
         broker = self.runtime.Broker("test-token", self.store)
@@ -635,6 +652,73 @@ class PluginRoutingTest(unittest.TestCase):
         self.assertFalse(self.plugin._mark_bridge_thread_before_slack_gate(adapter, {
             "thread_ts": "999.999", "channel": "C12345678",
         }))
+
+    def test_prefilter_marks_persisted_non_bridge_participation(self):
+        self.plugin.store.mark_participation("T12345678", "C12345678", "123.456")
+        adapter = types.SimpleNamespace(_bot_message_ts=set(), _channel_team={"C12345678": "T12345678"})
+        self.assertTrue(self.plugin._mark_bridge_thread_before_slack_gate(adapter, {
+            "thread_ts": "123.456", "channel": "C12345678",
+        }))
+        self.assertIn("123.456", adapter._bot_message_ts)
+
+    def test_native_send_persists_thread_participation(self):
+        class SlackAdapter:
+            _tether_prefilter = False
+
+            def __init__(self):
+                self._bot_message_ts = set()
+                self._channel_team = {"C12345678": "T12345678"}
+
+            async def connect(self):
+                return True
+
+            async def send(self, channel, content, reply_to=None, metadata=None):
+                return {"ok": True}
+
+            async def _handle_slack_message(self, event):
+                return event
+
+        modules = {
+            "plugins": types.ModuleType("plugins"),
+            "plugins.platforms": types.ModuleType("plugins.platforms"),
+            "plugins.platforms.slack": types.ModuleType("plugins.platforms.slack"),
+            "plugins.platforms.slack.adapter": types.ModuleType("plugins.platforms.slack.adapter"),
+        }
+        modules["plugins.platforms.slack.adapter"].SlackAdapter = SlackAdapter
+        with mock.patch.dict(sys.modules, modules), mock.patch.object(self.plugin, "_ensure_reply_poller"):
+            self.plugin._install_slack_bridge_prefilter()
+            adapter = SlackAdapter()
+            asyncio.run(adapter.send("C12345678", "done", "123.456", None))
+        self.assertTrue(self.plugin.store.participates(
+            "T12345678", "C12345678", "123.456",
+        ))
+
+    def test_existing_bot_thread_is_discovered_once_and_persisted(self):
+        class Client:
+            calls = 0
+
+            async def conversations_replies(self, **kwargs):
+                self.calls += 1
+                return {"messages": [
+                    {"ts": "123.456", "user": "UHUMAN001"},
+                    {"ts": "123.457", "user": "UBOT00001", "bot_id": "BBOT00001"},
+                ]}
+
+        client = Client()
+        adapter = types.SimpleNamespace(
+            _bot_message_ts=set(),
+            _channel_team={"C12345678": "T12345678"},
+            _team_bot_user_ids={"T12345678": "UBOT00001"},
+            _get_client=lambda _channel: client,
+        )
+        event = {"thread_ts": "123.456", "channel": "C12345678"}
+        self.assertTrue(asyncio.run(
+            self.plugin._discover_existing_thread_participation(adapter, event)
+        ))
+        self.assertTrue(self.plugin.store.participates(
+            "T12345678", "C12345678", "123.456",
+        ))
+        self.assertEqual(client.calls, 1)
 
     def test_prefilter_admits_unmentioned_reply_before_hermes_mention_gate(self):
         self.make_bridge()

--- a/tether/tests/test_bridge.py
+++ b/tether/tests/test_bridge.py
@@ -181,7 +181,7 @@ class StoreTest(unittest.TestCase):
         self.assertEqual(bridge.owner_user_id, "*", "Hermes's explicit allowlist is shared by default")
         self.assertEqual(status["allowed_user_count"], 2)
         self.assertEqual(status["implementation"], "tether")
-        self.assertEqual(status["protocol_version"], 3)
+        self.assertEqual(status["protocol_version"], 4)
         self.assertNotIn("allowed_users", status, "status reports readiness, never identities")
 
     def test_thread_history_stays_behind_broker_and_returns_sanitized_messages(self):
@@ -278,6 +278,39 @@ class StoreTest(unittest.TestCase):
         request["source"] = {"session_id": "claude-2", "cwd": "/tmp/parcha"}
         with self.assertRaisesRegex(ValueError, "already has an active"):
             broker.handle(request)
+
+    def test_rebind_replaces_only_the_existing_threads_zellij_source(self):
+        broker = self.runtime.Broker("test-token", self.store)
+        broker.handle({
+            "op": "attach", "source_kind": "claude_session",
+            "source": {"session_id": "wrong-session", "cwd": "/tmp/wrong"},
+            "owner_user_id": "U12345678", "team_id": "T12345678",
+            "channel_id": "C12345678", "thread_ts": "123.456",
+            "idempotency_key": "wrong-binding",
+        })
+        result = broker.handle({
+            "op": "rebind", "source_kind": "zellij_pane",
+            "source": {
+                "session_name": "work", "pane_id": "7", "cwd": "/tmp/right",
+                "pane_agent": "codex", "pane_command_hash": "expected",
+            },
+            "team_id": "T12345678", "channel_id": "C12345678",
+            "thread_ts": "123.456",
+        })
+        self.assertEqual(result["pane_id"], "7")
+        bridge = self.store.find("T12345678", "C12345678", "123.456")
+        self.assertEqual(bridge.source_kind, "zellij_pane")
+        self.assertEqual(bridge.source["pane_id"], "7")
+
+    def test_rebind_refuses_non_zellij_or_unknown_thread(self):
+        broker = self.runtime.Broker("test-token", self.store)
+        with self.assertRaisesRegex(ValueError, "active bridge not found"):
+            broker.handle({
+                "op": "rebind", "source_kind": "zellij_pane",
+                "source": {"session_name": "work", "pane_id": "7"},
+                "team_id": "T12345678", "channel_id": "C12345678",
+                "thread_ts": "123.456",
+            })
 
     def test_thread_participation_survives_store_reopen_and_team_lookup(self):
         self.store.mark_participation("T12345678", "C12345678", "123.456")
@@ -580,6 +613,20 @@ class NotifierTest(unittest.TestCase):
         self.assertEqual(kind, "zellij_pane")
         self.assertEqual(source["pane_command_hash"], "abc123")
         capture.assert_called_once_with("work", "7", str(pathlib.Path.cwd()))
+
+    def test_rebind_source_ignores_native_session_ids_and_requires_ambient_pane(self):
+        identity = {
+            "session_name": "work", "pane_id": "7", "cwd": str(pathlib.Path.cwd()),
+            "pane_agent": "codex", "pane_command_hash": "abc123",
+        }
+        with mock.patch.dict(os.environ, {
+            "CODEX_THREAD_ID": "must-not-be-used",
+            "ZELLIJ_SESSION_NAME": "work", "ZELLIJ_PANE_ID": "7",
+        }, clear=True), mock.patch.object(self.notifier, "zellij_pane_identity", return_value=identity):
+            kind, source = self.notifier.ambient_zellij_source()
+        self.assertEqual(kind, "zellij_pane")
+        self.assertEqual(source["pane_id"], "7")
+        self.assertNotIn("session_id", source)
 
     def test_noninteractive_setup_delegates_manifest_to_hermes(self):
         args = types.SimpleNamespace(non_interactive=True, no_restart=False)

--- a/tether/tests/test_bridge.py
+++ b/tether/tests/test_bridge.py
@@ -251,6 +251,22 @@ class StoreTest(unittest.TestCase):
         self.assertTrue(reopened.participates("T12345678", "C12345678", "123.456"))
         self.assertFalse(reopened.participates("T99999999", "C12345678", "123.456"))
 
+    def test_participating_thread_ingress_is_deduplicated_and_kept_recent(self):
+        self.store.mark_participation("T12345678", "C12345678", "123.456")
+        self.assertTrue(self.store.mark_thread_ingress(
+            "123.457", "T12345678", "C12345678", "123.456",
+        ))
+        self.assertFalse(self.store.mark_thread_ingress(
+            "123.457", "T12345678", "C12345678", "123.456",
+        ))
+        self.assertTrue(self.store.has_ingress("123.457"))
+        recent = self.store.recent_participating_threads()
+        self.assertIn(
+            ("T12345678", "C12345678", "123.456"),
+            [item[:3] for item in recent],
+        )
+        self.assertIsInstance(recent[0][3], float)
+
     def test_concurrent_idempotent_notifications_post_one_root_message(self):
         broker = self.runtime.Broker("test-token", self.store)
         request = {
@@ -822,6 +838,43 @@ class PluginRoutingTest(unittest.TestCase):
         self.assertEqual(recovered, 1)
         self.assertEqual(recovered_again, 0)
         self.assertEqual(adapter.events[0]["text"], "continue")
+        self.assertTrue(adapter.events[0]["_tether_polled"])
+
+    def test_reply_poller_recovers_unmentioned_participating_thread_reply(self):
+        self.plugin.store.mark_participation(
+            "T12345678", "C12345678", "123.456",
+        )
+        messages = [
+            {"ts": "123.456", "text": "root", "user": "U12345678"},
+            {
+                "ts": "123.457", "thread_ts": "123.456",
+                "text": "did you see this?", "user": "U12345678",
+            },
+        ]
+
+        class Client:
+            async def conversations_join(self, **_kwargs):
+                return {"ok": True}
+
+            async def conversations_replies(self, **_kwargs):
+                return {"messages": messages}
+
+        class Adapter:
+            def __init__(self):
+                self.events = []
+
+            def _get_client(self, _channel):
+                return Client()
+
+            async def _handle_slack_message(self, event):
+                self.events.append(event)
+
+        adapter = Adapter()
+        recovered = asyncio.run(self.plugin._poll_recent_replies(adapter))
+        recovered_again = asyncio.run(self.plugin._poll_recent_replies(adapter))
+        self.assertEqual(recovered, 1)
+        self.assertEqual(recovered_again, 0)
+        self.assertEqual(adapter.events[0]["text"], "did you see this?")
         self.assertTrue(adapter.events[0]["_tether_polled"])
 
     def test_reply_poller_recovers_peer_bot_thread_turns_when_enabled(self):

--- a/tether/tests/test_bridge.py
+++ b/tether/tests/test_bridge.py
@@ -205,7 +205,7 @@ class StoreTest(unittest.TestCase):
         self.assertEqual(call.call_args_list, [
             mock.call(
                 "test-token", "conversations.info",
-                {"channel": "C12345678", "include_num_members": False},
+                {"channel": "C12345678"},
             ),
             mock.call(
                 "test-token", "conversations.replies",
@@ -225,7 +225,7 @@ class StoreTest(unittest.TestCase):
         self.assertEqual(call.call_args_list, [
             mock.call(
                 "test-token", "conversations.info",
-                {"channel": "C12345678", "include_num_members": False},
+                {"channel": "C12345678"},
             ),
             mock.call("test-token", "conversations.join", {"channel": "C12345678"}),
         ])
@@ -239,7 +239,7 @@ class StoreTest(unittest.TestCase):
             broker._ensure_channel_membership("C12345678")
         call.assert_called_once_with(
             "test-token", "conversations.info",
-            {"channel": "C12345678", "include_num_members": False},
+            {"channel": "C12345678"},
         )
 
     def test_identity_returns_only_nonsecret_bot_metadata(self):

--- a/tether/tests/test_bridge.py
+++ b/tether/tests/test_bridge.py
@@ -181,7 +181,7 @@ class StoreTest(unittest.TestCase):
         self.assertEqual(bridge.owner_user_id, "*", "Hermes's explicit allowlist is shared by default")
         self.assertEqual(status["allowed_user_count"], 2)
         self.assertEqual(status["implementation"], "tether")
-        self.assertEqual(status["protocol_version"], 2)
+        self.assertEqual(status["protocol_version"], 3)
         self.assertNotIn("allowed_users", status, "status reports readiness, never identities")
 
     def test_thread_history_stays_behind_broker_and_returns_sanitized_messages(self):
@@ -244,6 +244,40 @@ class StoreTest(unittest.TestCase):
         self.assertEqual(result["thread_ts"], "123.456")
         self.assertEqual(self.store.recent_active_bridges(), [])
         self.assertTrue(self.store.participates("", "C12345678", "123.456"))
+
+    def test_attach_binds_existing_thread_without_posting(self):
+        broker = self.runtime.Broker("test-token", self.store)
+        with mock.patch.object(self.runtime, "slack_post") as post:
+            result = broker.handle({
+                "op": "attach",
+                "source_kind": "claude_session",
+                "source": {"session_id": "claude-1", "cwd": "/tmp/parcha"},
+                "owner_user_id": "U12345678",
+                "team_id": "T12345678",
+                "channel_id": "C12345678",
+                "thread_ts": "123.456",
+                "idempotency_key": "review-123.456",
+            })
+        post.assert_not_called()
+        self.assertEqual(result["thread_ts"], "123.456")
+        bridge = self.store.find("T12345678", "C12345678", "123.456")
+        self.assertEqual(bridge.source_kind, "claude_session")
+        self.assertEqual(bridge.source["session_id"], "claude-1")
+
+    def test_attach_refuses_to_replace_active_binding(self):
+        broker = self.runtime.Broker("test-token", self.store)
+        request = {
+            "op": "attach", "source_kind": "claude_session",
+            "source": {"session_id": "claude-1", "cwd": "/tmp/parcha"},
+            "owner_user_id": "U12345678", "team_id": "T12345678",
+            "channel_id": "C12345678", "thread_ts": "123.456",
+            "idempotency_key": "review-one",
+        }
+        broker.handle(request)
+        request["idempotency_key"] = "review-two"
+        request["source"] = {"session_id": "claude-2", "cwd": "/tmp/parcha"}
+        with self.assertRaisesRegex(ValueError, "already has an active"):
+            broker.handle(request)
 
     def test_thread_participation_survives_store_reopen_and_team_lookup(self):
         self.store.mark_participation("T12345678", "C12345678", "123.456")

--- a/tether/tests/test_bridge.py
+++ b/tether/tests/test_bridge.py
@@ -193,7 +193,7 @@ class StoreTest(unittest.TestCase):
             }]
         }
         with mock.patch.object(self.runtime, "_slack_call", side_effect=[
-            {"ok": True, "channel": {"id": "C12345678", "is_member": True}}, response,
+            {"ok": True, "messages": []}, response,
         ]) as call:
             result = broker.handle({
                 "op": "thread_history", "channel_id": "C12345678",
@@ -204,8 +204,8 @@ class StoreTest(unittest.TestCase):
         }])
         self.assertEqual(call.call_args_list, [
             mock.call(
-                "test-token", "conversations.info",
-                {"channel": "C12345678"},
+                "test-token", "conversations.history",
+                {"channel": "C12345678", "limit": 1},
             ),
             mock.call(
                 "test-token", "conversations.replies",
@@ -216,7 +216,7 @@ class StoreTest(unittest.TestCase):
     def test_public_destination_is_joined_only_once_per_broker(self):
         broker = self.runtime.Broker("test-token", self.store)
         with mock.patch.object(self.runtime, "_slack_call", side_effect=[
-            {"ok": True, "channel": {"id": "C12345678", "is_member": False}},
+            RuntimeError("Slack API error: not_in_channel"),
             {"ok": True},
         ]) as call:
             broker._ensure_channel_membership("C12345678")
@@ -224,22 +224,22 @@ class StoreTest(unittest.TestCase):
             broker._ensure_channel_membership("D12345678")
         self.assertEqual(call.call_args_list, [
             mock.call(
-                "test-token", "conversations.info",
-                {"channel": "C12345678"},
+                "test-token", "conversations.history",
+                {"channel": "C12345678", "limit": 1},
             ),
             mock.call("test-token", "conversations.join", {"channel": "C12345678"}),
         ])
 
     def test_group_dm_with_channel_id_is_never_joined(self):
         broker = self.runtime.Broker("test-token", self.store)
-        with mock.patch.object(self.runtime, "_slack_call", return_value={
-            "ok": True, "channel": {"id": "C12345678", "is_mpim": True},
-        }) as call:
+        with mock.patch.object(
+            self.runtime, "_slack_call", return_value={"ok": True, "messages": []},
+        ) as call:
             broker._ensure_channel_membership("C12345678")
             broker._ensure_channel_membership("C12345678")
         call.assert_called_once_with(
-            "test-token", "conversations.info",
-            {"channel": "C12345678"},
+            "test-token", "conversations.history",
+            {"channel": "C12345678", "limit": 1},
         )
 
     def test_identity_returns_only_nonsecret_bot_metadata(self):

--- a/tether/tests/test_bridge.py
+++ b/tether/tests/test_bridge.py
@@ -193,7 +193,7 @@ class StoreTest(unittest.TestCase):
             }]
         }
         with mock.patch.object(self.runtime, "_slack_call", side_effect=[
-            {"ok": True, "channel": {"id": "C12345678"}}, response,
+            {"ok": True, "channel": {"id": "C12345678", "is_member": True}}, response,
         ]) as call:
             result = broker.handle({
                 "op": "thread_history", "channel_id": "C12345678",
@@ -203,7 +203,10 @@ class StoreTest(unittest.TestCase):
             "ts": "123.456", "thread_ts": "100.000", "text": "reply", "user": "U12345678",
         }])
         self.assertEqual(call.call_args_list, [
-            mock.call("test-token", "conversations.join", {"channel": "C12345678"}),
+            mock.call(
+                "test-token", "conversations.info",
+                {"channel": "C12345678", "include_num_members": False},
+            ),
             mock.call(
                 "test-token", "conversations.replies",
                 {"channel": "C12345678", "ts": "100.000", "limit": 10},
@@ -212,12 +215,31 @@ class StoreTest(unittest.TestCase):
 
     def test_public_destination_is_joined_only_once_per_broker(self):
         broker = self.runtime.Broker("test-token", self.store)
-        with mock.patch.object(self.runtime, "_slack_call", return_value={"ok": True}) as call:
+        with mock.patch.object(self.runtime, "_slack_call", side_effect=[
+            {"ok": True, "channel": {"id": "C12345678", "is_member": False}},
+            {"ok": True},
+        ]) as call:
             broker._ensure_channel_membership("C12345678")
             broker._ensure_channel_membership("C12345678")
             broker._ensure_channel_membership("D12345678")
+        self.assertEqual(call.call_args_list, [
+            mock.call(
+                "test-token", "conversations.info",
+                {"channel": "C12345678", "include_num_members": False},
+            ),
+            mock.call("test-token", "conversations.join", {"channel": "C12345678"}),
+        ])
+
+    def test_group_dm_with_channel_id_is_never_joined(self):
+        broker = self.runtime.Broker("test-token", self.store)
+        with mock.patch.object(self.runtime, "_slack_call", return_value={
+            "ok": True, "channel": {"id": "C12345678", "is_mpim": True},
+        }) as call:
+            broker._ensure_channel_membership("C12345678")
+            broker._ensure_channel_membership("C12345678")
         call.assert_called_once_with(
-            "test-token", "conversations.join", {"channel": "C12345678"},
+            "test-token", "conversations.info",
+            {"channel": "C12345678", "include_num_members": False},
         )
 
     def test_identity_returns_only_nonsecret_bot_metadata(self):


### PR DESCRIPTION
## Summary
- persist exact Slack threads where the bot posts through native Hermes or Tether
- recover pre-upgrade participation once from Slack authorship metadata
- keep unmentioned follow-ups scoped to participating threads and trusted peer bots
- reject Slack user IDs used as bridge channel IDs

## Verification
- `python3 -m unittest discover -s tether/tests -v` (54 tests)