### PR TITLE
docs(recall): lock universal ingestion cascade

### DIFF
--- a/docs/LOOP_CHAIN_RECALL_UNIVERSAL_INGESTION_2026-07-16.md
+++ b/docs/LOOP_CHAIN_RECALL_UNIVERSAL_INGESTION_2026-07-16.md
@@ -1,7 +1,7 @@
 # Recall Universal Ingestion — Five-Loop Cascade
 
-**Status:** proposed for review
-**Mode:** PLAN; BUILD begins only after owner approval
+**Status:** approved for autonomous execution
+**Mode:** BUILD
 **Pacing:** autonomous between declared human gates
 **RDD:** `docs/rdd/RECALL_UNIVERSAL_INGESTION_2026-07-16.md`
 
@@ -29,9 +29,9 @@ uses red -> green -> refactor; every loop uses the full Cascade ribbon and has a
   unsupported deletion claim, arbitrary connector loading, and public exposure.
 - Every model or judge call uses the approved staging LiteLLM router with a short-lived scoped virtual
   key. Direct provider calls and master-key use are prohibited.
-- Each exit writes `docs/evidence/recall-universal-ingestion/<loop>/EXIT.md`, maps every acceptance
-  criterion to reproducible safe evidence at merged HEAD, carries the cumulative L0 -> Ln delta table,
-  runs recap against the objective, and records the ZEN check.
+- Each exit writes a mode-0600 private criterion map outside the repository, tied to merged HEAD, and
+  publishes only content-free aggregate checks through CI or the PR. No Cascade diary or live evidence
+  is committed. Each exit runs recap against the objective and records the ZEN result privately.
 - Human gates wait without timing out. Hitting any other bound produces `status: AT_BOUND` and stops;
   it never weakens an exit.
 
@@ -39,7 +39,7 @@ uses red -> green -> refactor; every loop uses the full Cascade ribbon and has a
 
 ```mermaid
 flowchart LR
-    L0[L0 Choose the rail and pin the substrate]
+    L0[L0 Pin the substrate and closed Google rail]
     L1[L1 Google Workspace life plane]
     L2[L2 Private communications and Mac utility]
     L3[L3 Social and work expansion]
@@ -49,38 +49,36 @@ flowchart LR
 
 | Task | `blockedBy` | Human gate |
 |---|---|---|
-| L0 | — | approve this RDD/chain; approve only the Google scopes selected by the bakeoff |
+| L0 | — | approve only the declared Google read-only scopes |
 | L1 | L0 | complete Google OAuth consent |
-| L2 | L1 | grant macOS permissions; choose WhatsApp export, experimental linked device, or disabled |
+| L2 | L1 | grant macOS permissions; WhatsApp is export-only in this chain |
 | L3 | L2 | approve X streams/retention/cost and each additional external account scope |
 | L4 | L3 | accept release or approve the successor chain |
 
-## L0 — Choose the rail and pin the substrate
+## L0 — Pin the substrate and closed Google rail
 
-- **goal:** Produce a closed, benchmarked ingestion substrate and select the smallest safe Google
-  Workspace acquisition rail before connecting personal data.
+- **goal:** Produce a closed, benchmarked ingestion substrate around pinned Google Workspace CLI
+  `gws` v0.22.5 before connecting personal data.
 - **prompt:** Read the RDD and current Recall connector/runtime code; freeze the unchanged retrieval,
   privacy, deletion, replay, and packaging baselines; red-test connector-v2 typed records, exact
   authority slots, ACK-gated checkpoints, revisions, tombstones, static registry preview, and rejection
-  of arbitrary factories; build a synthetic bakeoff of pinned OpenClaw `gog`, Google Workspace `gws`,
-  and direct official clients against Gmail history, Calendar sync, Contacts sync, Drive changes,
-  non-interactive JSON stability, empty-success failure, revoke, read-only enforcement, untrusted
-  content, crash replay, OS packaging, upgrade pinning, and credential isolation; select one rail per
-  source in an ADR, then implement only the closed rail boundary and shared contract in serial
-  one-concern PRs. Prefer `gog` where its exact command ceilings and delivery semantics pass; use `gws`
-  or a direct client only for a measured missing capability.
-- **accept:** The pre-change scorecard reproduces twice; the bakeoff contains non-null results for every
-  candidate/capability cell and the ADR maps every selected rail to evidence; all legacy connectors and
-  selected rails pass the v2 conformance suite; duplicate pages and every injected crash converge to
+  of arbitrary factories; pin `gws` v0.22.5 at tag commit `705fb0ec` with per-platform release
+  checksums; expose only Gmail message/history reads, Calendar event reads, People connections reads,
+  Drive change/file reads, and Docs exports through exact argv/method and response-schema allowlists;
+  test non-interactive JSON stability, empty-success failure, revoke, read-only enforcement, untrusted
+  content, crash replay, OS packaging, upgrade pinning, and credential isolation; then implement the
+  closed rail boundary and shared contract in serial one-concern PRs.
+- **accept:** The pre-change scorecard reproduces twice; all legacy connectors and the pinned `gws`
+  rail pass the v2 conformance suite; duplicate pages and every injected crash converge to
   one acknowledged version; cursor-before-ACK, executable config, shell invocation, unknown command,
   write method, ambient environment, empty success, schema drift, and secret-bearing error tests fail
   closed; encrypted storage, backup/restore, filesystem mode, source-writer, and Tailnet-only
   attestations are green; repository tests and the public-safety scan pass at merged HEAD.
 - **bound:** At most three serial PRs, two failed PROVE runs and three review rounds per PR, and ten
-  working days total; unresolved rail ambiguity or a failed storage/safety control exits AT_BOUND
+  working days total; checksum ambiguity or a failed storage/safety control exits AT_BOUND
   instead of authorizing Google data.
-- **exit →:** Write `docs/evidence/recall-universal-ingestion/L0/EXIT.md`, recap and pass ZEN, pause for
-  owner approval of the evidence-selected Google scopes, then trigger L1.
+- **exit →:** Write the private criterion map, recap and pass ZEN, pause for owner approval of the
+  declared Google scopes, then trigger L1.
 
 ## L1 — Google Workspace life plane
 
@@ -106,7 +104,7 @@ flowchart LR
 - **bound:** At most five source PRs, two failed PROVE runs and three review rounds per PR, and fourteen
   working days total; one failing source may be explicitly disabled only by owner decision, otherwise
   the loop exits AT_BOUND without calling the Google plane complete.
-- **exit →:** Write `docs/evidence/recall-universal-ingestion/L1/EXIT.md`, recap and pass ZEN, then
+- **exit →:** Write the private criterion map, recap and pass ZEN, then
   trigger L2; any loss, duplicate, receipt, revoke, scope, or privacy failure blocks private-message
   expansion.
 
@@ -117,9 +115,8 @@ flowchart LR
 - **prompt:** Red-test a signed Recall Bridge clean install, upgrade, rollback, launch-on-login,
   sleep/wake, network partition, bounded spool, per-source pause/revoke/forget, Keychain references,
   content-free status, and uninstall; add the iMessage source as a pinned read-only snapshot/WAL reader
-  with schema fixtures, edits, reactions, authoritative deletes, and attachment descriptors; at an
-  unbounded human gate choose WhatsApp export, experimental linked-device, or disabled, document the
-  risk decision without identity/content, and implement only the chosen read-only mode; route existing
+  with schema fixtures, edits, reactions, authoritative deletes, and attachment descriptors; add only
+  a watched WhatsApp export inbox with stable archive/chat/message identities; route existing
   ChatGPT/Cowork consented exports and coding collectors through the same lifecycle UI without changing
   their evidence semantics; run a private clean-Mac E2E and frozen source questions, using one concern
   per serial PR.
@@ -127,14 +124,14 @@ flowchart LR
   uninstall E2Es pass; the utility never opens iMessage writable, changes SIP, exposes a send surface,
   or displays content in diagnostics; repeated sync/import and every crash point yield zero duplicate
   versions for every enabled source; edits/deletes match frozen fixtures without claims based on list
-  absence; lost permissions and revoke fail closed; the WhatsApp decision is explicit and the disabled
-  choice counts only as an owner-approved omission; at least 80% of private frozen questions per
+  absence; lost permissions and revoke fail closed; WhatsApp never opens a linked-device session; at
+  least 80% of private frozen questions per
   enabled source retrieve the expected conversation evidence with valid receipts; signed artifacts
   verify and public proof remains aggregate/content-free.
 - **bound:** At most four serial PRs, two failed PROVE runs and three review rounds per PR, and fourteen
-  working days total; two failed clean-device E2Es or unresolved WhatsApp/account risk exits AT_BOUND
-  or leaves WhatsApp explicitly disabled rather than adding unsafe fallbacks.
-- **exit →:** Write `docs/evidence/recall-universal-ingestion/L2/EXIT.md`, recap and pass ZEN, pause for
+  working days total; two failed clean-device E2Es or unresolved WhatsApp export risk exits AT_BOUND
+  rather than adding unsafe fallbacks.
+- **exit →:** Write the private criterion map, recap and pass ZEN, pause for
   X and external-account scope decisions, then trigger L3.
 
 ## L3 — Social and work expansion
@@ -160,7 +157,7 @@ flowchart LR
 - **bound:** No more than six serial source PRs, two failed PROVE runs and three review rounds per PR,
   and fifteen working days total; a failing or policy-blocked source is disabled and named in an
   AT_BOUND/replan verdict rather than weakening the factory or expanding credentials.
-- **exit →:** Write `docs/evidence/recall-universal-ingestion/L3/EXIT.md`, recap and pass ZEN, freeze the
+- **exit →:** Write the private criterion map, recap and pass ZEN, freeze the
   final cross-source eval set before inspecting results, then trigger L4.
 
 ## L4 — Cross-source retrieval, operations acceptance, and replan
@@ -189,7 +186,7 @@ flowchart LR
 - **bound:** At most three ranking PRs, two failed PROVE runs and three review rounds per PR, one
   seven-day soak plus one remediation restart, and two successor drafts; owner sign-off waits unbounded
   by design, while a second soak failure exits AT_BOUND and stops release.
-- **exit →:** Write `docs/evidence/recall-universal-ingestion/L4/EXIT.md`, recap and pass ZEN, verify the
+- **exit →:** Write the private criterion map, recap and pass ZEN, verify the
   deployed release commit and content-free verdict at HEAD, then stop at the final human gate; release
   only on explicit owner acceptance, otherwise start the approved remediation/successor chain.
 
@@ -197,5 +194,5 @@ flowchart LR
 
 Approving this document authorizes only these five bounded outcomes and their serial one-concern PRs.
 It does not authorize broad OAuth presets, write/send tools, public Brain ingress, attachment content,
-experimental WhatsApp, durable home-timeline retention, or additional accounts without their named
-human gates.
+WhatsApp linked-device access, durable home-timeline retention, or additional accounts without their
+named human gates.

--- a/docs/LOOP_CHAIN_RECALL_UNIVERSAL_INGESTION_2026-07-16.md
+++ b/docs/LOOP_CHAIN_RECALL_UNIVERSAL_INGESTION_2026-07-16.md
@@ -1,352 +1,201 @@
-# Recall Universal Ingestion — Cascade Loop Chain
+# Recall Universal Ingestion — Five-Loop Cascade
 
 **Status:** proposed for review
 **Mode:** PLAN; BUILD begins only after owner approval
-**Date:** 2026-07-16
+**Pacing:** autonomous between declared human gates
 **RDD:** `docs/rdd/RECALL_UNIVERSAL_INGESTION_2026-07-16.md`
 
 ## Objective
 
-Make Recall a safe, owner-controlled context plane for personal communications, schedule, contacts,
-social activity, and local Mac sources. Every connector must preserve source receipts, survive replay,
-respect edits and deletions, and improve natural-language retrieval without leaking private proof into
-the public repository.
+Make Recall an owner-controlled context plane that safely ingests Google Workspace, local/private
+communications, social activity, and work systems, then answers natural-language questions across
+them with exact receipts, deletion lineage, and honest gaps.
 
-This is a TDD Cascade. Every loop follows red -> green -> refactor, changes one concern, ends at a
-hard eval or E2E gate, writes a content-free `EXIT.md`, applies the ZEN check, and merges before its
-dependent loop starts. A passing unit suite alone never closes a source loop.
+Five loops are enough. They are outcome-sized integration gates, not a loop per connector. A loop may
+ship several serial one-concern PRs, but it closes only when the combined eval/E2E is green. Every PR
+uses red -> green -> refactor; every loop uses the full Cascade ribbon and has a hard bound.
 
 ## Operating contract
 
-- **Pacing:** autonomous between declared human gates. Credentials, external consent, risky source
-  methods, retention expansion, and final acceptance remain human decisions.
-- **Public evidence:** synthetic fixtures, schemas, commands, aggregate counts, pass/fail results,
-  hashes of synthetic fixtures, and redacted deployment attestations only.
-- **Private evidence:** real prompts, answers, messages, event text, social content, identities,
-  exports, database samples, credentials, machine paths, and identifying infrastructure remain in
-  approved private runtime state and never enter commits, PRs, logs, screenshots, or `EXIT.md`.
-- **Safety floors:** secret leaks = 0; raw private records in public artifacts = 0; unauthorized source
-  reads = 0; cross-source authorization escapes = 0; cursor advancement before acknowledgement = 0;
-  unsupported deletion claims = 0; arbitrary runtime connector loading = 0.
-- **Determinism floor:** replaying the same retained source revision produces exactly one canonical
-  version, and restarting after every injected crash point produces the same acknowledged result.
-- **Exit convention:** `docs/evidence/recall-universal-ingestion/<loop>/EXIT.md`. Each exit maps every
-  acceptance criterion to a reproducible command and content-free result, records the ZEN check, and
-  names the verified merge commit and next loop.
-- **No drift:** after each exit, run Recall's recap procedure against the objective, RDD, safety floors,
-  and losing eval cells. Scope changes require an RDD amendment and owner approval.
+- Measure before changing behavior. L0 freezes the retrieval and safety baseline.
+- Each loop follows RE-PLAN -> BUILD -> PIN -> PROVE -> MEASURE -> REVIEW -> MERGE -> EXIT.
+- Maximum per PR: two failed PROVE runs and three review/fix rounds. Instrument failures are diagnosed
+  separately and do not become fake evidence.
+- A loop's public proof is synthetic or content-free. No message, event, contact, post, document,
+  transcript, query, answer, credential, private export, selector, identifying path, or infrastructure
+  detail enters a commit, PR, log, screenshot, or `EXIT.md`.
+- Safety floors are always zero: secret/PII canary leak, unauthorized read/retrieval, cross-source
+  authority escape, cursor advancement before Brain acknowledgement, deletion resurrection,
+  unsupported deletion claim, arbitrary connector loading, and public exposure.
+- Every model or judge call uses the approved staging LiteLLM router with a short-lived scoped virtual
+  key. Direct provider calls and master-key use are prohibited.
+- Each exit writes `docs/evidence/recall-universal-ingestion/<loop>/EXIT.md`, maps every acceptance
+  criterion to reproducible safe evidence at merged HEAD, carries the cumulative L0 -> Ln delta table,
+  runs recap against the objective, and records the ZEN check.
+- Human gates wait without timing out. Hitting any other bound produces `status: AT_BOUND` and stops;
+  it never weakens an exit.
 
-## Dependency graph
+## Task graph
 
 ```mermaid
 flowchart LR
