### PR TITLE
recall: gate managed infrastructure apply

### DIFF
--- a/recall/server/deploy/README.md
+++ b/recall/server/deploy/README.md
@@ -27,6 +27,22 @@ python -m recall_server.cli capability-check
 `--profile local-fixture` is a visibly non-production exception restricted to a
 loopback PostgreSQL fixture. It never reports production readiness.
 
+The separate approval document is owner-only, bound to the exact preview hash, and
+contains only explicit booleans plus the approved billing and region slugs. Validate it
+without applying anything:
+
+```bash
+python -m recall_server.cli deployment-approval-check \
+  --manifest server/deploy/recall-core.plan.example.json \
+  --approvals /private/approvals.json
+```
+
+Infrastructure reconciliation remains impossible until billing, region, provider
+authorization, and the Tailnet route are all approved. Writer cutover is a separate
+approval and is never inferred from infrastructure approval. Provider adapters receive
+only the closed desired state and return content-free receipts; repeated reconciliation
+must converge to `unchanged` without duplicate resources.
+
 ## Existing host pilot
 
 The existing host pilot listens on a Unix socket, not TCP. Tailscale Serve is its only network proxy.

--- a/recall/server/recall_server/cli.py
+++ b/recall/server/recall_server/cli.py
@@ -13,6 +13,7 @@ from .capabilities import CapabilityError, probe_database
 from .db import BrainStore
 from .deployment import DeploymentManifestError, load_manifest, preview
 from .federation import QUALITY_SCORES, SOURCE_FAMILIES
+from .managed_apply import ApprovalError, approval_status, load_approvals
 from .semantic import SemanticRuntime
 
 
@@ -26,6 +27,9 @@ def main() -> None:
     capability.add_argument("--profile", choices=("production", "local-fixture"), default="production")
     deployment = sub.add_parser("deployment-preview")
     deployment.add_argument("--manifest", type=Path, required=True)
+    approval = sub.add_parser("deployment-approval-check")
+    approval.add_argument("--manifest", type=Path, required=True)
+    approval.add_argument("--approvals", type=Path, required=True)
     sub.add_parser("rebuild")
     backfill_entities = sub.add_parser("backfill-entities")
     backfill_entities.add_argument("--batch-size", type=int, default=5000)
@@ -68,6 +72,18 @@ def main() -> None:
             print(json.dumps(preview(load_manifest(args.manifest)), sort_keys=True))
         except DeploymentManifestError:
             print(json.dumps({"status": "rejected", "code": "manifest_invalid"}), file=sys.stderr)
+            raise SystemExit(2) from None
+        return
+    if args.command == "deployment-approval-check":
+        try:
+            manifest = load_manifest(args.manifest)
+            plan_sha256 = preview(manifest)["plan_sha256"]
+            print(json.dumps(approval_status(
+                load_approvals(args.approvals, plan_sha256),
+            ), sort_keys=True))
+        except (ApprovalError, DeploymentManifestError) as error:
+            code = error.code if isinstance(error, ApprovalError) else "manifest_invalid"
+            print(json.dumps({"status": "rejected", "code": code}), file=sys.stderr)
             raise SystemExit(2) from None
         return
     if not args.dsn:

