### PR TITLE
fix(recall): schedule logical backups without overlap

### DIFF
--- a/recall/server/deploy/README.md
+++ b/recall/server/deploy/README.md
@@ -237,9 +237,13 @@ principal-wide. Add `--capture-origin ORIGIN` to a principal-aware read/write to
 arguments cannot override either. Hosted capture structurally scrubs title and body before the
 canonical event is stored.
 
-The pilot uses a five-minute logical-backup timer for a bounded RPO. Before multi-user scale or
-C10 production cutover, replace it with continuous WAL archival plus daily base backups; the
-same blank-database restore/fingerprint contract remains the gate.
+The pilot timer starts its first logical backup after 15 minutes and schedules another six hours
+after the previous run finishes. This deliberately prevents overlapping full dumps. The interval
+is a conservative example, not an RPO guarantee: measure a complete backup on the real corpus and
+set the schedule from its duration, available disk, and provider-native recovery guarantees.
+Before multi-user scale or C10 production cutover, use provider point-in-time recovery or
+continuous WAL archival plus daily base backups; the same blank-database restore/fingerprint
+contract remains the gate.
 
 Searches have a 300ms database-work budget by default. Override it only within the validated
 10–5000ms range with `RECALL_SEARCH_DEADLINE_MS`; the response and service log expose only

--- a/recall/server/deploy/recall-brain-backup.service
+++ b/recall/server/deploy/recall-brain-backup.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Recall BrainStore five-minute logical backup
+Description=Recall BrainStore logical backup
 After=recall-brain.service
 
 [Service]

--- a/recall/server/deploy/recall-brain-backup.timer
+++ b/recall/server/deploy/recall-brain-backup.timer
@@ -1,9 +1,9 @@
 [Unit]
-Description=Keep Recall BrainStore logical-backup RPO within five minutes
+Description=Schedule non-overlapping Recall BrainStore logical backups
 
 [Timer]
-OnBootSec=2min
-OnUnitActiveSec=5min
+OnActiveSec=15min
+OnUnitInactiveSec=6h
 AccuracySec=15s
 Persistent=true
 

--- a/recall/tests/test_backup_restore.py
+++ b/recall/tests/test_backup_restore.py
@@ -15,6 +15,14 @@ SCRIPT = ROOT / "server/scripts/backup_restore.sh"
 
 
 class BackupPublicationTest(unittest.TestCase):
+    def test_deployment_timer_is_non_overlapping_and_makes_no_false_rpo_claim(self) -> None:
+        timer = (ROOT / "server/deploy/recall-brain-backup.timer").read_text()
+        service = (ROOT / "server/deploy/recall-brain-backup.service").read_text()
+        self.assertIn("OnActiveSec=15min", timer)
+        self.assertIn("OnUnitInactiveSec=6h", timer)
+        self.assertNotIn("OnUnitActiveSec", timer)
+        self.assertNotIn("five-minute", (timer + service).lower())
+
     def test_backup_keeps_previous_dump_visible_until_replacement_is_complete(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)


### PR DESCRIPTION
## Summary
- schedule the first logical backup after 15 minutes and subsequent backups six hours after completion
- prevent overlapping full dumps with completion-relative scheduling
- remove the false five-minute RPO claim and document capacity-based tuning

## Live finding
The first real full-corpus backup completed successfully in 18m53s, so the previous five-minute activation cadence was neither honest nor operationally sound.

## Verification
- deployment timer contract: 3/3 tests pass
- credential-shape scan passed
- no evidence, transcripts, content, or credentials included