-    U0[U0 Baseline and threat gate] --> U1[U1 Connector contract v2]
-    U1 --> U2[U2 Projections and admission]
-    U2 --> U3[U3 Gmail]
-    U3 --> U4[U4 Google Calendar]
-    U4 --> U5[U5 Google Contacts]
-    U5 --> U6[U6 iMessage]
-    U6 --> U7{U7 WhatsApp method gate}
-    U7 --> U8{U8 X scope gate}
-    U8 --> U9[U9 Recall Bridge utility]
-    U9 --> U10[U10 Cross-source retrieval]
-    U10 --> U11{U11 Owner acceptance and replan}
+    L0[L0 Choose the rail and pin the substrate]
+    L1[L1 Google Workspace life plane]
+    L2[L2 Private communications and Mac utility]
+    L3[L3 Social and work expansion]
+    L4{L4 Retrieval acceptance and replan}
+    L0 --> L1 --> L2 --> L3 --> L4
 ```
 
 | Task | `blockedBy` | Human gate |
 |---|---|---|
-| U0 | — | approve RDD and chain before BUILD |
-| U1 | U0 | — |
-| U2 | U1 | — |
-| U3 | U2 | approve Google OAuth consent and Gmail scope |
-| U4 | U3 | approve Calendar scope |
-| U5 | U4 | approve Contacts scope |
-| U6 | U5 | grant macOS Full Disk Access to the signed utility |
-| U7 | U6 | choose export-only or experimental linked-device ingestion |
-| U8 | U7 | approve X streams, retention, and spending cap |
-| U9 | U8 | approve installer permissions before real-device E2E |
-| U10 | U9 | freeze private eval questions and expected evidence classes |
-| U11 | U10 | accept release or approve the successor chain |
+| L0 | — | approve this RDD/chain; approve only the Google scopes selected by the bakeoff |
+| L1 | L0 | complete Google OAuth consent |
+| L2 | L1 | grant macOS permissions; choose WhatsApp export, experimental linked device, or disabled |
+| L3 | L2 | approve X streams/retention/cost and each additional external account scope |
+| L4 | L3 | accept release or approve the successor chain |
 
-## Loop U0 — Baseline, harness, and threat gate
+## L0 — Choose the rail and pin the substrate
 
-- **Goal:** Freeze the current retrieval baseline and prove the evaluation, privacy, storage, and
-  evidence boundaries before any new personal source is connected.
-- **Prompt:** Write failing tests first for the connector-v2 invariants and content-free evidence
-  contract; add synthetic conversations, events, contacts, posts, edits, tombstones, duplicate pages,
-  poison instructions, and crash points; run the existing retrieval suite unchanged to record the
-  pre-change scorecard; produce content-free attestations for encrypted database storage, encrypted
-  backups, restore, filesystem modes, Tailnet-only reachability, and source-scoped writers; refactor
-  only the harness and fixtures, not production ingestion or retrieval behavior.
-- **Accept:** The checked-in synthetic suite fails for the intended missing capabilities before the
-  harness change and passes after it; the unchanged baseline scorecard is reproducible on two runs;
-  every safety floor is measured; the deployment attestation has no unknown or failing control; a
-  repository scan finds zero secret-shaped values, raw/private samples, identifying paths, or private
-  query/answer text in the diff and evidence tree.
-- **Bound:** One PR limited to synthetic fixtures, eval harnesses, threat model, and content-free
-  attestations; no connector, schema, ranking, live credential, or production behavior change; two
-  implementation attempts or five working days, then replan the harness rather than weakening a gate.
-- **Exit →:** Write `docs/evidence/recall-universal-ingestion/U0/EXIT.md` mapping every criterion to
-  commands and results, verify the merged commit on the target branch, recap and pass ZEN, then start
-  U1; any failed storage, privacy, reachability, or repository-safety control blocks all later loops.
+- **goal:** Produce a closed, benchmarked ingestion substrate and select the smallest safe Google
+  Workspace acquisition rail before connecting personal data.
+- **prompt:** Read the RDD and current Recall connector/runtime code; freeze the unchanged retrieval,
+  privacy, deletion, replay, and packaging baselines; red-test connector-v2 typed records, exact
+  authority slots, ACK-gated checkpoints, revisions, tombstones, static registry preview, and rejection
+  of arbitrary factories; build a synthetic bakeoff of pinned OpenClaw `gog`, Google Workspace `gws`,
+  and direct official clients against Gmail history, Calendar sync, Contacts sync, Drive changes,
+  non-interactive JSON stability, empty-success failure, revoke, read-only enforcement, untrusted
+  content, crash replay, OS packaging, upgrade pinning, and credential isolation; select one rail per
+  source in an ADR, then implement only the closed rail boundary and shared contract in serial
+  one-concern PRs. Prefer `gog` where its exact command ceilings and delivery semantics pass; use `gws`
+  or a direct client only for a measured missing capability.
+- **accept:** The pre-change scorecard reproduces twice; the bakeoff contains non-null results for every
+  candidate/capability cell and the ADR maps every selected rail to evidence; all legacy connectors and
+  selected rails pass the v2 conformance suite; duplicate pages and every injected crash converge to
+  one acknowledged version; cursor-before-ACK, executable config, shell invocation, unknown command,
+  write method, ambient environment, empty success, schema drift, and secret-bearing error tests fail
+  closed; encrypted storage, backup/restore, filesystem mode, source-writer, and Tailnet-only
+  attestations are green; repository tests and the public-safety scan pass at merged HEAD.
+- **bound:** At most three serial PRs, two failed PROVE runs and three review rounds per PR, and ten
+  working days total; unresolved rail ambiguity or a failed storage/safety control exits AT_BOUND
+  instead of authorizing Google data.
+- **exit →:** Write `docs/evidence/recall-universal-ingestion/L0/EXIT.md`, recap and pass ZEN, pause for
+  owner approval of the evidence-selected Google scopes, then trigger L1.
 
-## Loop U1 — Closed connector contract v2
+## L1 — Google Workspace life plane
 
-- **Goal:** Add a typed, capability-declared connector contract while preserving existing connector
-  behavior and forbidding arbitrary runtime code loading.
-- **Prompt:** Red-test manifest validation, typed canonical records, exact authority slots, static
-  preview, backward-compatible v1 adaptation, ACK-gated checkpoints, edit revisions, tombstones,
-  restart replay, and rejection of unknown factories or executable configuration; implement the
-  smallest closed registry and compatibility layer; refactor duplicate connector mechanics into the
-  conformance harness without moving policy into connector-specific branches.
-- **Accept:** All bundled legacy connectors pass the old suites unchanged and the new conformance
-  suite; every v2 record kind round-trips deterministically; duplicate delivery across two pages and
-  two restarts yields one acknowledged version; injected failures at every checkpoint never advance
-  the cursor early; edit and explicit-delete fixtures create the expected revision and tombstone;
-  attempts to load entry points, imports, commands, or current-directory plugins all fail closed.
-- **Bound:** One contract-and-registry PR with migrations and synthetic tests; no new external source,
-  live credential, projection, retrieval ranking, UI, or public endpoint; two failed green attempts or
-  seven working days triggers a smaller contract amendment reviewed against the RDD.
-- **Exit →:** Write `docs/evidence/recall-universal-ingestion/U1/EXIT.md`, verify all legacy and v2
-  conformance cells plus the merged commit, recap and pass ZEN, then start U2; any compatibility,
-  replay, authorization, or closed-registry failure returns to U1 red.
+- **goal:** Deliver one continuously synchronized Google context plane—Gmail, Calendar, Contacts, and
+  selected Drive/Docs—through the L0 rail with useful cited retrieval.
+- **prompt:** After least-privilege OAuth consent, execute a repeated source ribbon for Gmail,
+  Calendar, Contacts, Drive, and Docs: write failing synthetic contract/integration tests; add one
+  narrow normalizer and authority implementation per PR; prove full backfill, incremental sync,
+  pagination, overlap, quota/backoff, revoke, restart, edit, and authoritative deletion; for Gmail use
+  history IDs and prefer Pub/Sub pull only as a wakeup, never as the canonical cursor; for Calendar use
+  sync tokens and HTTP 410 reconciliation; for Contacts preserve ambiguous matches as candidates; for
+  Drive/Docs preserve stable IDs, revisions, hierarchy, exports, and change checkpoints; shadow a
+  bounded real account privately before searchable mode, then run frozen single-source and
+  cross-Google questions. Attachments and Sheets content stay off unless separately approved.
+- **accept:** Every enabled Google source is green in the synthetic connector-v2 matrix; two repeated
+  full/incremental cycles plus every injected crash produce zero duplicate acknowledged versions;
+  expired Gmail history, Calendar 410, Contacts token invalidation, and Drive change recovery lose no
+  retained evidence; edits and authoritative deletes invalidate derived material; revoke stops reads
+  and leaves only an ACK-recoverable spool; exact identifiers resolve while name-only contacts do not
+  silently merge; at least 80% of each source's private frozen questions and 85% of the cross-Google
+  set retrieve the expected evidence class, with valid canonical receipts for every material claim;
+  public proof contains aggregate results only and every serial PR is merged and verified at HEAD.
+- **bound:** At most five source PRs, two failed PROVE runs and three review rounds per PR, and fourteen
+  working days total; one failing source may be explicitly disabled only by owner decision, otherwise
+  the loop exits AT_BOUND without calling the Google plane complete.
+- **exit →:** Write `docs/evidence/recall-universal-ingestion/L1/EXIT.md`, recap and pass ZEN, then
+  trigger L2; any loss, duplicate, receipt, revoke, scope, or privacy failure blocks private-message
+  expansion.
 
-## Loop U2 — Conversation, event, identity, and admission projections
+## L2 — Private communications and Recall Bridge
 
-- **Goal:** Turn canonical evidence into rebuildable cross-source structures that improve retrieval
-  while preventing imported text from becoming trusted instructions.
-- **Prompt:** Red-test deterministic conversation reconstruction, recurring-event instances, contact
-  identity candidates, source-receipted claims, projection invalidation, temporal expansion,
-  contradiction and gap reporting, and task-conditioned memory admission; implement projections as
-  disposable views over canonical records; use agent judgment only for ambiguous resolution and
-  synthesis through the approved staging LiteLLM router and a short-lived scoped virtual key, with
-  deterministic authorization, provenance, and deletion checks before and after it; refactor until
-  every answer claim can be traced to retained canonical evidence.
-- **Accept:** Rebuilding projections twice yields byte-equivalent normalized outputs; edits and
-  tombstones remove stale projection material on the next rebuild; ambiguous identities remain
-  candidates unless evidence crosses the frozen threshold; prompt-injection fixtures achieve zero
-  instruction-following violations; every material answer sentence in the synthetic suite has a
-  valid source receipt; contradiction and insufficient-evidence cases are reported rather than
-  guessed; baseline retrieval does not regress beyond the predeclared noise band.
-- **Bound:** One projection-and-admission PR using synthetic records only; no source API, live personal
-  data, credential flow, installer, or broad ranking rewrite; two failed eval cycles or seven working
-  days triggers a projection design replan without relaxing safety floors.
-- **Exit →:** Write `docs/evidence/recall-universal-ingestion/U2/EXIT.md`, verify the merged commit and
-  full synthetic retrieval/admission matrix, recap and pass ZEN, then pause for Google OAuth consent
-  and begin U3.
+- **goal:** Make the Mac utility safely operate all approved local/private collectors, including
+  iMessage and the human-chosen WhatsApp mode, alongside existing coding and consented-export sources.
+- **prompt:** Red-test a signed Recall Bridge clean install, upgrade, rollback, launch-on-login,
+  sleep/wake, network partition, bounded spool, per-source pause/revoke/forget, Keychain references,
+  content-free status, and uninstall; add the iMessage source as a pinned read-only snapshot/WAL reader
+  with schema fixtures, edits, reactions, authoritative deletes, and attachment descriptors; at an
+  unbounded human gate choose WhatsApp export, experimental linked-device, or disabled, document the
+  risk decision without identity/content, and implement only the chosen read-only mode; route existing
+  ChatGPT/Cowork consented exports and coding collectors through the same lifecycle UI without changing
+  their evidence semantics; run a private clean-Mac E2E and frozen source questions, using one concern
+  per serial PR.
+- **accept:** Clean install, upgrade, rollback, sleep/wake, offline recovery, revoke, forget, and
+  uninstall E2Es pass; the utility never opens iMessage writable, changes SIP, exposes a send surface,
+  or displays content in diagnostics; repeated sync/import and every crash point yield zero duplicate
+  versions for every enabled source; edits/deletes match frozen fixtures without claims based on list
+  absence; lost permissions and revoke fail closed; the WhatsApp decision is explicit and the disabled
+  choice counts only as an owner-approved omission; at least 80% of private frozen questions per
+  enabled source retrieve the expected conversation evidence with valid receipts; signed artifacts
+  verify and public proof remains aggregate/content-free.
+- **bound:** At most four serial PRs, two failed PROVE runs and three review rounds per PR, and fourteen
+  working days total; two failed clean-device E2Es or unresolved WhatsApp/account risk exits AT_BOUND
+  or leaves WhatsApp explicitly disabled rather than adding unsafe fallbacks.
+- **exit →:** Write `docs/evidence/recall-universal-ingestion/L2/EXIT.md`, recap and pass ZEN, pause for
+  X and external-account scope decisions, then trigger L3.
 
-## Loop U3 — Gmail
+## L3 — Social and work expansion
 
-- **Goal:** Continuously ingest the owner's email through the official read-only Gmail API with exact
-  incremental recovery, thread context, and useful private retrieval.
-- **Prompt:** After owner-approved OAuth scope, red-test Gmail history cursors, MIME alternatives,
-  Inbox/Sent direction, labels, threads, attachments as descriptors, expired history recovery, quota
-  backoff, revoke, edits, explicit deletes, duplicate pages, and crash recovery; implement the Gmail
-  adapter behind the v2 conformance contract; shadow-sync a bounded real account privately before
-  enabling searchable mode; refactor only Gmail authority, decoding, and pagination mechanics.
-- **Accept:** Synthetic conformance is fully green; two consecutive full/incremental cycles produce
-  zero duplicate acknowledged versions; every injected crash converges after restart; expired-history
-  recovery neither loses nor duplicates retained records; revoke stops reads and leaves a recoverable
-  spool; edits and authoritative deletes propagate; a private owner-frozen set of five source-bound
-  questions returns the expected evidence class for at least four, with valid receipts for every
-  material claim and no private content in public evidence.
-- **Bound:** One Gmail PR; read-only scope, bounded owner-approved backfill, metadata-only attachments,
-  polling only, and no mail mutation; one week of live shadow observation or two failed E2E cycles,
-  then replan the adapter rather than broadening scope.
-- **Exit →:** Write `docs/evidence/recall-universal-ingestion/U3/EXIT.md` with synthetic commands and
-  aggregate private E2E results, verify the merged commit, recap and pass ZEN, then start U4; any loss,
-  duplicate, receipt, revoke, or privacy failure blocks Calendar work.
+- **goal:** Prove Recall's source factory across the owner's approved social and work systems without
+  introducing a generic recipe runner or broad agent credentials.
+- **prompt:** Freeze an owner-prioritized list from X, Slack, Notion, GitHub, Linear, Telegram, and other
+  official API/export sources; approve X stream types, retention, and cost ceiling first; execute the
+  same source ribbon for no more than six sources, one connector per PR: failing conformance fixtures,
+  exact read scopes, stable native IDs, incremental checkpoint or bounded reconciliation, rate/cost
+  cutoff, edit/delete semantics, revoke, shadow, then private frozen questions; use official APIs,
+  maintained bounded CLIs, or exports behind the closed rail contract, never browser sessions,
+  arbitrary HTTP recipes, runtime plugins, or send/action surfaces; stop adding sources when the
+  approved list or PR budget is exhausted and preserve the rest as measured successor candidates.
+- **accept:** X and every other enabled source pass the full synthetic conformance and safety matrix;
+  two repeated cycles and every crash restart yield zero duplicate versions; read scopes and source
+  writers cannot cross accounts or sources; revoke and cost ceilings stop reads; authoritative
+  edits/deletes invalidate projections within the frozen bound; each source reaches at least 80% on
+  its private frozen evidence questions with receipt resolution 1.00; the factory proves at least two
+  materially different acquisition shapes; all source PRs are merged at verified HEAD; omitted sources
+  are ranked by measured question demand, acquisition method, privacy class, and estimated effort,
+  with no private content in the repository.
+- **bound:** No more than six serial source PRs, two failed PROVE runs and three review rounds per PR,
+  and fifteen working days total; a failing or policy-blocked source is disabled and named in an
+  AT_BOUND/replan verdict rather than weakening the factory or expanding credentials.
+- **exit →:** Write `docs/evidence/recall-universal-ingestion/L3/EXIT.md`, recap and pass ZEN, freeze the
+  final cross-source eval set before inspecting results, then trigger L4.
 
-## Loop U4 — Google Calendar
+## L4 — Cross-source retrieval, operations acceptance, and replan
 
-- **Goal:** Continuously ingest the owner's calendar through the official read-only API with correct
-  recurring instances, cancellation state, timezone semantics, and incremental recovery.
-- **Prompt:** After owner-approved Calendar scope, red-test calendar lists, event pagination, sync
-  tokens, HTTP 410 reconciliation, recurring series and exceptions, all-day/timezone boundaries,
-  attendee identities, cancellations, edits, duplicate pages, quota backoff, revoke, and every crash
-  point; implement one Calendar adapter reusing only already-merged Google authority mechanics;
-  shadow-sync a bounded real horizon privately, then refactor Calendar-specific normalization.
-- **Accept:** The synthetic v2 and calendar fixture matrices are green; two consecutive full/incremental
-  cycles and every injected restart converge with zero duplicate versions; HTTP 410 reconciliation
-  loses no retained event; recurring exceptions and cancellations match frozen fixtures; revoke stops
-  reads safely; at least four of five private owner-frozen questions retrieve the expected event
-  evidence with valid receipts; public evidence contains no event, attendee, selector, query, answer,
-  credential, or identifying infrastructure.
-- **Bound:** One Calendar PR; read-only scope, selected calendars, bounded backfill, polling only, no
-  event mutation, RSVP, or conference action; one week of live shadow observation or two failed E2E
-  cycles, then replan Calendar semantics without changing Gmail.
-- **Exit →:** Write `docs/evidence/recall-universal-ingestion/U4/EXIT.md`, verify synthetic and aggregate
-  private E2E evidence plus the merged commit, recap and pass ZEN, then start U5; any time, recurrence,
-  deletion, receipt, revoke, or privacy failure blocks Contacts work.
-
-## Loop U5 — Google Contacts
-
-- **Goal:** Ingest authoritative owner contact identities through the official read-only People API
-  without silently merging ambiguous people.
-- **Prompt:** After owner-approved Contacts scope, red-test pagination, sync tokens, names, emails,
-  phones, organizations, self identity, edits, explicit deletes, duplicate pages, expired-token full
-  reconciliation, quota backoff, revoke, crash recovery, exact-identifier merge, ambiguous-name
-  candidates, split, and owner correction; implement one Contacts adapter feeding the already-merged
-  identity projection; shadow-sync privately, then refactor only stable contact normalization and
-  candidate generation.
-- **Accept:** Synthetic v2, contact, and identity matrices are green; two repeated syncs and every crash
-  restart yield zero duplicate versions; edits and authoritative deletes invalidate stale identities;
-  exact approved identifiers merge deterministically while name-only matches remain candidates;
-  revoke fails closed; the owner privately verifies a frozen sample of candidate/merge outcomes with
-  zero silent false merge; public evidence contains no name, address, phone, organization, selector,
-  query, answer, credential, or identifying infrastructure.
-- **Bound:** One Contacts PR; read-only scope, no contact mutation, no model-only automatic merge, and
-  no enrichment from external people-search services; one week of shadow observation or two failed
-  E2E cycles, then replan identity thresholds without changing Gmail or Calendar.
-- **Exit →:** Write `docs/evidence/recall-universal-ingestion/U5/EXIT.md`, verify synthetic and aggregate
-  private E2E evidence plus the merged commit, recap and pass ZEN, then start U6; any identity,
-  deletion, receipt, revoke, or privacy failure blocks iMessage work.
-
-## Loop U6 — Read-only iMessage collector
-
-- **Goal:** Reliably ingest iMessage history from the authoritative Mac without weakening macOS or
-  adding message-send capability.
-- **Prompt:** Red-test a pinned read-only snapshot reader against synthetic Messages databases for
-  schema variants, WAL consistency, participants, group threads, attributed text, attachments as
-  descriptors, edits, reactions, deletions, cursor overlap, sleep/wake, database replacement, and
-  mid-batch crash; implement the source-local adapter and privacy-before-spool path; package it only
-  after the owner grants Full Disk Access to the signed utility; shadow-sync a bounded real horizon
-  privately, then refactor version adapters behind stable canonical records.
-- **Accept:** The schema fixture matrix and v2 conformance suite are green; the collector never opens
-  the database writable and exposes no send path; two repeated syncs and every crash restart converge
-  with zero duplicate versions; edits, reactions, and authoritative deletes match frozen fixtures;
-  revoke or lost Full Disk Access fails closed with content-free status; at least four of five private
-  owner-frozen iMessage questions retrieve the expected conversation evidence with valid receipts;
-  public artifacts contain no database sample, message, identity, private path, query, or answer.
-- **Bound:** One iMessage PR; source Mac only, signed utility only, read-only database access, bounded
-  backfill, attachment descriptors only, no SIP changes, no injection, no automation, and no sending;
-  two failed live E2E cycles or seven working days triggers a schema/permissions replan.
-- **Exit →:** Write `docs/evidence/recall-universal-ingestion/U6/EXIT.md`, verify synthetic and aggregate
-  private E2E evidence plus the merged commit, recap and pass ZEN, then stop at the U7 WhatsApp method
-  gate; any writable access, privacy leak, or delivery ambiguity returns to U6 red.
-
-## Loop U7 — Human-chosen WhatsApp ingestion
-
-- **Goal:** Add useful WhatsApp evidence using only the ingestion method whose account, policy, and
-  operational risks the owner explicitly accepts.
-- **Prompt:** Before code, present two bounded choices: deterministic owner exports, or an experimental
-  linked-device reader with account-risk and upstream-breakage warnings; record the decision without
-  credentials or identity; red-test the chosen method for stable chats/messages, participants,
-  quoted replies, edits, revocations, disappearing-message limitations, media descriptors, duplicate
-  exports/pages, restart replay, revoke, and unsupported deletion claims; implement read-only ingest,
-  shadow privately, and refactor format/version handling behind the same canonical contract.
-- **Accept:** No implementation starts without the recorded owner choice; the selected method passes
-  its synthetic fixture and v2 conformance matrices; two repeated imports/syncs and crash recovery
-  yield zero duplicate versions; revoked or disappearing content is represented only when the source
-  provides authoritative evidence, otherwise Recall reports the gap; no send path exists; at least
-  four of five private owner-frozen questions retrieve expected chat evidence with valid receipts;
-  public evidence contains no chat/export content, account identity, query, answer, or credential.
-- **Bound:** One WhatsApp PR for exactly one approved method; read-only, bounded horizon, no media bytes,
-  no browser scraping, no reverse-engineered credential extraction, no bypass of upstream controls,
-  and no claim of unsupported completeness; two failed live E2E cycles or seven working days returns
-  to the human method gate instead of adding fallback paths.
-- **Exit →:** Write `docs/evidence/recall-universal-ingestion/U7/EXIT.md`, verify method-decision receipt,
-  synthetic tests, aggregate private E2E, and merged commit, recap and pass ZEN, then stop at the U8 X
-  scope gate; owner rejection exits cleanly with WhatsApp disabled and continues only by explicit
-  approval to omit the source.
-
-## Loop U8 — Official X ingestion with bounded scope
-
-- **Goal:** Ingest the approved parts of the owner's X activity through the official API with explicit
-  retention, compliance, and cost controls.
-- **Prompt:** Before code, have the owner choose among own posts, mentions, bookmarks, and a rolling
-  home timeline, plus backfill horizon, retention, and spending ceiling; red-test official OAuth,
-  pagination, since cursors, post/thread identity, edits when exposed, deletes/compliance events,
-  quota exhaustion, cost cutoff, stream gaps, restart replay, and revoke; implement only selected
-  streams, shadow privately, and refactor common timeline mechanics without pretending observations
-  are authoritative facts about people.
-- **Accept:** The approved scope is machine-readable and defaults closed; synthetic conformance,
-  pagination, quota, deletion, and cost-cutoff tests are green; two repeated syncs and crash recovery
-  produce zero duplicate versions; crossing the spending ceiling stops reads safely; revoke closes
-  authority; deletion/compliance signals invalidate projections within the frozen bound; at least four
-  of five private owner-frozen questions retrieve expected X evidence with valid receipts; no private
-  content, handle, query, answer, token, or identifying infrastructure appears in public evidence.
-- **Bound:** One X PR using official documented APIs only; read-only scopes, polling, selected streams,
-  bounded retention and budget, no scraping, no browser session reuse, no public webhook ingress, and
-  no posting; two failed live E2E cycles or seven working days triggers a scope/cost replan.
-- **Exit →:** Write `docs/evidence/recall-universal-ingestion/U8/EXIT.md`, verify synthetic and aggregate
-  private E2E evidence plus merged commit, recap and pass ZEN, then start U9; policy, deletion, cost,
-  receipt, or privacy failure keeps X disabled.
-
-## Loop U9 — Recall Bridge Mac utility and lifecycle controls
-
-- **Goal:** Give one owner a coherent Mac utility that installs, configures, observes, pauses, revokes,
-  repairs, and removes the approved collectors without exposing content in its control plane.
-- **Prompt:** Red-test clean install, upgrade, rollback, launch-on-login, sleep/wake, network loss,
-  source permissions, Keychain references, remote Brain authority, spool pressure, per-source pause,
-  revoke, forget, uninstall, and content-free diagnostics; implement a signed Recall Bridge around the
-  existing supervisor and closed connector registry; run install/upgrade/uninstall E2E on a clean Mac
-  user after explicit permission approval; refactor duplicated lifecycle code without moving source
-  content into UI, logs, receipts, or support bundles.
-- **Accept:** A clean-device E2E enables each approved connector without hand-editing config; sleep,
-  restart, offline spool, and upgrade converge without loss or duplicate versions; every source can be
-  independently paused and revoked; forget removes its local staged state and requests source-scoped
-  Brain deletion with a receipt; uninstall removes agents and credentials references; status and
-  diagnostics pass the content-free snapshot suite; the signed artifact verifies and rollback restores
-  the previous working release.
-- **Bound:** One utility/lifecycle PR with no new source adapter or retrieval change; single-owner alpha,
-  existing Tailnet transport, no public service, no secret display/export, and no automatic permission
-  escalation; two failed clean-device E2Es or seven working days triggers an installer replan.
-- **Exit →:** Write `docs/evidence/recall-universal-ingestion/U9/EXIT.md`, verify clean install, upgrade,
-  revoke, forget, rollback, synthetic safety, and merged commit, recap and pass ZEN, then freeze the U10
-  private eval set; any lifecycle loss or content-bearing diagnostic blocks release.
-
-## Loop U10 — Cross-source natural-language retrieval
-
-- **Goal:** Make questions about people, commitments, decisions, chronology, and follow-ups retrieve
-  the right evidence across the newly connected sources with calibrated gaps and citations.
-- **Prompt:** Before ranking changes, have the owner freeze a private eval set spanning single-source,
-  multi-source, temporal, person-resolution, contradictory, deleted, and insufficient-evidence cases;
-  record only aggregate cell IDs publicly; red-run it and the synthetic suite; improve query planning,
-  source selection, graph traversal, temporal/conversation expansion, reranking, and admission one
-  losing cluster at a time; preserve canonical evidence and deterministic authorization; refactor only
-  after each cluster is green and rerun all prior cells to detect regressions.
-- **Accept:** Every synthetic privacy, authorization, injection, deletion, contradiction, and citation
-  cell passes; every material claim has at least one valid canonical receipt; source/date/person filters
-  have zero authorization escapes; the private frozen set reaches at least 85% expected-evidence recall
-  and 80% owner-rated usefulness, improves by at least ten percentage points over U0 on multi-source
-  cells, and has no source-family regression greater than five points; repeated runs with frozen data
-  select the same evidence set; public evidence exposes only aggregate scores and content-free cell IDs.
-- **Bound:** One retrieval PR, no connector, credential, schema, ingestion, UI, or source-retention
-  change; at most three ranking iterations or ten working days, with each iteration closing one losing
-  cluster; if the target remains red, replan from error classes rather than tune to private wording.
-- **Exit →:** Write `docs/evidence/recall-universal-ingestion/U10/EXIT.md`, verify the full synthetic and
-  aggregate private matrices plus merged commit, recap and pass ZEN, then start U11; a safety-floor or
-  citation regression immediately reverts the candidate and returns to the last green iteration.
-
-## Loop U11 — Owner acceptance, operations drill, and successor replan
-
-- **Goal:** Prove the system works end to end across devices for the owner, then decide release and the
-  next source expansion from measured gaps rather than connector novelty.
-- **Prompt:** Run a private seven-day soak; execute clean-device install, source authorization, bounded
-  backfill, continuous sync, sleep/wake, network partition, credential revoke, restore, source forget,
-  deletion propagation, cross-device query, and disaster-recovery drills; rerun the frozen evals without
-  code changes; review source coverage and losing cells with the owner; draft a successor RDD/chain for
-  only the highest-value gaps, considering Drive, Slack, Notion, GitHub, Linear, Notes, browser history,
-  selected files, Photos metadata, Telegram, and attachment text under separate source loops.
-- **Accept:** Seven days complete with no unresolved safety-floor violation, data-loss incident,
-  duplicate storm, stuck cursor, unbounded spool, or public exposure; bounded ingestion lag meets the
-  per-source SLO for at least 99% of observed intervals; restore reproduces the acknowledged record and
-  projection counts; revoke and forget complete within their frozen bounds; all U10 eval floors remain
-  green; the owner can retrieve cited evidence from a second approved device; the successor document
-  maps every proposed source to measured demand, privacy class, official acquisition method, and hard
-  E2E exit, and the owner records an explicit accept, reject, or revise decision.
-- **Bound:** Operations, acceptance, and planning only; no production code, connector, ranking, scope,
-  retention, or credential expansion; one seven-day soak plus one remediation/restart allowance; any
-  second soak failure ends the chain red and requires a new remediation loop.
-- **Exit →:** Write `docs/evidence/recall-universal-ingestion/U11/EXIT.md`, verify the deployed release
-  commit and content-free acceptance receipts, recap and pass ZEN, then stop for the final human gate;
-  release only on explicit owner acceptance, otherwise execute the owner-approved remediation or
-  successor chain without silently extending this one.
+- **goal:** Prove end-to-end natural-language recall across devices and sources, then obtain an owner
+  release verdict and cut the next chain only from measured gaps.
+- **prompt:** Freeze a private eval set spanning people, commitments, decisions, chronology,
+  follow-ups, single-source, multi-source, temporal, contradictory, deleted, and insufficient-evidence
+  cases; red-run it before ranking changes; improve query planning, source selection, identity/temporal
+  graph traversal, conversation expansion, reranking, admission, citations, contradiction, and gap
+  reporting one losing cluster at a time through the approved router; rerun all prior safety and source
+  cells after each change; then run a private seven-day soak covering cross-device query, continuous
+  sync, sleep/wake, network loss, credential revoke, deletion propagation, source forget, backup
+  restore, and disaster recovery; draft a successor RDD/chain for only losing cells and deferred
+  sources such as Notes, browser history, Photos metadata, selected files, attachments, or remaining
+  work systems, and stop for owner review.
+- **accept:** Every synthetic privacy, authorization, injection, deletion, contradiction, and citation
+  cell passes; receipt resolution and deterministic repeated evidence selection are 1.00; the private
+  frozen set reaches at least 85% expected-evidence recall and 80% owner-rated usefulness, improves
+  multi-source recall by at least ten points over L0, and has no source-family regression greater than
+  five points; the seven-day soak has no unresolved safety incident, data loss, duplicate storm, stuck
+  cursor, unbounded spool, or public exposure, meets per-source lag SLO for 99% of observed intervals,
+  and restores canonical/projection parity; a second approved device retrieves cited evidence; the
+  successor document maps each proposal to a losing eval cell, safe acquisition method, privacy class,
+  and hard E2E exit; the owner records accept, reject, or revise.
+- **bound:** At most three ranking PRs, two failed PROVE runs and three review rounds per PR, one
+  seven-day soak plus one remediation restart, and two successor drafts; owner sign-off waits unbounded
+  by design, while a second soak failure exits AT_BOUND and stops release.
+- **exit →:** Write `docs/evidence/recall-universal-ingestion/L4/EXIT.md`, recap and pass ZEN, verify the
+  deployed release commit and content-free verdict at HEAD, then stop at the final human gate; release
+  only on explicit owner acceptance, otherwise start the approved remediation/successor chain.
 
 ## Review decision
 
-Approval of this document authorizes only the ordered BUILD loops and their bounded proof work. It
-does not authorize new external accounts, broader OAuth scopes, retention expansion, risky WhatsApp
-or X methods, public ingress, content-bearing public evidence, or any source named only in U11's
-successor candidates.
+Approving this document authorizes only these five bounded outcomes and their serial one-concern PRs.
+It does not authorize broad OAuth presets, write/send tools, public Brain ingress, attachment content,
+experimental WhatsApp, durable home-timeline retention, or additional accounts without their named
+human gates.

--- a/docs/LOOP_CHAIN_RECALL_UNIVERSAL_INGESTION_2026-07-16.md
+++ b/docs/LOOP_CHAIN_RECALL_UNIVERSAL_INGESTION_2026-07-16.md
@@ -1,0 +1,352 @@
+# Recall Universal Ingestion — Cascade Loop Chain
+
+**Status:** proposed for review
+**Mode:** PLAN; BUILD begins only after owner approval
+**Date:** 2026-07-16
+**RDD:** `docs/rdd/RECALL_UNIVERSAL_INGESTION_2026-07-16.md`
+
+## Objective
+
+Make Recall a safe, owner-controlled context plane for personal communications, schedule, contacts,
+social activity, and local Mac sources. Every connector must preserve source receipts, survive replay,
+respect edits and deletions, and improve natural-language retrieval without leaking private proof into
+the public repository.
+
+This is a TDD Cascade. Every loop follows red -> green -> refactor, changes one concern, ends at a
+hard eval or E2E gate, writes a content-free `EXIT.md`, applies the ZEN check, and merges before its
+dependent loop starts. A passing unit suite alone never closes a source loop.
+
+## Operating contract
+
+- **Pacing:** autonomous between declared human gates. Credentials, external consent, risky source
+  methods, retention expansion, and final acceptance remain human decisions.
+- **Public evidence:** synthetic fixtures, schemas, commands, aggregate counts, pass/fail results,
+  hashes of synthetic fixtures, and redacted deployment attestations only.
+- **Private evidence:** real prompts, answers, messages, event text, social content, identities,
+  exports, database samples, credentials, machine paths, and identifying infrastructure remain in
+  approved private runtime state and never enter commits, PRs, logs, screenshots, or `EXIT.md`.
+- **Safety floors:** secret leaks = 0; raw private records in public artifacts = 0; unauthorized source
+  reads = 0; cross-source authorization escapes = 0; cursor advancement before acknowledgement = 0;
+  unsupported deletion claims = 0; arbitrary runtime connector loading = 0.
+- **Determinism floor:** replaying the same retained source revision produces exactly one canonical
+  version, and restarting after every injected crash point produces the same acknowledged result.
+- **Exit convention:** `docs/evidence/recall-universal-ingestion/<loop>/EXIT.md`. Each exit maps every
+  acceptance criterion to a reproducible command and content-free result, records the ZEN check, and
+  names the verified merge commit and next loop.
+- **No drift:** after each exit, run Recall's recap procedure against the objective, RDD, safety floors,
+  and losing eval cells. Scope changes require an RDD amendment and owner approval.
+
+## Dependency graph
+
+```mermaid
+flowchart LR
+    U0[U0 Baseline and threat gate] --> U1[U1 Connector contract v2]
+    U1 --> U2[U2 Projections and admission]
+    U2 --> U3[U3 Gmail]
+    U3 --> U4[U4 Google Calendar]
+    U4 --> U5[U5 Google Contacts]
+    U5 --> U6[U6 iMessage]
+    U6 --> U7{U7 WhatsApp method gate}
+    U7 --> U8{U8 X scope gate}
+    U8 --> U9[U9 Recall Bridge utility]
+    U9 --> U10[U10 Cross-source retrieval]
+    U10 --> U11{U11 Owner acceptance and replan}
+```
+
+| Task | `blockedBy` | Human gate |
+|---|---|---|
+| U0 | — | approve RDD and chain before BUILD |
+| U1 | U0 | — |
+| U2 | U1 | — |
+| U3 | U2 | approve Google OAuth consent and Gmail scope |
+| U4 | U3 | approve Calendar scope |
+| U5 | U4 | approve Contacts scope |
+| U6 | U5 | grant macOS Full Disk Access to the signed utility |
+| U7 | U6 | choose export-only or experimental linked-device ingestion |
+| U8 | U7 | approve X streams, retention, and spending cap |
+| U9 | U8 | approve installer permissions before real-device E2E |
+| U10 | U9 | freeze private eval questions and expected evidence classes |
+| U11 | U10 | accept release or approve the successor chain |
+
+## Loop U0 — Baseline, harness, and threat gate
+
+- **Goal:** Freeze the current retrieval baseline and prove the evaluation, privacy, storage, and
+  evidence boundaries before any new personal source is connected.
+- **Prompt:** Write failing tests first for the connector-v2 invariants and content-free evidence
+  contract; add synthetic conversations, events, contacts, posts, edits, tombstones, duplicate pages,
+  poison instructions, and crash points; run the existing retrieval suite unchanged to record the
+  pre-change scorecard; produce content-free attestations for encrypted database storage, encrypted
+  backups, restore, filesystem modes, Tailnet-only reachability, and source-scoped writers; refactor
+  only the harness and fixtures, not production ingestion or retrieval behavior.
+- **Accept:** The checked-in synthetic suite fails for the intended missing capabilities before the
+  harness change and passes after it; the unchanged baseline scorecard is reproducible on two runs;
+  every safety floor is measured; the deployment attestation has no unknown or failing control; a
+  repository scan finds zero secret-shaped values, raw/private samples, identifying paths, or private
+  query/answer text in the diff and evidence tree.
+- **Bound:** One PR limited to synthetic fixtures, eval harnesses, threat model, and content-free
+  attestations; no connector, schema, ranking, live credential, or production behavior change; two
+  implementation attempts or five working days, then replan the harness rather than weakening a gate.
+- **Exit →:** Write `docs/evidence/recall-universal-ingestion/U0/EXIT.md` mapping every criterion to
+  commands and results, verify the merged commit on the target branch, recap and pass ZEN, then start
+  U1; any failed storage, privacy, reachability, or repository-safety control blocks all later loops.
+
+## Loop U1 — Closed connector contract v2
+
+- **Goal:** Add a typed, capability-declared connector contract while preserving existing connector
+  behavior and forbidding arbitrary runtime code loading.
+- **Prompt:** Red-test manifest validation, typed canonical records, exact authority slots, static
+  preview, backward-compatible v1 adaptation, ACK-gated checkpoints, edit revisions, tombstones,
+  restart replay, and rejection of unknown factories or executable configuration; implement the
+  smallest closed registry and compatibility layer; refactor duplicate connector mechanics into the
+  conformance harness without moving policy into connector-specific branches.
+- **Accept:** All bundled legacy connectors pass the old suites unchanged and the new conformance
+  suite; every v2 record kind round-trips deterministically; duplicate delivery across two pages and
+  two restarts yields one acknowledged version; injected failures at every checkpoint never advance
+  the cursor early; edit and explicit-delete fixtures create the expected revision and tombstone;
+  attempts to load entry points, imports, commands, or current-directory plugins all fail closed.
+- **Bound:** One contract-and-registry PR with migrations and synthetic tests; no new external source,
+  live credential, projection, retrieval ranking, UI, or public endpoint; two failed green attempts or
+  seven working days triggers a smaller contract amendment reviewed against the RDD.
+- **Exit →:** Write `docs/evidence/recall-universal-ingestion/U1/EXIT.md`, verify all legacy and v2
+  conformance cells plus the merged commit, recap and pass ZEN, then start U2; any compatibility,
+  replay, authorization, or closed-registry failure returns to U1 red.
+
+## Loop U2 — Conversation, event, identity, and admission projections
+
+- **Goal:** Turn canonical evidence into rebuildable cross-source structures that improve retrieval
+  while preventing imported text from becoming trusted instructions.
+- **Prompt:** Red-test deterministic conversation reconstruction, recurring-event instances, contact
+  identity candidates, source-receipted claims, projection invalidation, temporal expansion,
+  contradiction and gap reporting, and task-conditioned memory admission; implement projections as
+  disposable views over canonical records; use agent judgment only for ambiguous resolution and
+  synthesis through the approved staging LiteLLM router and a short-lived scoped virtual key, with
+  deterministic authorization, provenance, and deletion checks before and after it; refactor until
+  every answer claim can be traced to retained canonical evidence.
+- **Accept:** Rebuilding projections twice yields byte-equivalent normalized outputs; edits and
+  tombstones remove stale projection material on the next rebuild; ambiguous identities remain
+  candidates unless evidence crosses the frozen threshold; prompt-injection fixtures achieve zero
+  instruction-following violations; every material answer sentence in the synthetic suite has a
+  valid source receipt; contradiction and insufficient-evidence cases are reported rather than
+  guessed; baseline retrieval does not regress beyond the predeclared noise band.
+- **Bound:** One projection-and-admission PR using synthetic records only; no source API, live personal
+  data, credential flow, installer, or broad ranking rewrite; two failed eval cycles or seven working
+  days triggers a projection design replan without relaxing safety floors.
+- **Exit →:** Write `docs/evidence/recall-universal-ingestion/U2/EXIT.md`, verify the merged commit and
+  full synthetic retrieval/admission matrix, recap and pass ZEN, then pause for Google OAuth consent
+  and begin U3.
+
+## Loop U3 — Gmail
+
+- **Goal:** Continuously ingest the owner's email through the official read-only Gmail API with exact
+  incremental recovery, thread context, and useful private retrieval.
+- **Prompt:** After owner-approved OAuth scope, red-test Gmail history cursors, MIME alternatives,
+  Inbox/Sent direction, labels, threads, attachments as descriptors, expired history recovery, quota
+  backoff, revoke, edits, explicit deletes, duplicate pages, and crash recovery; implement the Gmail
+  adapter behind the v2 conformance contract; shadow-sync a bounded real account privately before
+  enabling searchable mode; refactor only Gmail authority, decoding, and pagination mechanics.
+- **Accept:** Synthetic conformance is fully green; two consecutive full/incremental cycles produce
+  zero duplicate acknowledged versions; every injected crash converges after restart; expired-history
+  recovery neither loses nor duplicates retained records; revoke stops reads and leaves a recoverable
+  spool; edits and authoritative deletes propagate; a private owner-frozen set of five source-bound
+  questions returns the expected evidence class for at least four, with valid receipts for every
+  material claim and no private content in public evidence.
+- **Bound:** One Gmail PR; read-only scope, bounded owner-approved backfill, metadata-only attachments,
+  polling only, and no mail mutation; one week of live shadow observation or two failed E2E cycles,
+  then replan the adapter rather than broadening scope.
+- **Exit →:** Write `docs/evidence/recall-universal-ingestion/U3/EXIT.md` with synthetic commands and
+  aggregate private E2E results, verify the merged commit, recap and pass ZEN, then start U4; any loss,
+  duplicate, receipt, revoke, or privacy failure blocks Calendar work.
+
+## Loop U4 — Google Calendar
+
+- **Goal:** Continuously ingest the owner's calendar through the official read-only API with correct
+  recurring instances, cancellation state, timezone semantics, and incremental recovery.
+- **Prompt:** After owner-approved Calendar scope, red-test calendar lists, event pagination, sync
+  tokens, HTTP 410 reconciliation, recurring series and exceptions, all-day/timezone boundaries,
+  attendee identities, cancellations, edits, duplicate pages, quota backoff, revoke, and every crash
+  point; implement one Calendar adapter reusing only already-merged Google authority mechanics;
+  shadow-sync a bounded real horizon privately, then refactor Calendar-specific normalization.
+- **Accept:** The synthetic v2 and calendar fixture matrices are green; two consecutive full/incremental
+  cycles and every injected restart converge with zero duplicate versions; HTTP 410 reconciliation
+  loses no retained event; recurring exceptions and cancellations match frozen fixtures; revoke stops
+  reads safely; at least four of five private owner-frozen questions retrieve the expected event
+  evidence with valid receipts; public evidence contains no event, attendee, selector, query, answer,
+  credential, or identifying infrastructure.
+- **Bound:** One Calendar PR; read-only scope, selected calendars, bounded backfill, polling only, no
+  event mutation, RSVP, or conference action; one week of live shadow observation or two failed E2E
+  cycles, then replan Calendar semantics without changing Gmail.
+- **Exit →:** Write `docs/evidence/recall-universal-ingestion/U4/EXIT.md`, verify synthetic and aggregate
+  private E2E evidence plus the merged commit, recap and pass ZEN, then start U5; any time, recurrence,
+  deletion, receipt, revoke, or privacy failure blocks Contacts work.
+
+## Loop U5 — Google Contacts
+
+- **Goal:** Ingest authoritative owner contact identities through the official read-only People API
+  without silently merging ambiguous people.
+- **Prompt:** After owner-approved Contacts scope, red-test pagination, sync tokens, names, emails,
+  phones, organizations, self identity, edits, explicit deletes, duplicate pages, expired-token full
+  reconciliation, quota backoff, revoke, crash recovery, exact-identifier merge, ambiguous-name
+  candidates, split, and owner correction; implement one Contacts adapter feeding the already-merged
+  identity projection; shadow-sync privately, then refactor only stable contact normalization and
+  candidate generation.
+- **Accept:** Synthetic v2, contact, and identity matrices are green; two repeated syncs and every crash
+  restart yield zero duplicate versions; edits and authoritative deletes invalidate stale identities;
+  exact approved identifiers merge deterministically while name-only matches remain candidates;
+  revoke fails closed; the owner privately verifies a frozen sample of candidate/merge outcomes with
+  zero silent false merge; public evidence contains no name, address, phone, organization, selector,
+  query, answer, credential, or identifying infrastructure.
+- **Bound:** One Contacts PR; read-only scope, no contact mutation, no model-only automatic merge, and
+  no enrichment from external people-search services; one week of shadow observation or two failed
+  E2E cycles, then replan identity thresholds without changing Gmail or Calendar.
+- **Exit →:** Write `docs/evidence/recall-universal-ingestion/U5/EXIT.md`, verify synthetic and aggregate
+  private E2E evidence plus the merged commit, recap and pass ZEN, then start U6; any identity,
+  deletion, receipt, revoke, or privacy failure blocks iMessage work.
+
+## Loop U6 — Read-only iMessage collector
+
+- **Goal:** Reliably ingest iMessage history from the authoritative Mac without weakening macOS or
+  adding message-send capability.
+- **Prompt:** Red-test a pinned read-only snapshot reader against synthetic Messages databases for
+  schema variants, WAL consistency, participants, group threads, attributed text, attachments as
+  descriptors, edits, reactions, deletions, cursor overlap, sleep/wake, database replacement, and
+  mid-batch crash; implement the source-local adapter and privacy-before-spool path; package it only
+  after the owner grants Full Disk Access to the signed utility; shadow-sync a bounded real horizon
+  privately, then refactor version adapters behind stable canonical records.
+- **Accept:** The schema fixture matrix and v2 conformance suite are green; the collector never opens
+  the database writable and exposes no send path; two repeated syncs and every crash restart converge
+  with zero duplicate versions; edits, reactions, and authoritative deletes match frozen fixtures;
+  revoke or lost Full Disk Access fails closed with content-free status; at least four of five private
+  owner-frozen iMessage questions retrieve the expected conversation evidence with valid receipts;
+  public artifacts contain no database sample, message, identity, private path, query, or answer.
+- **Bound:** One iMessage PR; source Mac only, signed utility only, read-only database access, bounded
+  backfill, attachment descriptors only, no SIP changes, no injection, no automation, and no sending;
+  two failed live E2E cycles or seven working days triggers a schema/permissions replan.
+- **Exit →:** Write `docs/evidence/recall-universal-ingestion/U6/EXIT.md`, verify synthetic and aggregate
+  private E2E evidence plus the merged commit, recap and pass ZEN, then stop at the U7 WhatsApp method
+  gate; any writable access, privacy leak, or delivery ambiguity returns to U6 red.
+
+## Loop U7 — Human-chosen WhatsApp ingestion
+
+- **Goal:** Add useful WhatsApp evidence using only the ingestion method whose account, policy, and
+  operational risks the owner explicitly accepts.
+- **Prompt:** Before code, present two bounded choices: deterministic owner exports, or an experimental
+  linked-device reader with account-risk and upstream-breakage warnings; record the decision without
+  credentials or identity; red-test the chosen method for stable chats/messages, participants,
+  quoted replies, edits, revocations, disappearing-message limitations, media descriptors, duplicate
+  exports/pages, restart replay, revoke, and unsupported deletion claims; implement read-only ingest,
+  shadow privately, and refactor format/version handling behind the same canonical contract.
+- **Accept:** No implementation starts without the recorded owner choice; the selected method passes
+  its synthetic fixture and v2 conformance matrices; two repeated imports/syncs and crash recovery
+  yield zero duplicate versions; revoked or disappearing content is represented only when the source
+  provides authoritative evidence, otherwise Recall reports the gap; no send path exists; at least
+  four of five private owner-frozen questions retrieve expected chat evidence with valid receipts;
+  public evidence contains no chat/export content, account identity, query, answer, or credential.
+- **Bound:** One WhatsApp PR for exactly one approved method; read-only, bounded horizon, no media bytes,
+  no browser scraping, no reverse-engineered credential extraction, no bypass of upstream controls,
+  and no claim of unsupported completeness; two failed live E2E cycles or seven working days returns
+  to the human method gate instead of adding fallback paths.
+- **Exit →:** Write `docs/evidence/recall-universal-ingestion/U7/EXIT.md`, verify method-decision receipt,
+  synthetic tests, aggregate private E2E, and merged commit, recap and pass ZEN, then stop at the U8 X
+  scope gate; owner rejection exits cleanly with WhatsApp disabled and continues only by explicit
+  approval to omit the source.
+
+## Loop U8 — Official X ingestion with bounded scope
+
+- **Goal:** Ingest the approved parts of the owner's X activity through the official API with explicit
+  retention, compliance, and cost controls.
+- **Prompt:** Before code, have the owner choose among own posts, mentions, bookmarks, and a rolling
+  home timeline, plus backfill horizon, retention, and spending ceiling; red-test official OAuth,
+  pagination, since cursors, post/thread identity, edits when exposed, deletes/compliance events,
+  quota exhaustion, cost cutoff, stream gaps, restart replay, and revoke; implement only selected
+  streams, shadow privately, and refactor common timeline mechanics without pretending observations
+  are authoritative facts about people.
+- **Accept:** The approved scope is machine-readable and defaults closed; synthetic conformance,
+  pagination, quota, deletion, and cost-cutoff tests are green; two repeated syncs and crash recovery
+  produce zero duplicate versions; crossing the spending ceiling stops reads safely; revoke closes
+  authority; deletion/compliance signals invalidate projections within the frozen bound; at least four
+  of five private owner-frozen questions retrieve expected X evidence with valid receipts; no private
+  content, handle, query, answer, token, or identifying infrastructure appears in public evidence.
+- **Bound:** One X PR using official documented APIs only; read-only scopes, polling, selected streams,
+  bounded retention and budget, no scraping, no browser session reuse, no public webhook ingress, and
+  no posting; two failed live E2E cycles or seven working days triggers a scope/cost replan.
+- **Exit →:** Write `docs/evidence/recall-universal-ingestion/U8/EXIT.md`, verify synthetic and aggregate
+  private E2E evidence plus merged commit, recap and pass ZEN, then start U9; policy, deletion, cost,
+  receipt, or privacy failure keeps X disabled.
+
+## Loop U9 — Recall Bridge Mac utility and lifecycle controls
+
+- **Goal:** Give one owner a coherent Mac utility that installs, configures, observes, pauses, revokes,
+  repairs, and removes the approved collectors without exposing content in its control plane.
+- **Prompt:** Red-test clean install, upgrade, rollback, launch-on-login, sleep/wake, network loss,
+  source permissions, Keychain references, remote Brain authority, spool pressure, per-source pause,
+  revoke, forget, uninstall, and content-free diagnostics; implement a signed Recall Bridge around the
+  existing supervisor and closed connector registry; run install/upgrade/uninstall E2E on a clean Mac
+  user after explicit permission approval; refactor duplicated lifecycle code without moving source
+  content into UI, logs, receipts, or support bundles.
+- **Accept:** A clean-device E2E enables each approved connector without hand-editing config; sleep,
+  restart, offline spool, and upgrade converge without loss or duplicate versions; every source can be
+  independently paused and revoked; forget removes its local staged state and requests source-scoped
+  Brain deletion with a receipt; uninstall removes agents and credentials references; status and
+  diagnostics pass the content-free snapshot suite; the signed artifact verifies and rollback restores
+  the previous working release.
+- **Bound:** One utility/lifecycle PR with no new source adapter or retrieval change; single-owner alpha,
+  existing Tailnet transport, no public service, no secret display/export, and no automatic permission
+  escalation; two failed clean-device E2Es or seven working days triggers an installer replan.
+- **Exit →:** Write `docs/evidence/recall-universal-ingestion/U9/EXIT.md`, verify clean install, upgrade,
+  revoke, forget, rollback, synthetic safety, and merged commit, recap and pass ZEN, then freeze the U10
+  private eval set; any lifecycle loss or content-bearing diagnostic blocks release.
+
+## Loop U10 — Cross-source natural-language retrieval
+
+- **Goal:** Make questions about people, commitments, decisions, chronology, and follow-ups retrieve
+  the right evidence across the newly connected sources with calibrated gaps and citations.
+- **Prompt:** Before ranking changes, have the owner freeze a private eval set spanning single-source,
+  multi-source, temporal, person-resolution, contradictory, deleted, and insufficient-evidence cases;
+  record only aggregate cell IDs publicly; red-run it and the synthetic suite; improve query planning,
+  source selection, graph traversal, temporal/conversation expansion, reranking, and admission one
+  losing cluster at a time; preserve canonical evidence and deterministic authorization; refactor only
+  after each cluster is green and rerun all prior cells to detect regressions.
+- **Accept:** Every synthetic privacy, authorization, injection, deletion, contradiction, and citation
+  cell passes; every material claim has at least one valid canonical receipt; source/date/person filters
+  have zero authorization escapes; the private frozen set reaches at least 85% expected-evidence recall
+  and 80% owner-rated usefulness, improves by at least ten percentage points over U0 on multi-source
+  cells, and has no source-family regression greater than five points; repeated runs with frozen data
+  select the same evidence set; public evidence exposes only aggregate scores and content-free cell IDs.
+- **Bound:** One retrieval PR, no connector, credential, schema, ingestion, UI, or source-retention
+  change; at most three ranking iterations or ten working days, with each iteration closing one losing
+  cluster; if the target remains red, replan from error classes rather than tune to private wording.
+- **Exit →:** Write `docs/evidence/recall-universal-ingestion/U10/EXIT.md`, verify the full synthetic and
+  aggregate private matrices plus merged commit, recap and pass ZEN, then start U11; a safety-floor or
+  citation regression immediately reverts the candidate and returns to the last green iteration.
+
+## Loop U11 — Owner acceptance, operations drill, and successor replan
+
+- **Goal:** Prove the system works end to end across devices for the owner, then decide release and the
+  next source expansion from measured gaps rather than connector novelty.
+- **Prompt:** Run a private seven-day soak; execute clean-device install, source authorization, bounded
+  backfill, continuous sync, sleep/wake, network partition, credential revoke, restore, source forget,
+  deletion propagation, cross-device query, and disaster-recovery drills; rerun the frozen evals without
+  code changes; review source coverage and losing cells with the owner; draft a successor RDD/chain for
+  only the highest-value gaps, considering Drive, Slack, Notion, GitHub, Linear, Notes, browser history,
+  selected files, Photos metadata, Telegram, and attachment text under separate source loops.
+- **Accept:** Seven days complete with no unresolved safety-floor violation, data-loss incident,
+  duplicate storm, stuck cursor, unbounded spool, or public exposure; bounded ingestion lag meets the
+  per-source SLO for at least 99% of observed intervals; restore reproduces the acknowledged record and
+  projection counts; revoke and forget complete within their frozen bounds; all U10 eval floors remain
+  green; the owner can retrieve cited evidence from a second approved device; the successor document
+  maps every proposed source to measured demand, privacy class, official acquisition method, and hard
+  E2E exit, and the owner records an explicit accept, reject, or revise decision.
+- **Bound:** Operations, acceptance, and planning only; no production code, connector, ranking, scope,
+  retention, or credential expansion; one seven-day soak plus one remediation/restart allowance; any
+  second soak failure ends the chain red and requires a new remediation loop.
+- **Exit →:** Write `docs/evidence/recall-universal-ingestion/U11/EXIT.md`, verify the deployed release
+  commit and content-free acceptance receipts, recap and pass ZEN, then stop for the final human gate;
+  release only on explicit owner acceptance, otherwise execute the owner-approved remediation or
+  successor chain without silently extending this one.
+
+## Review decision
+
+Approval of this document authorizes only the ordered BUILD loops and their bounded proof work. It
+does not authorize new external accounts, broader OAuth scopes, retention expansion, risky WhatsApp
+or X methods, public ingress, content-bearing public evidence, or any source named only in U11's
+successor candidates.

--- a/docs/rdd/RECALL_UNIVERSAL_INGESTION_2026-07-16.md
+++ b/docs/rdd/RECALL_UNIVERSAL_INGESTION_2026-07-16.md
@@ -1,0 +1,555 @@
+# Recall Universal Ingestion — RDD
+
+**Status:** proposed for review
+**Date:** 2026-07-16
+**Decision owner:** Recall owner
+**Execution plan:** `docs/LOOP_CHAIN_RECALL_UNIVERSAL_INGESTION_2026-07-16.md`
+
+## 1. Outcome
+
+Recall becomes an owner-controlled context plane that can continuously ingest, normalize, and
+retrieve useful evidence from communications, calendars, social activity, files, local Mac
+applications, research systems, and future sources without turning a personal brain into an
+unbounded surveillance database.
+
+For User #1, the product succeeds when a natural-language question can gather the right evidence
+across devices and sources, preserve surrounding conversation or event context, cite every material
+claim back to a canonical source receipt, distinguish current from stale or deleted state, admit only
+context appropriate to the task, and honestly report gaps.
+
+The intended shape is:
+
+```text
+source-local reader          always-on API reader
+(Mac databases/files)        (official remote APIs)
+         |                           |
+         +---- deterministic pull ---+
+                       |
+          normalize -> policy -> spool
+                       |
+              source-scoped write
+                       |
+                Tailnet-only Brain
+                       |
+       canonical immutable source evidence
+                       |
+       +---------------+----------------+
+       |               |                |
+  conversations   identity graph   temporal projections
+       |               |                |
+       +---------------+----------------+
+                       |
+       hybrid retrieval + task admission
+                       |
+      cited answer + contradiction/gap report
+```
+
+## 2. Why extend Recall rather than replace it
+
+Recall already owns the correctness boundary that matters most for private, heterogeneous inputs:
+
+- stable source and native identities;
+- content-addressed revisions and exact receipts;
+- source-scoped authorization;
+- ACK-gated cursor commits and recoverable mode-0600 spools;
+- replay-safe, content-hash deduplication;
+- explicit tombstones;
+- privacy policy before spool or network;
+- content-free health and supervisor state;
+- Tailnet-only service access; and
+- synthetic retrieval, privacy, deletion, and connector E2E suites.
+
+Adopting another memory product as the canonical store would weaken receipts and deletion lineage,
+force Recall records into a foreign page or fact model, and create a second trust contract. External
+projects remain references and eval competitors:
+
+- GBrain contributes the deterministic-collector pattern, compiled truth plus timelines, typed
+  graph traversal, hybrid retrieval, cited synthesis, and explicit gap analysis.
+- Botmem contributes a broad connector inventory, unified message shape, contact identity
+  resolution, and practical local-source acquisition patterns.
+- Ground-truth-preserving memory research supports keeping episodes and source evidence intact,
+  then improving retrieval and context expansion rather than performing lossy ingest-time rewriting.
+- Memory-admission research treats retrieved personal context as a control-channel boundary, not
+  automatically trustworthy prompt material.
+
+These are design inputs, not code dependencies. In particular, AGPL implementations must not be
+copied into Recall.
+
+## 3. Product principles
+
+1. **Evidence first.** Raw source events are canonical; facts, summaries, links, and profiles are
+   rebuildable projections with source receipts.
+2. **Code for mechanics, agents for judgment.** Pagination, IDs, timestamps, permalinks, MIME
+   decoding, edits, deletions, and cursor recovery are deterministic. Agents may classify,
+   synthesize, resolve ambiguity, and report gaps.
+3. **Read and act are different products.** Ingestion credentials are read-only. Sending mail,
+   messages, posts, or calendar mutations requires separate tools, credentials, and approval.
+4. **Collect broadly, admit narrowly.** Search may discover many sources, but only context relevant
+   and safe for the current task can enter an answer or tool prompt.
+5. **Local when local is authoritative.** Mac application data is read on the Mac and crosses the
+   privacy boundary before network writes. Official API readers may run on an always-on Tailnet host.
+6. **No public ingress by default.** Prefer incremental polling. A source that truly requires a
+   webhook gets a separate reviewed ingress design rather than exposing the Brain.
+7. **Explicit scope and deletion.** Every source declares include/exclude rules, backfill horizon,
+   retention, edit semantics, deletion semantics, and attachment policy.
+8. **Closed runtime.** Recall constructs only bundled, reviewed connector factories. It never loads
+   arbitrary entry points, imports, commands, recipes, or current-directory plugins.
+9. **Private proof stays private.** Public tests are synthetic. Real-source evals publish aggregate,
+   content-free receipts only; no message, query, answer, transcript, credential, private export,
+   identifying path, or infrastructure detail enters the repository.
+10. **Owner-visible control.** The utility must show what is enabled, where it runs, last success,
+    bounded lag, current backfill state, privacy mode, and how to revoke or forget it.
+
+## 4. Scope
+
+### 4.1 First-class source families
+
+| Family | Initial connectors | Default execution |
+|---|---|---|
+| `communications` | Gmail, iMessage, WhatsApp, Slack, Telegram | API host or source Mac |
+| `schedule` | Google Calendar, Apple Calendar later | API host or source Mac |
+| `contacts` | Google Contacts, source participant identities | API host plus projection |
+| `social` | owner-authored X posts, mentions, bookmarks; optional home feed | API host |
+| `documents` | Drive, Notion, selected filesystem roots, attachments | API host or source Mac |
+| `work_activity` | GitHub, Linear, existing coding and research sources | API host or existing host |
+| `personal_media` | selected Photos metadata/OCR, voice notes later | source Mac |
+| `local_activity` | Apple Notes, browser bookmarks/history, selected local files | source Mac |
+
+Finance, health, precise location, and password-manager data are not ordinary connector additions.
+They require successor RDDs with stronger classification, retention, and admission policies.
+
+### 4.2 Explicit non-goals for this chain
+
+- No sending, posting, deleting upstream, RSVP, or calendar mutation.
+- No arbitrary website scraping or browser automation when an official API/export exists.
+- No public Brain URL or generic webhook executor.
+- No model training on imported content.
+- No silent contact merges based only on similar names.
+- No attachment ingestion by default.
+- No automatic promotion of source text into durable user preference or instruction memory.
+- No claim that missing upstream records prove deletion unless the source emitted an explicit,
+  authoritative deletion signal.
+
+## 5. Runtime topology
+
+### 5.1 Source placement
+
+Each connector declares one of three placements:
+
+- `source_local`: data exists only on a selected device, such as iMessage `chat.db`.
+- `always_on_api`: an official API benefits from continuous polling, such as X's bounded timeline.
+- `either`: an incremental API can safely catch up after sleep, such as Gmail or Calendar.
+
+The first implementation keeps placement static in private configuration. Dynamic workload movement
+is unnecessary and risks copying credentials between hosts.
+
+### 5.2 Credential boundary
+
+- External-source and Brain credentials are distinct.
+- Each connector has one exact source-scoped Brain writer.
+- Mac credentials are Keychain references; server credentials are approved secret-manager or strict
+  mode-0600 references.
+- Every model or judge call uses the approved staging LiteLLM router with a short-lived scoped virtual
+  key minted from the protected environment; master keys and direct provider calls are prohibited.
+- Config files contain references, never secret values.
+- Logs, exceptions, status, cursors, provenance, receipts, tests, and evidence never render secret
+  values or authority references.
+- Revoking source authority stops reads; revoking Brain authority leaves an ACK-recoverable spool.
+
+### 5.3 Storage boundary
+
+Tailnet encryption does not protect database disks or backups. Before bulk personal communications
+ingestion, the deployment must produce a content-free attestation for encrypted database storage,
+encrypted backups, tested restore, restricted filesystem modes, and source-scoped access.
+
+Canonical source envelopes and searchable projections may contain personal content. Searchable
+plaintext therefore relies on encrypted volumes and strict host access. A later optional encrypted
+raw-payload sidecar may reduce the searchable projection footprint; it is not allowed to compromise
+receipt parity or deletion lineage.
+
+## 6. Connector contract v2
+
+The current pull contract remains the execution primitive. V2 adds declared capabilities and typed
+records without allowing runtime plugin discovery.
+
+### 6.1 Bundled manifest
+
+Each bundled connector factory declares:
+
+```text
+connector_id
+contract_version
+source_family
+record_kinds
+execution_placement
+authority_slots
+minimum_external_scopes
+backfill_modes
+checkpoint_semantics
+edit_semantics
+deletion_semantics
+retention_modes
+attachment_capability
+default_privacy_mode
+```
+
+Registry preview is static and performs no credential, source, network, or filesystem reads. Status
+remains content-free and reads only explicitly selected private state.
+
+### 6.2 Typed canonical records
+
+All records retain `source_id`, stable `native_id`, optional `native_parent_id`, `occurred_at`,
+content hash, provenance, and deletion state. The content object additionally declares one closed
+kind.
+
+#### `communication_message.v1`
+
+- stable conversation/thread identity;
+- stable message identity and optional reply identity;
+- author and participant source identifiers;
+- inbound/outbound/system direction;
+- sent, received, edited, and deleted timestamps when authoritative;
+- subject and cleaned text;
+- deterministic source permalink when available;
+- MIME/format metadata; and
+- attachment descriptors without attachment bytes by default.
+
+#### `calendar_event.v1`
+
+- calendar and event identities;
+- recurring-series and instance identities;
+- organizer and attendee source identifiers;
+- start/end/timezone/all-day fields;
+- title, description, location, conference reference;
+- busy/visibility/status fields; and
+- deterministic source permalink when available.
+
+#### `social_post.v1`
+
+- platform post, author, thread, and reply identities;
+- text and source URL;
+- created/edited/deleted state;
+- authenticated stream type (`own`, `mention`, `bookmark`, `home`); and
+- observed public metrics as a separate revisionable projection.
+
+#### `contact_identity.v1`
+
+- source-scoped identifier and identifier type;
+- display name and optional organization/title;
+- self/other role; and
+- provenance confidence.
+
+#### `document.v1`
+
+- provider document/file identity and parent hierarchy;
+- name, MIME type, modified time, owner/participant identities;
+- extracted text when explicitly allowed; and
+- source permalink.
+
+### 6.3 Identity, revision, and deletion
+
+- `source_id + native_id` is logical identity.
+- `source_id + native_id + content_sha256` is an acknowledged version.
+- A changed canonical content object creates a revision, never an overwrite.
+- A lost Brain acknowledgement replays the exact staged batch.
+- An upstream page cursor commits only after every retained event or tombstone is acknowledged.
+- Stable already-acknowledged versions advance the source cursor without another Brain write.
+- Explicit authoritative deletion creates a tombstone and invalidates every derived projection.
+- List absence is not deletion.
+- Sources with provider compliance obligations declare a bounded deletion reconciliation job.
+
+## 7. Privacy and source policy
+
+Each source has an owner-private policy with closed fields:
+
+```text
+enabled
+include selectors
+exclude selectors
+backfill start/end
+privacy mode: scrub | drop
+retention mode: mirror | archive | explicit-only
+attachments: off | metadata | selected-content
+noise treatment: searchable | low-priority | excluded
+derived-memory eligibility
+```
+
+`off` privacy is prohibited for new personal-communication connectors. Selectors are connector-
+specific but structurally bounded: Gmail labels/senders, calendar IDs, chat IDs, source folders,
+X stream types, or explicit roots. Policy previews show counts and categories, never source content
+or selectors that expose private identities.
+
+### 7.1 Default classifier behavior
+
+Drop before spool and network:
+
+- one-time passcodes and authentication codes;
+- password-reset or account-recovery secrets;
+- private keys, API keys, bearer tokens, session cookies, and credential files;
+- payment-card authentication values; and
+- records classified as authentication material rather than durable communication.
+
+Scrub secret-shaped spans and high-risk identifiers while preserving safe surrounding context.
+Contextual PII classification remains opt-in and, when enabled, uses only the approved staging model
+router with a short-lived scoped key.
+
+Marketing, notification, receipt, and automated senders are classified rather than silently dropped.
+Retrieval can demote noise without making potentially useful evidence unrecoverable.
+
+### 7.2 Prompt-injection and action isolation
+
+Imported content is evidence, never instruction. Retrieval labels source text as untrusted quoted
+material. The admission layer cannot let an email, message, post, or document change system policy,
+authorization, tool parameters, or user intent. Tool-enabled agents receive only admitted evidence
+plus receipts; all action tools retain their independent approval model.
+
+## 8. Projections and retrieval
+
+### 8.1 Rebuildable projections
+
+1. **Items:** cleaned source evidence with exact receipts.
+2. **Conversations:** ordered messages grouped by native parent/thread.
+3. **Temporal events:** event revisions with current, cancelled, superseded, or deleted state.
+4. **Identity graph:** source identities joined to owner-approved people.
+5. **Claims:** extracted assertions with validity, confidence, extractor version, and evidence.
+6. **Relationships:** typed, time-bounded edges supported by receipts.
+7. **Compiled views:** person/project/topic summaries that separate current truth from timeline.
+
+An extracted claim, edge, or summary cannot be cited unless it resolves to live source receipts.
+Deletion or policy exclusion removes its derived embeddings, links, and compiled views.
+
+### 8.2 Contact resolution
+
+Deterministic exact identifiers may merge automatically only when policy permits:
+
+- normalized email address;
+- normalized phone number;
+- stable provider identity mapped by an authoritative contact record; or
+- explicit owner alias.
+
+Name-only, organization-only, or model-suggested matches remain candidates. The Mac utility presents
+a diff and supporting source types for owner approval. Splits and corrections are versioned.
+
+### 8.3 Query path
+
+```text
+query
+  -> intent/domain/time/person/source planning
+  -> hard authorization and source-policy filters
+  -> lexical + vector + exact/entity candidate legs
+  -> RRF and logical-evidence deduplication
+  -> task-conditioned memory admission
+  -> thread/episode neighbor expansion
+  -> optional identity/temporal graph expansion
+  -> rerank
+  -> cited synthesis with contradiction and gap reporting
+```
+
+Memory admission is observable and content-free: selected domains, source families, temporal mode,
+and exclusion reason counts. It never exposes excluded content.
+
+## 9. Source-specific acquisition decisions
+
+### 9.1 Gmail, Calendar, and Contacts
+
+- Use official Google OAuth with least-privilege read scopes and bring-your-own OAuth credentials
+  for the first owner deployment.
+- Use Gmail `historyId` incremental sync; an expired history window triggers a bounded full
+  reconciliation.
+- Use Calendar `syncToken`; HTTP 410 triggers a full reconciliation without logical duplicates.
+- Use message IDs as native IDs and thread IDs as parents.
+- Import Inbox and Sent so response state can be reconstructed.
+- Treat attachments as metadata until separately enabled.
+- Keep OAuth onboarding explicit about restricted scopes, personal-use status, refresh-token expiry,
+  revoke behavior, and any public-distribution verification requirement.
+
+### 9.2 iMessage
+
+- Run only on a selected Mac with explicit Full Disk Access.
+- Use a pinned, reviewed, read-only adapter against the local Messages database or an equivalent
+  stable JSON reader.
+- Do not enable send, AppleScript mutation, private framework injection, or SIP modifications.
+- Snapshot safely before querying a live SQLite/WAL source.
+- Track stable message and chat IDs, edits, unsends/deletes when represented, participants, and
+  attachment metadata.
+
+### 9.3 WhatsApp
+
+Two separately reviewed modes are allowed:
+
+1. `export`: explicit owner-supplied exports; safest, not continuous.
+2. `linked-device-experimental`: an isolated, pinned Baileys-compatible reader; continuous but
+   unofficial and subject to account/session risk.
+
+The experimental mode requires an unbounded human gate acknowledging the risk. It must expose no
+send surface, pace syncs, isolate session keys in strict private storage, prove unlink/revoke, and
+never claim that reconnect will recover unavailable history. The official WhatsApp Business Cloud
+API is not a substitute for a personal chat-history API.
+
+### 9.4 X
+
+- Use official OAuth user context only; no scraping or browser automation.
+- Durable defaults: owner-authored posts, mentions, bookmarks, and explicitly saved items.
+- General home-timeline ingestion defaults to a bounded rolling retention or derived digest, not an
+  unbounded permanent archive.
+- Use current pay-per-use limits and an explicit monthly cost ceiling.
+- Stored X content must reconcile edits, deletions, protected/suspended state, and policy requests
+  within the required window.
+- Off-X identity linking and any durable home-feed mode require an explicit reviewed policy choice.
+
+### 9.5 Official API bundle
+
+Drive, Slack, Notion, GitHub, and Linear use official read APIs or exports, stable upstream IDs,
+incremental checkpoints where available, and separate source-scoped writers. A generic HTTP recipe
+runner is not introduced. Each connector passes the same conformance suite and adds only its narrow
+normalizer and authority implementation.
+
+### 9.6 Local Mac bundle
+
+Apple Notes, selected Photos metadata/OCR, browser bookmarks/history, and selected filesystem roots
+are individually opt-in. No connector inventories Desktop, Downloads, application support, browser
+state, or the home directory beyond its explicit root/surface. Symlinks, hard-link escapes, archive
+traversal, and unsupported database schemas fail closed.
+
+## 10. Mac utility
+
+Extend the packaged utility into a menu-bar-capable `Recall Bridge` while preserving CLI parity.
+For each source it provides:
+
+- explanation of data read, external scope, execution host, privacy mode, and retention;
+- explicit source/root/account/chat selection;
+- OAuth, QR, Full Disk Access, or export onboarding appropriate to that source;
+- content-free preview before first read;
+- bounded backfill progress, last success, lag, error class, and pending counts;
+- pause, resume, retry, reauthorize, unlink, disable, forget-by-receipt, and delete-local-state flows;
+- no credential values, message samples, private paths, selectors, or cursors in diagnostics; and
+- an exportable content-free support bundle.
+
+Uninstall keeps recoverable state by default. Deleting source state or central memory is a separate,
+explicit operation with clear consequences.
+
+## 11. Test-driven development contract
+
+Every BUILD follows red -> green -> refactor. A loop cannot claim TDD merely because tests exist at
+the end.
+
+### 11.1 Reusable connector conformance suite
+
+Every pull connector is tested against synthetic fixtures for:
+
+- first page, pagination, empty page, and terminal cursor;
+- stable replay and lost acknowledgement;
+- crash after fetch, stage, Brain commit, and cursor commit;
+- repeated identical record and changed-content revision;
+- explicit edit and tombstone;
+- out-of-order and overlapping upstream pages;
+- expired/invalid cursor requiring full reconciliation;
+- rate limit, transient failure, authorization failure, and malformed response;
+- all-records-dropped privacy page;
+- credential-shaped upstream exception;
+- attachment oversize/type rejection;
+- source-policy include/exclude behavior; and
+- content-free status and logs.
+
+Fake success is pinned: a test must fail if the connector advances a cursor before ACK, treats list
+absence as deletion, changes identity on restart, swallows an authorization error, emits an empty
+scoreboard, or lets private fixtures enter repository evidence.
+
+### 11.2 Evaluation pyramid
+
+1. Unit: normalizers, identity, cursor codec, policy, and deletion semantics.
+2. Contract: connector state machine with fake upstream and fake Brain.
+3. Integration: pinned official-client or local-reader adapter against synthetic servers/databases.
+4. Brain E2E: ingest -> project -> retrieve -> show -> tombstone.
+5. Mac package E2E: install -> authorize/reference -> run -> status -> disable -> uninstall.
+6. Private shadow: real User #1 sources and questions; aggregate-only public receipt.
+
+### 11.3 Non-negotiable floors
+
+| Metric | Floor |
+|---|---:|
+| Unauthorized retrieval | `0` |
+| Secret/PII canary leakage | `0` |
+| Duplicate logical evidence after replay/restart | `0` |
+| Deletion resurrection | `0` |
+| Cursor commit before Brain ACK | `0` |
+| Deterministic repeat ranking agreement | `1.00` |
+| Exact identifier Hit@1 | `1.00` |
+| Receipt resolution | `1.00` |
+
+Average quality gains never compensate for a safety-floor regression.
+
+### 11.4 Real-source acceptance
+
+Private real-source runs use questions frozen before opening results. Public evidence contains only a
+run ID, source-family counts, corpus/query hashes, aggregate metrics, latency, and sanitized failure
+categories. Samples below 30 are labeled directional. No real message, event, query, expected answer,
+hit text, receipt, participant, source selector, or path is committed.
+
+## 12. Operational requirements
+
+- Supervisor leases, bounded cadence, jitter, backoff, rate-limit caps, and repair generations remain
+  deterministic and content-free.
+- Every connector publishes enabled/configured/health/checkpoint/pending/lag/error-class state.
+- Backfills are pausable, resumable, rate-limited, and cannot starve live incremental sync.
+- Source polling is staggered; one failed source cannot block another.
+- Schema and projection migrations are restartable and rollbackable.
+- Backups include canonical events, grants, source profiles, projections, aliases, and migration
+  metadata; restore proves receipt and tombstone parity.
+- Model-derived enrichment is asynchronous, versioned, rebuildable, and never blocks canonical
+  evidence ingestion.
+
+## 13. Rollout and rollback
+
+Each source starts in four states:
+
+1. `preview`: configuration and permissions only; zero source reads.
+2. `shadow`: ingest into isolated private state and compare counts/receipts; excluded from default
+   retrieval.
+3. `searchable`: evidence participates in explicit source-routed queries.
+4. `default`: evidence participates in ordinary admitted retrieval.
+
+Rollback disables the source, preserves recoverable local cursor/spool unless explicitly deleted,
+removes it from default retrieval immediately, and optionally tombstones its central events through
+an owner-confirmed forget operation. Rollback never requires rewriting another source.
+
+## 14. Release decision
+
+Universal ingestion is not one giant release. Every connector and every shared substrate change is
+one bounded Cascade loop and one concern per PR. A loop exits only when its `EXIT.md` maps every
+criterion to safe evidence verified at merged HEAD. The final loop runs cross-device, cross-source
+questions, produces an aggregate verdict, drafts the successor chain from losing cells, and pauses
+for owner sign-off.
+
+## 15. Human decisions deliberately deferred to gates
+
+1. Approve this RDD and loop chain before BUILD.
+2. Choose WhatsApp export-only or explicitly accept linked-device experimental risk.
+3. Choose X rolling home-feed retention or keep durable ingestion limited to owner/saved streams.
+4. Opt into any attachment content, contextual-PII judge, or source-specific durable fact extraction.
+5. Accept the final User #1 quality and privacy verdict before broadening distribution.
+
+## 16. External design references
+
+These primary references were rechecked on 2026-07-16. They support acquisition and architecture
+choices, but do not override the hard safety and evidence contracts in this RDD.
+
+- [GBrain repository](https://github.com/garrytan/gbrain), including its compiled-truth/timeline,
+  hybrid retrieval, typed graph, synthesis, and gap-analysis direction.
+- [Botmem product and open-source overview](https://botmem.xyz/) for its local-first connector and
+  contact-graph patterns; Recall does not inherit Botmem's trust or merge policy.
+- [Gmail incremental synchronization](https://developers.google.com/workspace/gmail/api/guides/sync)
+  for `historyId`, partial sync, and full reconciliation after an expired history window.
+- [Google Calendar incremental synchronization](https://developers.google.com/workspace/calendar/api/guides/sync)
+  for `syncToken`, pagination, authoritative deleted entries, and HTTP 410 recovery.
+- [Google People contacts guide](https://developers.google.com/people/v1/contacts) for contact
+  pagination and sync-token behavior.
+- [Google OAuth guidance](https://developers.google.com/identity/protocols/oauth2) for incremental,
+  least-privilege consent and separate API scopes.
+- [Apple Full Disk Access guidance](https://support.apple.com/guide/mac-help/change-privacy-security-settings-mchl211c911f/mac)
+  for explicit access to other applications' local data, including Messages.
+- [X timeline API](https://docs.x.com/x-api/posts/timelines/introduction) and
+  [X API pricing](https://docs.x.com/x-api/getting-started/pricing) for official authenticated streams,
+  bounded history, and pay-per-use cost controls.
+- [Baileys repository and disclaimer](https://github.com/WhiskeySockets/Baileys) for the explicitly
+  experimental WhatsApp linked-device option and its non-affiliation, breakage, and account-risk gate.

--- a/docs/rdd/RECALL_UNIVERSAL_INGESTION_2026-07-16.md
+++ b/docs/rdd/RECALL_UNIVERSAL_INGESTION_2026-07-16.md
@@ -1,6 +1,6 @@
 # Recall Universal Ingestion — RDD
 
-**Status:** proposed for review
+**Status:** approved for autonomous execution
 **Date:** 2026-07-16
 **Decision owner:** Recall owner
 **Execution plan:** `docs/LOOP_CHAIN_RECALL_UNIVERSAL_INGESTION_2026-07-16.md`
@@ -273,16 +273,14 @@ pinned CLI or direct API client
   -> canonical Recall record + checkpoint
 ```
 
