### PR TITLE
feat(tether): attach existing threads to exact native panes

### DIFF
--- a/tether/runtime/bridge_runtime.py
+++ b/tether/runtime/bridge_runtime.py
@@ -770,7 +770,7 @@ class Broker:
         status = {
             "ok": True,
             "implementation": "tether",
-            "protocol_version": 2,
+            "protocol_version": 3,
             "channel_configured": bool(effective_channel(config)),
             "owner_configured": bool(config.default_owner or allowed_users),
             "allowed_user_count": len(allowed_users),
@@ -907,6 +907,41 @@ class Broker:
             "source_kind": rebound.source_kind,
         }
 
+    def _attach(
+        self,
+        incoming: BridgeRequest,
+        config: Config,
+        allowed_users: tuple[str, ...],
+    ) -> dict[str, Any]:
+        request = BridgeRequest(incoming)
+        request["channel_id"] = str(request.get("channel_id") or effective_channel(config))
+        request["owner_user_id"] = str(
+            request.get("owner_user_id") or config.default_owner or ("*" if allowed_users else "")
+        )
+        request["team_id"] = str(request.get("team_id") or config.team_id)
+        thread_ts = str(request.get("thread_ts") or "")
+        if not request["channel_id"] or not thread_ts:
+            raise ValueError("Slack channel and existing thread timestamp are required")
+        existing = self.store.find(request["team_id"], request["channel_id"], thread_ts)
+        if existing is not None:
+            if existing.idempotency_key == str(request.get("idempotency_key") or ""):
+                return {
+                    "ok": True,
+                    "bridge_id": existing.bridge_id,
+                    "thread_ts": existing.thread_ts,
+                    "deduplicated": True,
+                }
+            raise ValueError("Slack thread already has an active Tether binding")
+        bridge = self.store.create(request)
+        bridge = self.store.bind(bridge.bridge_id, thread_ts)
+        self.store.mark_participation(bridge.team_id, bridge.channel_id, thread_ts)
+        return {
+            "ok": True,
+            "bridge_id": bridge.bridge_id,
+            "thread_ts": bridge.thread_ts,
+            "deduplicated": False,
+        }
+
     def _history(self, request: BridgeRequest, config: Config) -> dict[str, Any]:
         limit = max(1, min(int(request.get("limit", 15)), 100))
         channel = str(request.get("channel_id") or effective_channel(config))
@@ -970,6 +1005,9 @@ class Broker:
         if operation == "notify":
             with self._notify_lock:
                 return self._notify(request, config, allowed_users)
+        if operation == "attach":
+            with self._notify_lock:
+                return self._attach(request, config, allowed_users)
         if operation == "reply":
             return self._reply(request)
         if operation == "rebind":
@@ -1204,6 +1242,67 @@ def _pane_number(pane: str) -> int:
     return int(normalized)
 
 