--- a/recall/server/recall_server/managed_apply.py
+++ b/recall/server/recall_server/managed_apply.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+import stat
+from pathlib import Path
+from typing import Any, Protocol
+
+from .deployment import preview, validate_manifest
+
+
+MAX_APPROVAL_BYTES = 16 * 1024
+SHA256_RE = re.compile(r"[0-9a-f]{64}\Z")
+SELECTION_RE = re.compile(r"[a-z0-9][a-z0-9-]{1,62}\Z")
+INFRASTRUCTURE_GATES = (
+    "provider-billing", "provider-region", "provider-authorization", "tailnet-route",
+)
+
+
+class ApprovalError(RuntimeError):
+    def __init__(self, code: str):
+        self.code = code
+        super().__init__(code)
+
+
+class ProviderAdapter(Protocol):
+    def ensure(self, logical_id: str, desired: dict[str, Any]) -> dict[str, str]: ...
+
+
+def _object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ApprovalError("approval_invalid")
+        result[key] = value
+    return result
+
+
+def _closed(value: object, fields: set[str]) -> dict[str, Any]:
+    if not isinstance(value, dict) or set(value) != fields:
+        raise ApprovalError("approval_invalid")
+    return value
+
+
+def _read_private(path: Path) -> bytes:
+    try:
+        descriptor = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+    except OSError as error:
+        raise ApprovalError("approval_unavailable") from error
+    try:
+        metadata = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(metadata.st_mode)
+            or metadata.st_uid != os.geteuid()
+            or metadata.st_mode & 0o077
+            or not 0 < metadata.st_size <= MAX_APPROVAL_BYTES
+        ):
+            raise ApprovalError("approval_file_unsafe")
+        with os.fdopen(descriptor, "rb") as source:
+            descriptor = -1
+            return source.read(MAX_APPROVAL_BYTES + 1)
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+
+
+def load_approvals(path: Path, plan_sha256: str) -> dict[str, Any]:
+    payload = _read_private(path)
+    if len(payload) > MAX_APPROVAL_BYTES:
+        raise ApprovalError("approval_file_unsafe")
+    try:
+        value = json.loads(payload, object_pairs_hook=_object)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ApprovalError("approval_invalid") from error
+    root = _closed(
+        value, {"schema_version", "plan_sha256", "infrastructure", "writer-cutover"},
+    )
+    if root["schema_version"] != 1 or type(root["schema_version"]) is not int:
+        raise ApprovalError("approval_invalid")
+    if (
+        not isinstance(root["plan_sha256"], str)
+        or not SHA256_RE.fullmatch(root["plan_sha256"])
+        or root["plan_sha256"] != plan_sha256
+    ):
+        raise ApprovalError("approval_plan_mismatch")
+    infrastructure = _closed(root["infrastructure"], set(INFRASTRUCTURE_GATES))
+    for gate in ("provider-billing", "provider-region"):
+        approval = _closed(infrastructure[gate], {"approved", "selection"})
+        if type(approval["approved"]) is not bool or not isinstance(approval["selection"], str):
+            raise ApprovalError("approval_invalid")
+        if not SELECTION_RE.fullmatch(approval["selection"]):
+            raise ApprovalError("approval_invalid")
+    for gate in ("provider-authorization", "tailnet-route"):
+        approval = _closed(infrastructure[gate], {"approved"})
+        if type(approval["approved"]) is not bool:
+            raise ApprovalError("approval_invalid")
+    cutover = _closed(root["writer-cutover"], {"approved"})
+    if type(cutover["approved"]) is not bool:
+        raise ApprovalError("approval_invalid")
+    return root
+
+
+def _adapter_result(value: object) -> dict[str, str]:
+    result = _closed(value, {"action", "receipt_sha256"})
+    if result["action"] not in {"created", "unchanged"}:
+        raise ApprovalError("provider_result_invalid")
+    if not isinstance(result["receipt_sha256"], str) or not SHA256_RE.fullmatch(
+        result["receipt_sha256"],
+    ):
+        raise ApprovalError("provider_result_invalid")
+    return result
+
+
+def approval_status(approvals: dict[str, Any]) -> dict[str, Any]:
+    infrastructure = approvals.get("infrastructure") or {}
+    pending = [
+        gate for gate in INFRASTRUCTURE_GATES
+        if (infrastructure.get(gate) or {}).get("approved") is not True
+    ]
+    if approvals.get("writer-cutover", {}).get("approved") is not True:
+        pending.append("writer-cutover")
+    return {
+        "schema_version": 1,
+        "status": "approval_required" if pending else "approved",
+        "plan_sha256": approvals["plan_sha256"],
+        "pending_gates": pending,
+        "mutation_count": 0,
+        "network_calls": 0,
+        "credential_values_rendered": 0,
+    }
+
+
+def reconcile_infrastructure(
+    manifest: dict[str, Any], approvals: dict[str, Any],
+    adapters: dict[str, ProviderAdapter],
+) -> dict[str, Any]:
+    manifest = validate_manifest(manifest)
+    if approvals.get("plan_sha256") != preview(manifest)["plan_sha256"]:
+        raise ApprovalError("approval_plan_mismatch")
+    infrastructure = approvals.get("infrastructure") or {}
+    if any((infrastructure.get(gate) or {}).get("approved") is not True for gate in INFRASTRUCTURE_GATES):
+        raise ApprovalError("infrastructure_approval_required")
+    if set(adapters) != {"database", "service", "network"}:
+        raise ApprovalError("provider_adapter_invalid")
+    region = infrastructure["provider-region"]["selection"]
+    billing = infrastructure["provider-billing"]["selection"]
+    desired = {
+        "database": {
+            **manifest["database"], "region": region, "billing_plan": billing,
+        },
+        "service": {
+            **manifest["service"], "image": manifest["image"],
+            "region": region, "billing_plan": billing,
+        },
+        "network": {
+            **manifest["network"], "provider_authorized": True, "route_approved": True,
+        },
+    }
+    results = [
+        _adapter_result(adapters[kind].ensure(f"recall-core-{kind}", desired[kind]))
+        for kind in ("database", "service", "network")
+    ]
+    actions = {
+        action: sum(result["action"] == action for result in results)
+        for action in ("created", "unchanged")
+    }
+    return {
+        "schema_version": 1,
+        "status": (
+            "infrastructure_ready_for_cutover"
+            if approvals["writer-cutover"]["approved"]
+            else "writer_cutover_approval_required"
+        ),
+        "plan_sha256": approvals["plan_sha256"],
+        "resource_count": len(results),
+        "actions": actions,
+        "resource_receipts": [result["receipt_sha256"] for result in results],
+        "credential_values_rendered": 0,
+        "source_reads": 0,
+    }