-The first BUILD loop runs a pinned bakeoff rather than selecting by popularity:
+The first BUILD loop pins one transport rather than exposing a choice to runtime agents:
 
-| Candidate | What it gives Recall | Main risk | Intended role |
+| Transport | What it gives Recall | Main risk | Intended role |
 |---|---|---|---|
-| OpenClaw `gog` | task-first Gmail/Calendar/Drive/Docs/Contacts commands; stable JSON; non-interactive and read-only flags; exact command allowlists; untrusted-content wrapping; typed read-only MCP; Gmail history/watch with Pub/Sub pull and delivery-before-cursor-advance | third-party CLI and release cadence; task abstractions may omit raw sync fields for some services | leading production candidate, especially Gmail |
-| Google Workspace `gws` | Discovery-generated access to the full Workspace API surface; JSON/NDJSON; schema introspection; automatic pagination; 100+ agent skills; optional Model Armor response scanning | pre-v1 breaking changes, dynamic command surface, broad scopes and write methods unless Recall closes them | coverage candidate and raw-method escape hatch |
-| direct official APIs | exact control over request fields, cursors, errors, and reconciliation | maximum custom code, auth duplication, and maintenance | only where neither pinned CLI proves the required semantics |
+| Google Workspace `gws` v0.22.5, tag commit `705fb0ec` | Discovery-generated access to Gmail History, Calendar sync tokens, People sync tokens, Drive changes, and Docs exports through JSON/NDJSON | dynamic command surface and write methods unless Recall closes them | sole v1 transport, installed from checksum-pinned official assets and hidden behind exact read-only method/schema allowlists |
 
