### PR TITLE
fix(recall): keep database credentials out of process arguments

### DIFF
--- a/recall/server/scripts/backup_restore.sh
+++ b/recall/server/scripts/backup_restore.sh
@@ -5,6 +5,8 @@ umask 077
 MODE=${1:-}
 BACKUP_DIR=${2:-}
 TOOLS_IMAGE=${PG_TOOLS_IMAGE:-postgres:17-alpine}
+SCRIPT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+LIBPQ_ENV="$SCRIPT_DIR/libpq_env.py"
 
 usage() {
   echo "usage: RECALL_DATABASE_URL=... $0 backup DIR" >&2
@@ -13,10 +15,11 @@ usage() {
 }
 
 fingerprint() {
-  local dsn=$1
+  local url_env=$1
   local snapshot=${2:-}
   if [ -n "$snapshot" ]; then
-    psql "$dsn" -XAtq -v ON_ERROR_STOP=1 <<SQL
+    python3 "$LIBPQ_ENV" exec --url-env "$url_env" -- \
+      psql -XAtq -v ON_ERROR_STOP=1 <<SQL
 BEGIN ISOLATION LEVEL REPEATABLE READ READ ONLY;
 SET TRANSACTION SNAPSHOT '$snapshot';
 SELECT count(*) || ':' || COALESCE(md5(string_agg(source_id || ':' || native_id || ':' || revision || ':' || content_sha256, '|' ORDER BY id)), md5('')) FROM source_events;
@@ -24,13 +27,15 @@ COMMIT;
 SQL
     return
   fi
-  psql "$dsn" -At -v ON_ERROR_STOP=1 -c \
+  python3 "$LIBPQ_ENV" exec --url-env "$url_env" -- \
+    psql -At -v ON_ERROR_STOP=1 -c \
     "SELECT count(*) || ':' || COALESCE(md5(string_agg(source_id || ':' || native_id || ':' || revision || ':' || content_sha256, '|' ORDER BY id)), md5('')) FROM source_events"
 }
 
 snapshot_newest_epoch() {
-  local dsn=$1 snapshot=$2
-  psql "$dsn" -XAtq -v ON_ERROR_STOP=1 <<SQL
+  local url_env=$1 snapshot=$2
+  python3 "$LIBPQ_ENV" exec --url-env "$url_env" -- \
+    psql -XAtq -v ON_ERROR_STOP=1 <<SQL
 BEGIN ISOLATION LEVEL REPEATABLE READ READ ONLY;
 SET TRANSACTION SNAPSHOT '$snapshot';
 SELECT COALESCE(extract(epoch FROM max(created_at))::bigint,0) FROM source_events;
@@ -61,7 +66,8 @@ case "$MODE" in
     started=$(date -u +%s)
     started_ms=$(date -u +%s%3N)
     (
-      psql "$RECALL_DATABASE_URL" -XAtq -v ON_ERROR_STOP=1 <<SQL
+      python3 "$LIBPQ_ENV" exec --url-env RECALL_DATABASE_URL -- \
+        psql -XAtq -v ON_ERROR_STOP=1 <<SQL
 BEGIN ISOLATION LEVEL REPEATABLE READ READ ONLY;
 SELECT pg_export_snapshot();
 \! read ignored < "$snapshot_release"
@@ -76,10 +82,12 @@ SQL
     done
     read -r database_snapshot < "$snapshot_output"
     case "$database_snapshot" in ''|*[!A-Fa-f0-9-]*) echo "invalid exported database snapshot" >&2; exit 1;; esac
-    source_fingerprint=$(fingerprint "$RECALL_DATABASE_URL" "$database_snapshot")
-    newest_epoch=$(snapshot_newest_epoch "$RECALL_DATABASE_URL" "$database_snapshot")
-    docker run --rm --network host "$TOOLS_IMAGE" \
-      pg_dump "$RECALL_DATABASE_URL" --snapshot="$database_snapshot" --format=custom --no-owner >"$stage/brain.dump"
+    source_fingerprint=$(fingerprint RECALL_DATABASE_URL "$database_snapshot")
+    newest_epoch=$(snapshot_newest_epoch RECALL_DATABASE_URL "$database_snapshot")
+    python3 "$LIBPQ_ENV" write --url-env RECALL_DATABASE_URL \
+      --output "$stage/libpq.env"
+    docker run --rm --network host --env-file "$stage/libpq.env" "$TOOLS_IMAGE" \
+      pg_dump --snapshot="$database_snapshot" --format=custom --no-owner >"$stage/brain.dump"
     printf 'release\n' >&9
     wait "$snapshot_pid"
     snapshot_pid=''
@@ -110,7 +118,7 @@ PY
     mv -f "$stage/brain.dump" "$BACKUP_DIR/brain.dump"
     mv -f "$stage/manifest.json" "$BACKUP_DIR/manifest.json"
     chmod 600 "$BACKUP_DIR/brain.dump" "$BACKUP_DIR/manifest.json"
-    rm -f "$stage/snapshot-release" "$stage/snapshot-id"
+    rm -f "$stage/snapshot-release" "$stage/snapshot-id" "$stage/libpq.env"
     rmdir "$stage"
     exec 9>&- 9<&-
     trap - EXIT
@@ -128,9 +136,12 @@ PY
     expected_fingerprint=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["source_fingerprint"])' "$snapshot/manifest.json")
     started=$(date -u +%s)
     started_ms=$(date -u +%s%3N)
-    docker run --rm --network host -v "$snapshot:/backup:ro" "$TOOLS_IMAGE" \
-      pg_restore --dbname="$RECALL_RESTORE_DATABASE_URL" --clean --if-exists --no-owner /backup/brain.dump
-    actual_fingerprint=$(fingerprint "$RECALL_RESTORE_DATABASE_URL")
+    python3 "$LIBPQ_ENV" write --url-env RECALL_RESTORE_DATABASE_URL \
+      --output "$snapshot/libpq.env"
+    docker run --rm --network host --env-file "$snapshot/libpq.env" \
+      -v "$snapshot:/backup:ro" "$TOOLS_IMAGE" \
+      pg_restore --clean --if-exists --no-owner /backup/brain.dump
+    actual_fingerprint=$(fingerprint RECALL_RESTORE_DATABASE_URL)
     completed=$(date -u +%s)
     completed_ms=$(date -u +%s%3N)
     [ "$expected_fingerprint" = "$actual_fingerprint" ] || { echo "restore fingerprint mismatch" >&2; exit 1; }

--- a/recall/server/scripts/libpq_env.py
+++ b/recall/server/scripts/libpq_env.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Translate a verified PostgreSQL URL into libpq environment variables."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import stat
+from pathlib import Path
+from urllib.parse import parse_qsl, unquote, urlsplit
+
+
+ALLOWED_QUERY = {
+    "application_name": "PGAPPNAME",
+    "channel_binding": "PGCHANNELBINDING",
+    "connect_timeout": "PGCONNECT_TIMEOUT",
+    "options": "PGOPTIONS",
+    "sslcert": "PGSSLCERT",
+    "sslkey": "PGSSLKEY",
+    "sslrootcert": "PGSSLROOTCERT",
+    "target_session_attrs": "PGTARGETSESSIONATTRS",
+}
+
+
+class ConnectionPolicyError(ValueError):
+    pass
+
+
+def libpq_environment(url: str) -> dict[str, str]:
+    if not url or any(character in url for character in "\x00\r\n"):
+        raise ConnectionPolicyError("database URL unavailable")
+    parsed = urlsplit(url)
+    try:
+        port = parsed.port or 5432
+    except ValueError as error:
+        raise ConnectionPolicyError("database port invalid") from error
+    database = unquote(parsed.path.removeprefix("/"))
+    username = unquote(parsed.username or "")
+    password = unquote(parsed.password or "")
+    if (
+        parsed.scheme not in {"postgres", "postgresql"}
+        or not parsed.hostname
+        or not database
+        or not username
+        or not password
+        or parsed.fragment
+    ):
+        raise ConnectionPolicyError("database URL invalid")
+    pairs = parse_qsl(parsed.query, keep_blank_values=True)
+    if len({key for key, _value in pairs}) != len(pairs):
+        raise ConnectionPolicyError("database query duplicated")
+    query = dict(pairs)
+    if query.pop("sslmode", None) != "verify-full":
+        raise ConnectionPolicyError("database TLS policy invalid")
+    unknown = set(query) - set(ALLOWED_QUERY)
+    if unknown:
+        raise ConnectionPolicyError("database query unsupported")
+    values = {
+        "PGHOST": parsed.hostname,
+        "PGPORT": str(port),
+        "PGDATABASE": database,
+        "PGUSER": username,
+        "PGPASSWORD": password,
+        "PGSSLMODE": "verify-full",
+        **{ALLOWED_QUERY[key]: value for key, value in query.items()},
+    }
+    if any(
+        not value or any(character in value for character in "\x00\r\n")
+        for value in values.values()
+    ):
+        raise ConnectionPolicyError("database field invalid")
+    return values
+
+
+def write_environment(path: Path, values: dict[str, str]) -> None:
+    if path.exists() or path.is_symlink():
+        raise ConnectionPolicyError("environment output already exists")
+    descriptor = os.open(
+        path,
+        os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0),
+        0o600,
+    )
+    try:
+        with os.fdopen(descriptor, "w") as output:
+            descriptor = -1
+            for key, value in sorted(values.items()):
+                output.write(f"{key}={value}\n")
+            output.flush()
+            os.fsync(output.fileno())
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+    if stat.S_IMODE(path.stat().st_mode) != 0o600:
+        path.unlink(missing_ok=True)
+        raise ConnectionPolicyError("environment output mode invalid")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    operations = parser.add_subparsers(dest="operation", required=True)
+    execute = operations.add_parser("exec")
+    execute.add_argument("--url-env", required=True)
+    execute.add_argument("command", nargs=argparse.REMAINDER)
+    write = operations.add_parser("write")
+    write.add_argument("--url-env", required=True)
+    write.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    values = libpq_environment(os.environ.get(args.url_env, ""))
+    if args.operation == "write":
+        write_environment(args.output, values)
+        return
+    command = args.command
+    if command[:1] == ["--"]:
+        command = command[1:]
+    if not command:
+        execute.error("a command is required")
+    environment = os.environ.copy()
+    environment.pop(args.url_env, None)
+    environment.update(values)
+    os.execvpe(command[0], command, environment)
+
+
+if __name__ == "__main__":
+    main()