+def _zellij_agent_process(
+    session: str,
+    pane: str,
+    allowed: set[str],
+    proc_root: Path = Path("/proc"),
+) -> tuple[str, str]:
+    candidates: list[tuple[bool, int, str, str]] = []
+    for process_dir in proc_root.iterdir():
+        if not process_dir.name.isdigit():
+            continue
+        try:
+            environment = {
+                item.split(b"=", 1)[0]: item.split(b"=", 1)[1]
+                for item in (process_dir / "environ").read_bytes().split(b"\0")
+                if b"=" in item
+            }
+            if environment.get(b"ZELLIJ_SESSION_NAME", b"").decode(
+                "utf-8", "replace"
+            ) != session or environment.get(b"ZELLIJ_PANE_ID", b"").decode(
+                "utf-8", "replace"
+            ).removeprefix("terminal_") != pane.removeprefix("terminal_"):
+                continue
+            raw_command = (process_dir / "cmdline").read_bytes()
+            tokens = [
+                value.decode("utf-8", "replace")
+                for value in raw_command.split(b"\0")
+                if value
+            ]
+            agent = next(
+                (
+                    name
+                    for token in tokens
+                    for name in allowed
+                    if Path(token).name == name
+                ),
+                "",
+            )
+            if not agent:
+                continue
+            stat_text = (process_dir / "stat").read_text(encoding="utf-8")
+            fields = stat_text[stat_text.rfind(")") + 2 :].split()
+            pid = int(process_dir.name)
+            foreground = len(fields) > 19 and int(fields[5]) == pid
+            start_time = fields[19] if len(fields) > 19 else ""
+            descriptor = (
+                f"proc:{pid}:{start_time}:"
+                f"{hashlib.sha256(raw_command).hexdigest()}"
+            )
+            candidates.append((foreground, pid, agent, descriptor))
+        except (FileNotFoundError, PermissionError, ProcessLookupError, ValueError, IndexError):
+            continue
+    foreground = [candidate for candidate in candidates if candidate[0]]
+    selected = foreground or candidates
+    if len(selected) != 1:
+        raise NativeContinuationError(
+            "Zellij omitted pane command metadata and an exact live agent process could not be resolved"
+        )
+    _, _, agent, descriptor = selected[0]
+    return agent, descriptor
+
+
 def zellij_pane_identity(
     session: str,
     pane: str,
@@ -1239,14 +1338,20 @@ def zellij_pane_identity(
     )
     if record is None or record.get("exited"):
         raise NativeContinuationError("captured Zellij pane is no longer active")
-    terminal_command = str(record.get("terminal_command") or "")
-    tokens = shlex.split(terminal_command)
     configured = config or load_config()
     allowed = set(configured.zellij_agent_commands)
-    agent = next(
-        (name for token in tokens for name in allowed if Path(token).name == name),
-        "",
-    )
+    terminal_command = str(record.get("terminal_command") or "")
+    if terminal_command:
+        tokens = shlex.split(terminal_command)
+        agent = next(
+            (name for token in tokens for name in allowed if Path(token).name == name),
+            "",
+        )
+        fingerprint_source = terminal_command
+    else:
+        agent, fingerprint_source = _zellij_agent_process(
+            session, str(pane_number), allowed
+        )
     if not agent:
         raise NativeContinuationError(
             "captured Zellij pane is not running an allowlisted agent; use --run-id for a shell or cron"
@@ -1256,7 +1361,9 @@ def zellij_pane_identity(
         "pane_id": str(pane_number),
         "cwd": cwd,
         "pane_agent": agent,
-        "pane_command_hash": hashlib.sha256(terminal_command.encode()).hexdigest(),
+        "pane_command_hash": hashlib.sha256(
+            fingerprint_source.encode()
+        ).hexdigest(),
     }
 
 

--- a/tether/skills/tether/SKILL.md
+++ b/tether/skills/tether/SKILL.md
@@ -42,6 +42,28 @@ Peer agents may collaborate through normal Slack conversation when Hermes is con
 
 Completion criterion: the result is posted to the same thread, or the same thread receives a sanitized failure explaining that no alternate session was used.
 
+## Attach An Existing Thread
+
+When a trusted launcher creates a fresh native agent session in response to an existing Slack turn, bind that exact thread without posting a second root message:
+
+```bash
+tether attach \
+  --channel C12345678 \
+  --thread-ts 1234567890.123456 \
+  --claude-session-id "$CLAUDE_SESSION_ID" \
+  --zellij-session "$ZELLIJ_SESSION_NAME" \
+  --zellij-pane-id "$ZELLIJ_PANE_ID" \
+  --cwd /absolute/repo/path \
+  --idempotency-key "stable-launch-id" \
+  --json
+```
+
+The local broker refuses to replace another active binding. When the target is
+already running in Zellij, provide both pane arguments so Tether fingerprints
+that exact live process and sends follow-ups into it; omitting them starts a
+separate native resume process. After attaching, use `tether reply --bridge-id
+...` for the native session's result. Do not guess a pane or session identity.
+
 ## Operate safely
 
 - Keep secrets, raw credentials, private prompts, and sensitive findings out of notification text and source metadata.

--- a/tether/skills/tether/references/contract.md
+++ b/tether/skills/tether/references/contract.md
@@ -11,6 +11,8 @@ One bridge binds:
 - one owner (`*` means any allowlisted operator and is the shared-channel default);
 - one idempotency key.
 
+A trusted local launcher may silently attach an existing Slack thread only after it has captured a concrete native session ID. When that session already runs in Zellij, attach must also capture and fingerprint the exact pane; otherwise Tether would create a parallel resume process. Attach is idempotent and refuses to replace an active binding; it is not a semantic router or stale-session fallback.
+
 An explicit run ID always creates `headless_run`, even inside Codex or Claude Code. Native sessions remain the source when those agents run inside Zellij, but the captured and fingerprinted live pane is their delivery endpoint.
 
 ## Inbound routing

--- a/tether/skills/tether/scripts/tether_notify.py
+++ b/tether/skills/tether/scripts/tether_notify.py
@@ -68,6 +68,41 @@ def detected_source(args: argparse.Namespace) -> tuple[str, dict[str, str]]:
     raise SystemExit("No resumable context found; pass --run-id for a headless run")
 
 
+def attached_source(args: argparse.Namespace) -> tuple[str, dict[str, str]]:
+    cwd = str(Path(args.cwd or Path.cwd()).resolve())
+    zellij_session = str(args.zellij_session or "")
+    zellij_pane = str(args.zellij_pane_id or "")
+    if bool(zellij_session) != bool(zellij_pane):
+        raise SystemExit("--zellij-session and --zellij-pane-id must be provided together")
+    terminal = {}
+    terminal_identity = None
+    if zellij_session:
+        terminal_identity = zellij_pane_identity(zellij_session, zellij_pane, cwd)
+        terminal = {
+            "zellij_session": zellij_session,
+            "zellij_pane_id": zellij_pane,
+            "pane_agent": terminal_identity["pane_agent"],
+            "pane_command_hash": terminal_identity["pane_command_hash"],
+        }
+    if args.claude_session_id and args.codex_session_id:
+        raise SystemExit("choose one native session ID")
+    if args.claude_session_id:
+        return "claude_session", {
+            "session_id": args.claude_session_id,
+            "cwd": cwd,
+            **terminal,
+        }
+    if args.codex_session_id:
+        return "codex_session", {
+            "session_id": args.codex_session_id,
+            "cwd": cwd,
+            **terminal,
+        }
+    if terminal_identity:
+        return "zellij_pane", terminal_identity
+    return detected_source(args)
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Send or answer a resumable Hermes Slack thread")
     sub = parser.add_subparsers(dest="command", required=True)
@@ -87,6 +122,20 @@ def build_parser() -> argparse.ArgumentParser:
     rebind = sub.add_parser("rebind")
     rebind.add_argument("--channel", required=True)
     rebind.add_argument("--thread-ts", required=True)
+    attach = sub.add_parser("attach")
+    attach.add_argument("--channel", required=True)
+    attach.add_argument("--thread-ts", required=True)
+    attach.add_argument("--owner")
+    attach.add_argument("--team")
+    attach.add_argument("--idempotency-key", required=True)
+    attach.add_argument("--claude-session-id")
+    attach.add_argument("--codex-session-id")
+    attach.add_argument("--zellij-session")
+    attach.add_argument("--zellij-pane-id")
+    attach.add_argument("--run-id")
+    attach.add_argument("--hermes-session-id")
+    attach.add_argument("--cwd")
+    attach.add_argument("--json", action="store_true")
     post = sub.add_parser("post")
     post.add_argument("--channel", required=True)
     post.add_argument("--thread-ts", required=True)
@@ -229,6 +278,17 @@ def main(argv: Sequence[str] | None = None) -> int:
             "op": "rebind", "channel_id": args.channel,
             "thread_ts": args.thread_ts, "source_kind": kind, "source": source,
         })