-The result may be one CLI or a narrow hybrid, but each source has exactly one selected rail in a
-release. Swapping rails must replay the same synthetic conformance fixtures and prove canonical-record
+Every Google source uses this one pinned transport and has exactly one allowed command family in a
+release. Swapping transports must replay the same synthetic conformance fixtures and prove canonical-record
 parity before live use. A rail is transport, not the Brain's data model and not a generic shell tool.
 `gws` Model Armor is a useful comparison point but is not enabled: Recall's model/judge traffic must
 use the approved staging LiteLLM route, so imported-content classification stays behind that boundary.
@@ -573,19 +571,18 @@ an owner-confirmed forget operation. Rollback never requires rewriting another s
 
 Universal ingestion is five outcome-level Cascade loops, not a loop per connector. A loop may contain
 multiple small, serial PRs, but every PR still has one concern and the loop exits only after its
-system-level eval/E2E gate is green. Its `EXIT.md` maps every criterion to safe evidence verified at
-merged HEAD. The final loop runs cross-device, cross-source questions, produces an aggregate verdict,
+system-level eval/E2E gate is green. A mode-0600 private exit manifest maps every criterion to safe
+evidence verified at merged HEAD; no Cascade diary or live evidence enters git. The final loop runs
+cross-device, cross-source questions, produces an aggregate verdict,
 drafts the successor chain from losing cells, and pauses for owner sign-off.
 
 ## 15. Human decisions deliberately deferred to gates
 