--- a/recall/tests/test_backup_restore.py
+++ b/recall/tests/test_backup_restore.py
@@ -30,6 +30,15 @@ class BackupPublicationTest(unittest.TestCase):
             docker.write_text(
                 """#!/bin/sh
 set -eu
+case "$*" in *synthetic-secret*) exit 9;; esac
+previous=''
+environment=''
+for argument in "$@"; do
+  test "$previous" != '--env-file' || environment=$argument
+  previous=$argument
+done
+test -n "$environment"
+grep -qx 'PGPASSWORD=synthetic-secret' "$environment"
 case "$*" in *':/backup'*) exit 5;; esac
 case "$*" in *--snapshot=00000001-00000001-1*) :;; *) exit 3;; esac
 printf partial
@@ -59,7 +68,10 @@ esac
             psql.chmod(0o755)
             environment = os.environ | {
                 "PATH": str(binaries) + os.pathsep + os.environ["PATH"],
-                "RECALL_DATABASE_URL": "postgresql://synthetic.invalid/db",
+                "RECALL_DATABASE_URL": (
+                    "postgresql://synthetic:synthetic-secret@synthetic.invalid/db"
+                    "?sslmode=verify-full"
+                ),
                 "BACKUP_CONTROL_DIR": str(control),
             }
             process = subprocess.Popen(
@@ -113,11 +125,18 @@ esac
             docker.write_text(
                 """#!/bin/sh
 set -eu
+case "$*" in *synthetic-secret*) exit 9;; esac
 mount=''