+    elif args.command == "attach":
+        kind, source = attached_source(args)
+        result = broker_call({
+            "op": "attach", "source_kind": kind, "source": source,
+            "owner_user_id": args.owner or "", "channel_id": args.channel,
+            "team_id": args.team or "", "thread_ts": args.thread_ts,
+            "idempotency_key": args.idempotency_key,
+        })
+        if args.json:
+            print(json.dumps(result, ensure_ascii=False))
+            return 0
     elif args.command == "post":
         result = broker_call({
             "op": "thread_reply", "channel_id": args.channel,

--- a/tether/tests/test_bridge.py
+++ b/tether/tests/test_bridge.py
@@ -193,7 +193,7 @@ class StoreTest(unittest.TestCase):
         self.assertEqual(bridge.owner_user_id, "*", "Hermes's explicit allowlist is shared by default")
         self.assertEqual(status["allowed_user_count"], 2)
         self.assertEqual(status["implementation"], "tether")
-        self.assertEqual(status["protocol_version"], 2)
+        self.assertEqual(status["protocol_version"], 3)
         self.assertNotIn("allowed_users", status, "status reports readiness, never identities")
 
     def test_shared_channel_rejects_accidental_owner_restriction(self):
@@ -358,6 +358,40 @@ class StoreTest(unittest.TestCase):
         self.assertEqual(result["thread_ts"], "123.456")
         self.assertEqual(self.store.recent_active_bridges(), [])
         self.assertTrue(self.store.participates("", "C12345678", "123.456"))
+
+    def test_attach_binds_existing_thread_without_posting(self):
+        broker = self.runtime.Broker("test-token", self.store)
+        with mock.patch.object(self.runtime, "slack_post") as post:
+            result = broker.handle({
+                "op": "attach",
+                "source_kind": "claude_session",
+                "source": {"session_id": "claude-1", "cwd": "/tmp/parcha"},
+                "owner_user_id": "U12345678",
+                "team_id": "T12345678",
+                "channel_id": "C12345678",
+                "thread_ts": "123.456",
+                "idempotency_key": "review-123.456",
+            })
+        post.assert_not_called()
+        self.assertEqual(result["thread_ts"], "123.456")
+        bridge = self.store.find("T12345678", "C12345678", "123.456")
+        self.assertEqual(bridge.source_kind, "claude_session")
+        self.assertEqual(bridge.source["session_id"], "claude-1")
+
+    def test_attach_refuses_to_replace_active_binding(self):
+        broker = self.runtime.Broker("test-token", self.store)
+        request = {
+            "op": "attach", "source_kind": "claude_session",
+            "source": {"session_id": "claude-1", "cwd": "/tmp/parcha"},
+            "owner_user_id": "U12345678", "team_id": "T12345678",
+            "channel_id": "C12345678", "thread_ts": "123.456",
+            "idempotency_key": "review-one",
+        }
+        broker.handle(request)
+        request["idempotency_key"] = "review-two"
+        request["source"] = {"session_id": "claude-2", "cwd": "/tmp/parcha"}
+        with self.assertRaisesRegex(ValueError, "already has an active"):
+            broker.handle(request)
 
     def test_thread_participation_survives_store_reopen_and_team_lookup(self):
         self.store.mark_participation("T12345678", "C12345678", "123.456")
@@ -541,6 +575,32 @@ class CredentialBoundaryTest(unittest.TestCase):
             with self.assertRaisesRegex(self.runtime.NativeContinuationError, "not running an allowlisted agent"):
                 self.runtime.zellij_pane_identity("work", "7")
 
+    def test_zellij_identity_resolves_old_pane_with_null_command(self):
+        panes = [{
+            "id": 31,
+            "is_plugin": False,
+            "exited": False,
+            "terminal_command": None,
+        }]
+        completed = types.SimpleNamespace(stdout=json.dumps(panes))
+        with mock.patch.object(
+            self.runtime, "_resolve_executable", return_value="/usr/bin/zellij"
+        ), mock.patch.object(
+            self.runtime.subprocess, "run", return_value=completed
+        ), mock.patch.object(
+            self.runtime,
+            "_zellij_agent_process",
+            return_value=("claude", "proc:3381024:39575982:command-hash"),
+        ) as process_identity:
+            identity = self.runtime.zellij_pane_identity(
+                "didactic-jellyfish", "31", "/tmp/project"
+            )
+        process_identity.assert_called_once_with(
+            "didactic-jellyfish", "31", {"claude", "codex", "gemini", "hermes", "pi"}
+        )
+        self.assertEqual(identity["pane_agent"], "claude")
+        self.assertEqual(len(identity["pane_command_hash"]), 64)
+
     def test_zellij_delivery_fails_closed_when_pane_process_changes(self):
         bridge = self.runtime.Bridge(
             "brg_test", "zellij_pane",
@@ -692,6 +752,59 @@ class NotifierTest(unittest.TestCase):
         request = broker.call_args.args[0]
         self.assertEqual(request["op"], "rebind")
         self.assertEqual(request["source"]["pane_command_hash"], "new-fingerprint")
+
+    def test_attach_captures_an_explicit_existing_native_pane(self):
+        identity = {
+            "session_name": "didactic-jellyfish",
+            "pane_id": "31",
+            "cwd": "/tmp/project",
+            "pane_agent": "claude",
+            "pane_command_hash": "exact-fingerprint",
+        }
+        with mock.patch.object(
+            self.notifier, "zellij_pane_identity", return_value=identity,
+        ) as capture, mock.patch.object(
+            self.notifier, "broker_call",
+            return_value={
+                "ok": True,
+                "bridge_id": "brg_test",
+                "thread_ts": "123.456",
+            },
+        ) as broker:
+            result = self.notifier.main([
+                "attach",
+                "--channel", "C12345678",
+                "--thread-ts", "123.456",
+                "--claude-session-id", "claude-session",
+                "--zellij-session", "didactic-jellyfish",
+                "--zellij-pane-id", "31",
+                "--cwd", "/tmp/project",
+                "--idempotency-key", "attach-existing-123",
+                "--json",
+            ])
+        self.assertEqual(result, 0)
+        capture.assert_called_once_with(
+            "didactic-jellyfish", "31", "/tmp/project"
+        )
+        request = broker.call_args.args[0]
+        self.assertEqual(request["source_kind"], "claude_session")
+        self.assertEqual(request["source"]["session_id"], "claude-session")
+        self.assertEqual(
+            request["source"]["pane_command_hash"], "exact-fingerprint"
+        )
+
+    def test_attach_requires_a_complete_explicit_pane(self):
+        with self.assertRaisesRegex(
+            SystemExit, "--zellij-session and --zellij-pane-id"
+        ):
+            self.notifier.main([
+                "attach",
+                "--channel", "C12345678",
+                "--thread-ts", "123.456",
+                "--claude-session-id", "claude-session",
+                "--zellij-session", "work",
+                "--idempotency-key", "attach-existing-123",
+            ])
 
     def test_noninteractive_setup_delegates_manifest_to_hermes(self):
         args = types.SimpleNamespace(non_interactive=True, no_restart=False)


### PR DESCRIPTION
## Summary
- add a fail-closed `tether attach` operation for existing Slack threads
- capture and fingerprint an explicit live Zellij pane when attaching
- resolve older panes whose Zellij command metadata is absent through exact process metadata
- refuse replacement of an existing active binding

## Validation
- `npm test` (74 tests)
- live attached QA thread to existing grep7 Claude session in Zellij pane 31
- pane received the request and posted one reply to the original thread