### PR TITLE
fix(tether): support current Hermes Slack payloads

### DIFF
--- a/tether/runtime/plugin/__init__.py
+++ b/tether/runtime/plugin/__init__.py
@@ -286,7 +286,7 @@ def _install_slack_bridge_prefilter():
     original_restart = getattr(SlackAdapter, "_restart_socket_mode", None)
 
     @functools.wraps(original)
-    async def bridged_handle(self, event):
+    async def bridged_handle(self, event, *args, **kwargs):
         if not event.get("_tether_polled"):
             state.last_inbound_at = time.monotonic()
             state.slack_transport_connected = True
@@ -312,7 +312,7 @@ def _install_slack_bridge_prefilter():
                     return None
         except Exception:
             log.exception("Could not evaluate a Slack bridge thread before the mention gate")
-        return await original(self, event)
+        return await original(self, event, *args, **kwargs)
 
     SlackAdapter._handle_slack_message = bridged_handle
 

--- a/tether/tests/test_bridge.py
+++ b/tether/tests/test_bridge.py
@@ -1005,8 +1005,8 @@ class PluginRoutingTest(unittest.TestCase):
                 self.sent.append((channel, content, metadata))
                 return {"ok": True}
 
-            async def _handle_slack_message(self, event):
-                return event.get("thread_ts") in self._bot_message_ts
+            async def _handle_slack_message(self, event, payload=None):
+                return event.get("thread_ts") in self._bot_message_ts, payload
 
         modules = {
             "plugins": types.ModuleType("plugins"),
@@ -1018,15 +1018,16 @@ class PluginRoutingTest(unittest.TestCase):
         with mock.patch.dict(sys.modules, modules), mock.patch.object(self.plugin, "_ensure_reply_poller"):
             self.plugin._install_slack_bridge_prefilter()
             adapter = SlackAdapter()
-            admitted = asyncio.run(adapter._handle_slack_message({
+            admitted, payload = asyncio.run(adapter._handle_slack_message({
                 "ts": "111.1", "thread_ts": "123.456", "channel": "C12345678",
-            }))
-            ignored = asyncio.run(adapter._handle_slack_message({
+            }, {"team_id": "T12345678"}))
+            ignored, _ = asyncio.run(adapter._handle_slack_message({
                 "ts": "111.2", "thread_ts": "999.999", "channel": "C12345678",
             }))
             suppressed = asyncio.run(adapter.send("C12345678", "NO_REPLY"))
             delivered = asyncio.run(adapter.send("C12345678", "NO_REPLY is a control token"))
         self.assertTrue(admitted)
+        self.assertEqual(payload, {"team_id": "T12345678"})
         self.assertFalse(ignored)
         self.assertTrue(suppressed["suppressed"])
         self.assertEqual(len(adapter.sent), 1)


### PR DESCRIPTION
## Summary
- preserve Hermes Slack event payload arguments through the Tether prefilter
- cover both legacy and current adapter call signatures

## Verification
- `ruff check`
- `bandit`
- root test suite
- 69 Tether tests