+previous=''
+environment=''
 for argument in "$@"; do
+  test "$previous" != '--env-file' || environment=$argument
   case "$argument" in *:/backup:ro) mount=${argument%:/backup:ro};; esac
+  previous=$argument
 done
 test -n "$mount"
+test -n "$environment"
+grep -qx 'PGPASSWORD=synthetic-secret' "$environment"
 touch "$BACKUP_CONTROL_DIR/snapshot-opened"
 while test ! -e "$BACKUP_CONTROL_DIR/continue"; do sleep 0.02; done
 test "$(cat "$mount/brain.dump")" = 'stable-root-owned-dump'
@@ -132,7 +151,10 @@ test "$(cat "$mount/brain.dump")" = 'stable-root-owned-dump'
             forbidden_link.chmod(0o755)
             environment = os.environ | {
                 "PATH": str(binaries) + os.pathsep + os.environ["PATH"],
-                "RECALL_RESTORE_DATABASE_URL": "postgresql://synthetic.invalid/restore",
+                "RECALL_RESTORE_DATABASE_URL": (
+                    "postgresql://synthetic:synthetic-secret@synthetic.invalid/restore"
+                    "?sslmode=verify-full"
+                ),
                 "BACKUP_CONTROL_DIR": str(control),
             }
             process = subprocess.Popen(

--- a/recall/tests/test_libpq_env.py
+++ b/recall/tests/test_libpq_env.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+import stat
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+HELPER = ROOT / "server" / "scripts" / "libpq_env.py"
+SPEC = importlib.util.spec_from_file_location("libpq_env", HELPER)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class LibpqEnvironmentTest(unittest.TestCase):
+    def test_verified_url_becomes_private_environment_file(self) -> None:
+        url = (
+            "postgresql://synthetic-user:synthetic-password@db.invalid:5433/recall"
+            "?sslmode=verify-full&sslrootcert=%2Fsynthetic%2Fca.pem"
+        )
+        values = MODULE.libpq_environment(url)
+        self.assertEqual(values["PGHOST"], "db.invalid")
+        self.assertEqual(values["PGPORT"], "5433")
+        self.assertEqual(values["PGPASSWORD"], "synthetic-password")
+        self.assertEqual(values["PGSSLMODE"], "verify-full")
+        with tempfile.TemporaryDirectory() as temporary:
+            output = Path(temporary) / "libpq.env"
+            MODULE.write_environment(output, values)
+            self.assertEqual(stat.S_IMODE(output.stat().st_mode), 0o600)
+            self.assertIn("PGPASSWORD=synthetic-password", output.read_text())
+
+    def test_exec_removes_url_and_secret_from_process_arguments(self) -> None:
+        url = (
+            "postgresql://synthetic-user:synthetic-password@db.invalid/recall"
+            "?sslmode=verify-full"
+        )
+        code = (
+            "import json,os,sys;"
+            "print(json.dumps({'argv':sys.argv,'url':os.getenv('DATABASE_URL'),"
+            "'password':os.getenv('PGPASSWORD'),'tls':os.getenv('PGSSLMODE')}))"
+        )
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(HELPER),
+                "exec",
+                "--url-env",
+                "DATABASE_URL",
+                "--",
+                sys.executable,
+                "-c",
+                code,
+            ],
+            env=os.environ | {"DATABASE_URL": url},
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        self.assertNotIn("synthetic-password", " ".join(completed.args))
+        self.assertNotIn(url, completed.stdout)
+        self.assertIn('"url": null', completed.stdout)
+        self.assertIn('"password": "synthetic-password"', completed.stdout)
+        self.assertIn('"tls": "verify-full"', completed.stdout)
+
+    def test_rejects_weaker_tls_and_duplicate_query_keys(self) -> None:
+        for url in (
+            "postgresql://user:password@db.invalid/recall?sslmode=require",
+            "postgresql://user:password@db.invalid/recall"
+            "?sslmode=verify-full&sslmode=verify-full",
+        ):
+            with self.subTest(url=url):
+                with self.assertRaises(MODULE.ConnectionPolicyError):
+                    MODULE.libpq_environment(url)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- translate verified PostgreSQL URLs into libpq environment variables
- keep database passwords out of local and container process arguments
- use transient mode-600 container environment files with cleanup

## Verification
- 517 Python tests + 3 launcher E2Es
- Ruff, Bandit, and pip-audit clean
- targeted backup/TLS/argv tests: 5/5
- staged credential-shape scan passed
- no docs/evidence, transcripts, live content, or credentials included