-1. Approve this RDD and loop chain before BUILD.
-2. Approve the least-privilege Google services/scopes after the rail bakeoff; CLI selection itself is
-   an evidence decision, not a preference poll.
-3. Choose WhatsApp export-only or explicitly accept linked-device experimental risk.
-4. Choose X rolling home-feed retention or keep durable ingestion limited to owner/saved streams.
-5. Opt into any attachment content, contextual-PII judge, or source-specific durable fact extraction.
-6. Accept the final User #1 quality and privacy verdict before broadening distribution.
+1. Approve the least-privilege Google read-only services/scopes declared by the pinned `gws` rail.
+2. Grant access only to a WhatsApp export inbox; linked-device access is outside this chain.
+3. Choose X rolling home-feed retention or keep durable ingestion limited to owner/saved streams.
+4. Opt into any attachment content, contextual-PII judge, or source-specific durable fact extraction.
+5. Accept the final User #1 quality and privacy verdict before broadening distribution.
 
 ## 16. External design references
 

--- a/docs/rdd/RECALL_UNIVERSAL_INGESTION_2026-07-16.md
+++ b/docs/rdd/RECALL_UNIVERSAL_INGESTION_2026-07-16.md
@@ -258,6 +258,56 @@ kind.
 - List absence is not deletion.
 - Sources with provider compliance obligations declare a bounded deletion reconciliation job.
 