--- a/recall/tests/central_brain/test_managed_apply.py
+++ b/recall/tests/central_brain/test_managed_apply.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+RECALL = Path(__file__).resolve().parents[2]
+SERVER = RECALL / "server"
+sys.path.insert(0, str(SERVER))
+
+from recall_server.deployment import load_manifest, preview  # noqa: E402
+from recall_server.managed_apply import (  # noqa: E402
+    ApprovalError,
+    approval_status,
+    load_approvals,
+    reconcile_infrastructure,
+)
+
+
+class FakeAdapter:
+    def __init__(self) -> None:
+        self.resources: dict[str, str] = {}
+        self.calls = 0
+
+    def ensure(self, logical_id: str, desired: dict) -> dict[str, str]:
+        self.calls += 1
+        digest = __import__("hashlib").sha256(json.dumps(
+            desired, sort_keys=True, separators=(",", ":"),
+        ).encode()).hexdigest()
+        action = "unchanged" if self.resources.get(logical_id) == digest else "created"
+        self.resources[logical_id] = digest
+        return {"action": action, "receipt_sha256": digest}
+
+
+class ManagedApplyTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.manifest = load_manifest(SERVER / "deploy" / "recall-core.plan.example.json")
+        self.plan_sha256 = preview(self.manifest)["plan_sha256"]
+
+    def approvals(self, **updates) -> dict:
+        value = {
+            "schema_version": 1,
+            "plan_sha256": self.plan_sha256,
+            "infrastructure": {
+                "provider-billing": {"approved": True, "selection": "starter"},
+                "provider-region": {"approved": True, "selection": "oregon"},
+                "provider-authorization": {"approved": True},
+                "tailnet-route": {"approved": True},
+            },
+            "writer-cutover": {"approved": False},
+        }
+        value.update(updates)
+        return value
+
+    def write_approvals(self, value: dict, mode: int = 0o600) -> Path:
+        directory = tempfile.TemporaryDirectory(); self.addCleanup(directory.cleanup)
+        path = Path(directory.name) / "approvals.json"
+        path.write_text(json.dumps(value)); os.chmod(path, mode)
+        return path
+
+    def test_approval_file_is_private_closed_and_bound_to_exact_plan(self) -> None:
+        loaded = load_approvals(self.write_approvals(self.approvals()), self.plan_sha256)
+        self.assertFalse(loaded["writer-cutover"]["approved"])
+        status = approval_status(loaded)
+        self.assertEqual(status["pending_gates"], ["writer-cutover"])
+        self.assertEqual(status["mutation_count"], 0)
+        for mutate in (
+            lambda value: value.update({"plan_sha256": "0" * 64}),
+            lambda value: value.update({"token": "not-allowed"}),
+            lambda value: value["infrastructure"]["provider-region"].update({"selection": ""}),
+        ):
+            value = self.approvals(); mutate(value)
+            with self.assertRaises(ApprovalError):
+                load_approvals(self.write_approvals(value), self.plan_sha256)
+        with self.assertRaises(ApprovalError):
+            load_approvals(self.write_approvals(self.approvals(), 0o644), self.plan_sha256)
+
+    def test_missing_infrastructure_approval_makes_zero_adapter_calls(self) -> None:
+        value = self.approvals()
+        value["infrastructure"]["provider-billing"]["approved"] = False
+        approvals = load_approvals(self.write_approvals(value), self.plan_sha256)
+        adapters = {key: FakeAdapter() for key in ("database", "service", "network")}
+        with self.assertRaises(ApprovalError) as raised:
+            reconcile_infrastructure(self.manifest, approvals, adapters)
+        self.assertEqual(raised.exception.code, "infrastructure_approval_required")
+        self.assertEqual(sum(adapter.calls for adapter in adapters.values()), 0)
+
+    def test_two_applies_converge_without_duplicates_or_rendered_values(self) -> None:
+        approvals = load_approvals(
+            self.write_approvals(self.approvals()), self.plan_sha256,
+        )
+        adapters = {key: FakeAdapter() for key in ("database", "service", "network")}
+        first = reconcile_infrastructure(self.manifest, approvals, adapters)
+        second = reconcile_infrastructure(self.manifest, approvals, adapters)
+        self.assertEqual(first["actions"], {"created": 3, "unchanged": 0})
+        self.assertEqual(second["actions"], {"created": 0, "unchanged": 3})
+        self.assertEqual(first["resource_count"], second["resource_count"])
+        self.assertEqual(sum(len(adapter.resources) for adapter in adapters.values()), 3)
+        self.assertEqual(second["status"], "writer_cutover_approval_required")
+        rendered = json.dumps([first, second], sort_keys=True)
+        for forbidden in ("starter", "oregon", "secret://", "approval://"):
+            self.assertNotIn(forbidden, rendered)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Continues the revised L0 after #56 with the final pre-authorization contract.

- adds an owner-only approval document bound to the exact content-free deployment plan hash
- separates infrastructure approvals (billing, region, provider authorization, Tailnet route) from writer cutover
- guarantees missing approval performs zero adapter calls
- defines a provider-neutral reconciliation seam with closed, content-free adapter receipts
- proves two synthetic applies converge from 3 created resources to 3 unchanged resources with no duplicates
- adds an offline CLI approval check that performs zero mutations and zero network calls

## Safety boundary

This PR contains no provider implementation and cannot mutate PlanetScale, Render, or Tailscale. It reads no source data and renders no credential/reference/approval values. Live provider adapters and apply remain the final L0 PR and require explicit owner authorization.

## Local proof

- 316 Python tests + 3 Node tests: pass
- targeted approval/apply fake-success tests: pass
- ruff and Bandit: pass
- public-safety scan: pass

This is total L0 PR 3 of the maximum 4 including #53. L0 remains open.
