### PR TITLE
docs(recall): fold managed migration into L0

### DIFF
--- a/docs/LOOP_CHAIN_RECALL_UNIVERSAL_INGESTION_2026-07-16.md
+++ b/docs/LOOP_CHAIN_RECALL_UNIVERSAL_INGESTION_2026-07-16.md
@@ -1,9 +1,10 @@
 # Recall Universal Ingestion — Five-Loop Cascade
 
-**Status:** approved for autonomous execution
+**Status:** replanned after L0 AT_BOUND; approved for autonomous remediation through human gates
 **Mode:** BUILD
 **Pacing:** autonomous between declared human gates
 **RDD:** `docs/rdd/RECALL_UNIVERSAL_INGESTION_2026-07-16.md`
+**Replan issue:** [#54 — managed Postgres deployment](https://github.com/miguelrios/unc-skills/issues/54)
 
 ## Objective
 
@@ -17,7 +18,8 @@ uses red -> green -> refactor; every loop uses the full Cascade ribbon and has a
 
 ## Operating contract
 
-- Measure before changing behavior. L0 freezes the retrieval and safety baseline.
+- Measure before changing behavior. L0 preserves the frozen retrieval/safety baseline while moving
+  the central plane onto an encrypted, restore-tested managed deployment.
 - Each loop follows RE-PLAN -> BUILD -> PIN -> PROVE -> MEASURE -> REVIEW -> MERGE -> EXIT.
 - Maximum per PR: two failed PROVE runs and three review/fix rounds. Instrument failures are diagnosed
   separately and do not become fake evidence.
@@ -39,7 +41,7 @@ uses red -> green -> refactor; every loop uses the full Cascade ribbon and has a
 
 ```mermaid
 flowchart LR
-    L0[L0 Pin the substrate and closed Google rail]
+    L0[L0 Pin and migrate the ingestion substrate]
     L1[L1 Google Workspace life plane]
     L2[L2 Private communications and Mac utility]
     L3[L3 Social and work expansion]
@@ -49,36 +51,61 @@ flowchart LR
 
 | Task | `blockedBy` | Human gate |
 |---|---|---|
-| L0 | — | approve only the declared Google read-only scopes |
+| L0 | — | approve provider billing/region, provider credential grants, Tailnet route, final cutover, then only the declared Google read-only scopes |
 | L1 | L0 | complete Google OAuth consent |
 | L2 | L1 | grant macOS permissions; WhatsApp is export-only in this chain |
 | L3 | L2 | approve X streams/retention/cost and each additional external account scope |
 | L4 | L3 | accept release or approve the successor chain |
 
-## L0 — Pin the substrate and closed Google rail
+## L0 — Pin and migrate the ingestion substrate
 
-- **goal:** Produce a closed, benchmarked ingestion substrate around pinned Google Workspace CLI
-  `gws` v0.22.5 before connecting personal data.
-- **prompt:** Read the RDD and current Recall connector/runtime code; freeze the unchanged retrieval,
-  privacy, deletion, replay, and packaging baselines; red-test connector-v2 typed records, exact
-  authority slots, ACK-gated checkpoints, revisions, tombstones, static registry preview, and rejection
-  of arbitrary factories; pin `gws` v0.22.5 at tag commit `705fb0ec` with per-platform release
-  checksums; expose only Gmail message/history reads, Calendar event reads, People connections reads,
-  Drive change/file reads, and Docs exports through exact argv/method and response-schema allowlists;
-  test non-interactive JSON stability, empty-success failure, revoke, read-only enforcement, untrusted
-  content, crash replay, OS packaging, upgrade pinning, and credential isolation; then implement the
-  closed rail boundary and shared contract in serial one-concern PRs.
-- **accept:** The pre-change scorecard reproduces twice; all legacy connectors and the pinned `gws`
-  rail pass the v2 conformance suite; duplicate pages and every injected crash converge to
-  one acknowledged version; cursor-before-ACK, executable config, shell invocation, unknown command,
-  write method, ambient environment, empty success, schema drift, and secret-bearing error tests fail
-  closed; encrypted storage, backup/restore, filesystem mode, source-writer, and Tailnet-only
-  attestations are green; repository tests and the public-safety scan pass at merged HEAD.
-- **bound:** At most three serial PRs, two failed PROVE runs and three review rounds per PR, and ten
-  working days total; checksum ambiguity or a failed storage/safety control exits AT_BOUND
-  instead of authorizing Google data.
-- **exit →:** Write the private criterion map, recap and pass ZEN, pause for owner approval of the
-  declared Google scopes, then trigger L1.
+- **goal:** Finish the already-merged closed connector substrate by moving the central Brain onto an
+  agent-deployable, encrypted, restore-tested managed Postgres deployment before connecting any new
+  personal source.
+- **prompt:** Start from Issue #54, the RDD, merged PR #53, the frozen pre-change scorecard, and current
+  Recall deployment contract. Preserve the connector-v2 typed records, static registry, ACK-gated
+  revisions/tombstones, pinned `gws` v0.22.5 rail, retrieval behavior, privacy boundary, and package
+  surfaces. Red-test an immutable `recall-core` container, standard-Postgres capability probe,
+  restartable migrations, least-privilege application/migration roles, encrypted connector durability,
+  and a closed deployment manifest that contains references rather than credential values. Implement
+  the first agent-managed profile as PlanetScale Postgres plus a Render private service and Tailscale
+  gateway; the application must consume standard `DATABASE_URL` semantics and provider-neutral SQL so
+  Supabase, Neon, and conforming pgvector Postgres remain substitutable profiles. Move always-on
+  connector outbox/checkpoint durability into Postgres or another provider-attested encrypted boundary;
+  local collectors retain private device spools and never receive database credentials. Provisioning
+  may preview automatically but must pause for billing, region, provider authorization, Tailnet route,
+  and cutover approval. Prove backup/restore into an isolated target, extension recreation, canonical
+  event/revision/tombstone/receipt/projection parity, fault-injected final delta, endpoint rotation,
+  second-device retrieval, and rollback before decommissioning the old writer. No live Google OAuth,
+  reads, or backfill occur in L0.
+- **accept:**
+  1. The twice-reproduced baseline and every merged connector/rail conformance cell remain green.
+  2. The same immutable container passes a standard pgvector fixture and the PlanetScale pilot
+     capability probe with zero provider-specific SQL or canonical behavior differences.
+  3. A fresh-account deployment dry-run is content-free, idempotent, agent-runnable, makes zero
+     billable mutations, and pauses at every declared human grant; after approval, two applies converge
+     to the same manifest with zero duplicate resources or credential values rendered.
+  4. Provider APIs attest encryption at rest for the database, backups, and connector durability;
+     connection tests fail when TLS verification is disabled or server identity does not match.
+  5. Restore into an isolated target recreates required extensions and reaches exact canonical-event,
+     revision, tombstone, receipt, grant, source-profile, projection, and embedding parity.
+  6. Two synthetic cutover cycles plus crash-after-copy, crash-after-Brain-ACK, restart, network-loss,
+     revoke, and rollback faults produce zero missing live records, duplicate acknowledged versions,
+     resurrected deletions, cross-source authority changes, or cursor commits before ACK.
+  7. Existing Linux and Mac collectors ingest and retrieve cited synthetic evidence after cutover; a
+     second approved device retrieves the same evidence and resolves every receipt.
+  8. The User #1 Tailnet profile has zero public Recall listeners, and an external non-Tailnet probe
+     cannot reach the service.
+  9. Backup restore, credential rotation/revoke, process restart, rollback, repository tests,
+     deployment E2Es, container/supply-chain scan, and public-safety scan pass at merged and deployed
+     HEAD with content-free aggregate output.
+- **bound:** At most four total serial L0 PRs including merged PR #53, two failed PROVE runs and three
+  review rounds per PR, one cutover plus one remediation restart, and fourteen working days from this
+  replan. A failed encryption, parity, restore, rollback, authorization, or exposure control writes a
+  private `AT_BOUND` criterion map and stops without authorizing Google data.
+- **exit →:** Write the mode-0600 private criterion map tied to merged and deployed HEAD, run recap and
+  pass ZEN, obtain owner acceptance of the cutover and the four declared Google read-only scopes, then
+  trigger L1.
 
 ## L1 — Google Workspace life plane
 
@@ -196,3 +223,12 @@ Approving this document authorizes only these five bounded outcomes and their se
 It does not authorize broad OAuth presets, write/send tools, public Brain ingress, attachment content,
 WhatsApp linked-device access, durable home-timeline retention, or additional accounts without their
 named human gates.
+
+## Replan record — 2026-07-16
+
+L0's connector-v2 substrate and pinned Workspace rail merged in PR #53, but the operational storage
+attestation could not prove the encryption floor, so L0 stopped `AT_BOUND` before Google
+authorization. The owner chose migration before live source expansion. Issue #54 is therefore folded
+into L0 as its remediation phase rather than added as a sixth loop. L1 through L4 retain their order,
+scope, quality floors, and human gates; only L0's central deployment, migration, and cutover work is
+expanded. No new personal source may be enabled until the revised L0 exit is complete.

--- a/docs/rdd/RECALL_UNIVERSAL_INGESTION_2026-07-16.md
+++ b/docs/rdd/RECALL_UNIVERSAL_INGESTION_2026-07-16.md
@@ -1,9 +1,10 @@
 # Recall Universal Ingestion — RDD
 
-**Status:** approved for autonomous execution
+**Status:** replanned after L0 storage AT_BOUND; approved for autonomous remediation through human gates
 **Date:** 2026-07-16
 **Decision owner:** Recall owner
 **Execution plan:** `docs/LOOP_CHAIN_RECALL_UNIVERSAL_INGESTION_2026-07-16.md`
+**Migration issue:** [#54](https://github.com/miguelrios/unc-skills/issues/54)
 
 ## 1. Outcome
 
@@ -29,7 +30,9 @@ source-local reader          always-on API reader
                        |
               source-scoped write
                        |
-                Tailnet-only Brain
+        managed Recall Core API/workers
+                       |
+       managed Postgres + encrypted durability
                        |
        canonical immutable source evidence
                        |
@@ -87,9 +90,11 @@ copied into Recall.
 4. **Collect broadly, admit narrowly.** Search may discover many sources, but only context relevant
    and safe for the current task can enter an answer or tool prompt.
 5. **Local when local is authoritative.** Mac application data is read on the Mac and crosses the
-   privacy boundary before network writes. Official API readers may run on an always-on Tailnet host.
-6. **No public ingress by default.** Prefer incremental polling. A source that truly requires a
-   webhook gets a separate reviewed ingress design rather than exposing the Brain.
+   privacy boundary before network writes. Official API readers may run in the managed central plane.
+6. **Private ingress first, portable ingress later.** User #1 keeps Tailnet-only Brain ingress.
+   Ordinary laptop users may later use authenticated public HTTPS with device-scoped credentials only
+   after its separate cross-tenant, revocation, abuse, and exposure gates pass. Source polling remains
+   preferred; a webhook requires its own reviewed ingress design.
 7. **Explicit scope and deletion.** Every source declares include/exclude rules, backfill horizon,
    retention, edit semantics, deletion semantics, and attachment policy.
 8. **Closed runtime.** Recall constructs only bundled, reviewed connector factories. It never loads
@@ -132,7 +137,39 @@ They require successor RDDs with stronger classification, retention, and admissi
 
 ## 5. Runtime topology
 
-### 5.1 Source placement
+### 5.1 Central Brain placement
+
+The first managed profile is one immutable `recall-core` container on a Render private service,
+PlanetScale Postgres as the canonical database, and a Tailscale gateway for private User #1 ingress.
+The container packages the existing Recall HTTP API, projection/retrieval runtime, and background
+workers; it is a deployment boundary, not a rewrite or a second memory product.
+
+Application behavior remains standard PostgreSQL:
+
+- one `DATABASE_URL` contract with full TLS certificate verification;
+- startup capability probes for PostgreSQL version, required extensions, migration state, and role
+  privileges;
+- provider-neutral schema, queries, receipts, revisions, and tombstones;
+- separate migration, application, source-writer, and read-only operational roles; and
+- no PlanetScale, Render, Supabase, or Neon SDK inside canonical ingestion or retrieval code.
+
+PlanetScale is the first live profile because it supplies managed encrypted Postgres, pgvector,
+backups/PITR, roles, and agent-accessible provisioning. Supabase, Neon, and conforming pgvector
+Postgres remain deployment adapters tested against the same capability contract. Provider branches
+are deployment and restore units, never Recall source identity or authorization boundaries.
+
+Collectors communicate only with Recall Core. A laptop or source connector never receives a database
+credential. Source-local collectors keep mode-0600 device spools; always-on cloud connectors place
+their outbox/checkpoint state in Postgres or a separately provider-attested encrypted durable volume.
+The end state is a stateless Core process, but the first cutover may retain a narrow encrypted state
+volume when required for safe incremental migration.
+
+Provisioning is agent-runnable but not agent-authorized: automation may validate and preview a plan,
+then must pause for billing, region, provider-account grants, Tailnet route approval, and final writer
+cutover. Secret values live only in approved provider secret stores and never in manifests, argv,
+logs, CI, support bundles, or repository evidence.
+
+### 5.2 Source placement
 
 Each connector declares one of three placements:
 
@@ -143,7 +180,7 @@ Each connector declares one of three placements:
 The first implementation keeps placement static in private configuration. Dynamic workload movement
 is unnecessary and risks copying credentials between hosts.
 
-### 5.2 Credential boundary
+### 5.3 Credential boundary
 
 - External-source and Brain credentials are distinct.
 - Each connector has one exact source-scoped Brain writer.
@@ -155,17 +192,26 @@ is unnecessary and risks copying credentials between hosts.
 - Logs, exceptions, status, cursors, provenance, receipts, tests, and evidence never render secret
   values or authority references.
 - Revoking source authority stops reads; revoking Brain authority leaves an ACK-recoverable spool.
+- Database administration credentials exist only for bounded migrations. Runtime uses a rotatable,
+  least-privilege application role; collectors use source-scoped Brain credentials, never SQL roles.
 
-### 5.3 Storage boundary
+### 5.4 Storage boundary
 
-Tailnet encryption does not protect database disks or backups. Before bulk personal communications
-ingestion, the deployment must produce a content-free attestation for encrypted database storage,
-encrypted backups, tested restore, restricted filesystem modes, and source-scoped access.
+Tailnet encryption does not protect database disks, connector state, or backups. Before bulk personal
+communications ingestion, the deployment must produce content-free provider attestations for
+encrypted database storage, encrypted backups, encrypted durable connector state, tested restore,
+restricted filesystem modes, TLS server-identity verification, and source-scoped access.
 
 Canonical source envelopes and searchable projections may contain personal content. Searchable
 plaintext therefore relies on encrypted volumes and strict host access. A later optional encrypted
 raw-payload sidecar may reduce the searchable projection footprint; it is not allowed to compromise
 receipt parity or deletion lineage.
+
+Migration freezes a canonical manifest before copying, restores into an isolated target, recreates
+extensions explicitly, and verifies canonical events, revisions, tombstones, receipts, grants, source
+profiles, projections, and embeddings. The final delta is ACK-gated. Old and new writers never run
+unfenced against the same source, and the old deployment remains rollback-only until parity, backup
+restore, both-device retrieval, and the owner cutover gate pass.
 
 ## 6. Connector contract v2
 
@@ -542,6 +588,15 @@ hit text, receipt, participant, source selector, or path is committed.
 
 ## 12. Operational requirements
 
+- `recall-core` builds reproducibly as an immutable, vulnerability-scanned container with a
+  content-free health contract; no source data, credential, private selector, or deployment identity
+  enters the image or build provenance.
+- The deployment manifest is closed and provider-neutral at runtime. Provider adapters may provision
+  infrastructure but cannot change canonical schema, authorization, deletion, or retrieval semantics.
+- Provisioning preview performs no billable mutation and renders no secret. Apply pauses at explicit
+  billing, region, account-grant, network-route, and writer-cutover gates.
+- Database startup fails closed on missing extensions, migration drift, excessive role privilege,
+  disabled TLS verification, unavailable encrypted durability, or an untested backup policy.
 - Supervisor leases, bounded cadence, jitter, backoff, rate-limit caps, and repair generations remain
   deterministic and content-free.
 - Every connector publishes enabled/configured/health/checkpoint/pending/lag/error-class state.
@@ -554,6 +609,12 @@ hit text, receipt, participant, source selector, or path is committed.
   evidence ingestion.
 
 ## 13. Rollout and rollback
+
+The managed deployment rolls out before new source activation. First restore an isolated copy and run
+parity reads. Next run synthetic collectors against the new writer. At the human cutover gate, pause
+old writers, drain acknowledged work, apply one bounded final delta, rotate collector endpoints, and
+keep the previous deployment read-only and rollback-ready. Rollback reverses endpoints and replays
+only ACK-safe staged work; it never runs unfenced dual writers or infers deletion from copy absence.
 
 Each source starts in four states:
 
@@ -576,13 +637,18 @@ evidence verified at merged HEAD; no Cascade diary or live evidence enters git. 
 cross-device, cross-source questions, produces an aggregate verdict,
 drafts the successor chain from losing cells, and pauses for owner sign-off.
 
+The L0 storage failure does not add a sixth loop. Issue #54 is the remediation phase of L0 and must
+close at both merged and deployed HEAD before L1 may request Google consent or read personal data.
+
 ## 15. Human decisions deliberately deferred to gates
 
-1. Approve the least-privilege Google read-only services/scopes declared by the pinned `gws` rail.
-2. Grant access only to a WhatsApp export inbox; linked-device access is outside this chain.
-3. Choose X rolling home-feed retention or keep durable ingestion limited to owner/saved streams.
-4. Opt into any attachment content, contextual-PII judge, or source-specific durable fact extraction.
-5. Accept the final User #1 quality and privacy verdict before broadening distribution.
+1. Approve the managed provider, billing plan, region, provider-account grants, Tailnet route, and
+   final writer cutover after reviewing a content-free deployment preview.
+2. Approve the least-privilege Google read-only services/scopes declared by the pinned `gws` rail.
+3. Grant access only to a WhatsApp export inbox; linked-device access is outside this chain.
+4. Choose X rolling home-feed retention or keep durable ingestion limited to owner/saved streams.
+5. Opt into any attachment content, contextual-PII judge, or source-specific durable fact extraction.
+6. Accept the final User #1 quality and privacy verdict before broadening distribution.
 
 ## 16. External design references
 
@@ -608,6 +674,19 @@ choices, but do not override the hard safety and evidence contracts in this RDD.
 - [Google Workspace CLI](https://github.com/googleworkspace/cli) for Discovery-generated command
   coverage, schema introspection, structured output, agent skills, and response sanitization. The
   repository explicitly labels the CLI pre-v1 and not an officially supported Google product.
+- [PlanetScale Postgres](https://planetscale.com/docs/postgres),
+  [extensions](https://planetscale.com/docs/postgres/extensions),
+  [security](https://planetscale.com/docs/security), and
+  [backups/PITR](https://planetscale.com/docs/postgres/backups) for the first managed database profile.
+- [Render Blueprints](https://render.com/docs/infrastructure-as-code),
+  [private services](https://render.com/docs/private-services), and
+  [Tailscale template](https://render.com/templates/tailscale) for the first agent-managed compute and
+  private-ingress profile.
+- [Tailscale Serve](https://tailscale.com/docs/features/tailscale-serve) for private Tailnet ingress;
+  Funnel is not enabled by the User #1 profile.
+- [Supabase Postgres](https://supabase.com/docs/guides/database/overview) and
+  [Neon pgvector](https://neon.com/docs/ai/ai-scale-with-neon) as portability profiles that must obey
+  the same standard-Postgres capability and Recall safety contracts.
 - [Apple Full Disk Access guidance](https://support.apple.com/guide/mac-help/change-privacy-security-settings-mchl211c911f/mac)
   for explicit access to other applications' local data, including Messages.
 - [X timeline API](https://docs.x.com/x-api/posts/timelines/introduction) and


### PR DESCRIPTION
Replans the existing five-loop Recall universal-ingestion Cascade after the L0 storage gate stopped AT_BOUND.

- keeps exactly five loops; Issue #54 becomes the remediation phase of L0, not a sixth loop
- preserves merged connector-v2 and pinned Workspace rail work
- pins PlanetScale Postgres + Render private service + Tailscale as the first deployment profile
- keeps runtime behavior portable to Supabase, Neon, and standard pgvector Postgres
- adds nine eval/E2E-driven L0 exits for dry-run/apply convergence, encryption/TLS, restore parity, faulted cutover, both-device retrieval, Tailnet-only exposure, rollback, and supply-chain safety
- blocks live Google OAuth and reads until migrated and deployed HEAD passes
- adds explicit billing, region, provider authorization, Tailnet route, cutover, and Google-scope human gates

This PR is the authoritative correction to the earlier “L0.5” shorthand in Issue #54. It contains no credentials, private paths, identifying infrastructure, transcripts, source content, or live evidence.