+### 6.4 Workspace acquisition rail
+
+Recall should not reimplement every Google REST client unless a required correctness property cannot
+be obtained from a maintained CLI. It introduces a closed `WorkspaceRail` boundary whose output is
+still normalized through the same connector-v2 contract:
+
+```text
+pinned CLI or direct API client
+  -> exact argv/method allowlist
+  -> structured JSON/NDJSON envelope
+  -> source-specific deterministic normalizer
+  -> privacy policy before spool/network
+  -> canonical Recall record + checkpoint
+```
+
+The first BUILD loop runs a pinned bakeoff rather than selecting by popularity:
+
+| Candidate | What it gives Recall | Main risk | Intended role |
+|---|---|---|---|
+| OpenClaw `gog` | task-first Gmail/Calendar/Drive/Docs/Contacts commands; stable JSON; non-interactive and read-only flags; exact command allowlists; untrusted-content wrapping; typed read-only MCP; Gmail history/watch with Pub/Sub pull and delivery-before-cursor-advance | third-party CLI and release cadence; task abstractions may omit raw sync fields for some services | leading production candidate, especially Gmail |
+| Google Workspace `gws` | Discovery-generated access to the full Workspace API surface; JSON/NDJSON; schema introspection; automatic pagination; 100+ agent skills; optional Model Armor response scanning | pre-v1 breaking changes, dynamic command surface, broad scopes and write methods unless Recall closes them | coverage candidate and raw-method escape hatch |
+| direct official APIs | exact control over request fields, cursors, errors, and reconciliation | maximum custom code, auth duplication, and maintenance | only where neither pinned CLI proves the required semantics |
+
+The result may be one CLI or a narrow hybrid, but each source has exactly one selected rail in a
+release. Swapping rails must replay the same synthetic conformance fixtures and prove canonical-record
+parity before live use. A rail is transport, not the Brain's data model and not a generic shell tool.
+`gws` Model Armor is a useful comparison point but is not enabled: Recall's model/judge traffic must
+use the approved staging LiteLLM route, so imported-content classification stays behind that boundary.
+
+Every CLI execution is closed and fail-safe:
+
+- pin version and release checksum; upgrades are explicit conformance-tested changes;
+- construct an argv vector without a shell, executable config, arbitrary subcommand, or user-supplied
+  flag passthrough;
+- allow only exact read methods required by the enabled source, plus capability-specific read-only and
+  no-send ceilings where the CLI supports them;
+- require non-interactive JSON/NDJSON, a frozen output schema, bounded pages/bytes/time, and explicit
+  exit-code handling; empty success output fails rather than advancing a cursor;
+- pass a minimal environment containing credential references, not the ambient agent environment;
+- disable verbose/body logging and sanitize stdout, stderr, and errors before any persistent log;
+- treat every returned field as untrusted source evidence, never as an instruction; and
+- keep CLI/MCP access internal to the collector. Recall never exposes a generic command bridge to an
+  answering agent.
+
+OpenClaw's useful pattern is the separation between a thin agent skill and a durable CLI. Recall reuses
+that boundary, the exact capability ceilings, and the Gmail delivery-before-checkpoint behavior. It
+does not copy OpenClaw's on-demand agent workflow wholesale: continuous ingestion remains a
+deterministic collector, and imported mail never becomes a hook prompt before Recall policy and
+admission checks.
+
 ## 7. Privacy and source policy
 
 Each source has an owner-private policy with closed fields:
@@ -350,18 +400,24 @@ and exclusion reason counts. It never exposes excluded content.
 
 ## 9. Source-specific acquisition decisions
 
-### 9.1 Gmail, Calendar, and Contacts
+### 9.1 Google Workspace
 
-- Use official Google OAuth with least-privilege read scopes and bring-your-own OAuth credentials
-  for the first owner deployment.
+- Use the L0-selected, pinned Workspace rail over official Google APIs with least-privilege read scopes
+  and bring-your-own OAuth credentials for the first owner deployment.
+- Prefer OpenClaw's operational shape where it proves the contract: non-interactive structured output,
+  exact command allowlists, read-only/no-send ceilings, untrusted-content wrapping, and Gmail Pub/Sub
+  pull so no public inbound endpoint is required.
 - Use Gmail `historyId` incremental sync; an expired history window triggers a bounded full
-  reconciliation.
+  reconciliation. CLI notifications are wakeups, never the canonical cursor or delivery receipt.
 - Use Calendar `syncToken`; HTTP 410 triggers a full reconciliation without logical duplicates.
-- Use message IDs as native IDs and thread IDs as parents.
-- Import Inbox and Sent so response state can be reconstructed.
-- Treat attachments as metadata until separately enabled.
-- Keep OAuth onboarding explicit about restricted scopes, personal-use status, refresh-token expiry,
-  revoke behavior, and any public-distribution verification requirement.
+- Use People API sync tokens for Contacts; ambiguous identity resolution remains a Recall projection,
+  not a CLI merge.
+- Add Drive and Docs through the same chosen rail when their stable IDs, revisions, exports, and change
+  checkpoints pass the connector contract; Sheets remains metadata unless explicitly selected.
+- Use message IDs as native IDs and thread IDs as parents. Import Inbox and Sent so response state can
+  be reconstructed. Treat attachments as metadata until separately enabled.
+- Keep OAuth onboarding explicit about restricted scopes, incremental consent, personal-use status,
+  refresh-token expiry, revoke behavior, and any public-distribution verification requirement.
 
 ### 9.2 iMessage
 
@@ -515,19 +571,21 @@ an owner-confirmed forget operation. Rollback never requires rewriting another s
 
 ## 14. Release decision
 
-Universal ingestion is not one giant release. Every connector and every shared substrate change is
-one bounded Cascade loop and one concern per PR. A loop exits only when its `EXIT.md` maps every
-criterion to safe evidence verified at merged HEAD. The final loop runs cross-device, cross-source
-questions, produces an aggregate verdict, drafts the successor chain from losing cells, and pauses
-for owner sign-off.
+Universal ingestion is five outcome-level Cascade loops, not a loop per connector. A loop may contain
+multiple small, serial PRs, but every PR still has one concern and the loop exits only after its
+system-level eval/E2E gate is green. Its `EXIT.md` maps every criterion to safe evidence verified at
+merged HEAD. The final loop runs cross-device, cross-source questions, produces an aggregate verdict,
+drafts the successor chain from losing cells, and pauses for owner sign-off.
 
 ## 15. Human decisions deliberately deferred to gates
 
 1. Approve this RDD and loop chain before BUILD.
-2. Choose WhatsApp export-only or explicitly accept linked-device experimental risk.
-3. Choose X rolling home-feed retention or keep durable ingestion limited to owner/saved streams.
-4. Opt into any attachment content, contextual-PII judge, or source-specific durable fact extraction.
-5. Accept the final User #1 quality and privacy verdict before broadening distribution.
+2. Approve the least-privilege Google services/scopes after the rail bakeoff; CLI selection itself is
+   an evidence decision, not a preference poll.
+3. Choose WhatsApp export-only or explicitly accept linked-device experimental risk.
+4. Choose X rolling home-feed retention or keep durable ingestion limited to owner/saved streams.
+5. Opt into any attachment content, contextual-PII judge, or source-specific durable fact extraction.
+6. Accept the final User #1 quality and privacy verdict before broadening distribution.
 
 ## 16. External design references
 
@@ -546,6 +604,13 @@ choices, but do not override the hard safety and evidence contracts in this RDD.
   pagination and sync-token behavior.
 - [Google OAuth guidance](https://developers.google.com/identity/protocols/oauth2) for incremental,
   least-privilege consent and separate API scopes.
+- [OpenClaw's `gog` skill](https://github.com/openclaw/openclaw/blob/main/skills/gog/SKILL.md),
+  [`gog` CLI](https://github.com/openclaw/gogcli), and
+  [Gmail watch design](https://github.com/openclaw/gogcli/blob/main/docs/watch.md) for the thin-skill,
+  constrained-CLI, Pub/Sub pull, retry, and delivery-before-checkpoint patterns.
+- [Google Workspace CLI](https://github.com/googleworkspace/cli) for Discovery-generated command
+  coverage, schema introspection, structured output, agent skills, and response sanitization. The
+  repository explicitly labels the CLI pre-v1 and not an officially supported Google product.
 - [Apple Full Disk Access guidance](https://support.apple.com/guide/mac-help/change-privacy-security-settings-mchl211c911f/mac)
   for explicit access to other applications' local data, including Messages.
 - [X timeline API](https://docs.x.com/x-api/posts/timelines/introduction) and


### PR DESCRIPTION
Locks the approved five-loop execution contract for Recall universal ingestion. The plan selects pinned gws, always-on API collectors, and WhatsApp export-only; it also keeps all live/private evidence outside git and requires hard synthetic or aggregate exits.