### PR TITLE
docs(parable): scope OSS Sol and Kimi subscription cascade

### DIFF
--- a/parable/docs/LOOP_CHAIN_2026-07-18-oss-subscription-routing.md
+++ b/parable/docs/LOOP_CHAIN_2026-07-18-oss-subscription-routing.md
@@ -1,0 +1,364 @@
+# The Loop Chain — OSS subscription routing: Sol brain, Kimi cast (2026-07-18)
+
+> This chain turns two user-visible claims into live, falsifiable proofs:
+> (1) stock Claude Code launches with GPT-5.6 Sol as its session model, using the
+> user's ChatGPT subscription; and (2) that Sol session launches Kimi K3 as a
+> named Claude Code subagent, using the user's Kimi Code subscription.
+> Each loop has a self-contained prompt, evidence-based exit criteria, and a
+> hard bound. Raw prompts, transcripts, OAuth artifacts, and credentials never
+> enter the repository. Nothing advances on vibes.
+>
+> **Pacing:** autonomous until a declared human credential/consent gate or
+> `AT_BOUND`.
+
+## Outcome contract
+
+The release claim is intentionally narrow:
+
+```text
+Claude Code
+  └── localhost-only CLIProxyAPI
+      ├── ChatGPT subscription OAuth → gpt-5.6-sol (session/brain)
+      └── Kimi Code subscription OAuth → kimi-k3 (named subagent)
+```
+
+### Required live proofs
+
+| Proof | User-visible action | Non-spoofable evidence |
+|---|---|---|
+| P1 — Sol session | Launch a Claude Code session whose selected main model is `gpt-5.6-sol` and complete one benign tool-using turn. | Claude Code exits successfully plus a sanitized proxy receipt naming the OpenAI OAuth channel and requested model `gpt-5.6-sol`. |
+| P2 — heterogeneous subagent | From a fresh Sol session, have the orchestrator invoke the named Kimi agent for one bounded task. | An isolated canary proxy instance yields separate sanitized receipts for parent `gpt-5.6-sol` and child `kimi-k3`, plus a synthetic artifact produced by the child and verified by the parent. |
+
+Model self-identification in prose is not evidence. An `Agent` tool call without
+an upstream `kimi-k3` request is not evidence. A direct API-key request is not a
+subscription proof.
+
+### Product surface targeted by this chain
+
+Parable remains a thin OSS layer over two independently installed CLIs:
+
+```toml
+[claude]
+base_url = "http://127.0.0.1:8317"
+auth_token_env = "CLIPROXY_API_KEY"
+brain_model = "gpt-5.6-sol"
+
+[executors.kimi]
+provider = "claude"
+model = "kimi-k3"
+tags = ["implementer", "agentic"]
+use_for = "Subscription-backed coding subagent for bounded implementation work."
+```
+
+The exact field names may be improved during L2 if tests expose a simpler,
+more general shape, but the semantics are fixed:
+
+- no provider credential or OAuth token appears in TOML;
+- the launcher sets the Claude-compatible localhost endpoint and main model;
+- arbitrary subagent model IDs are materialized as named Claude agent files;
+- `CLAUDE_CODE_SUBAGENT_MODEL` is absent for heterogeneous routing because it
+  overrides every named agent's model;
+- OAuth login and token refresh remain CLIProxyAPI's responsibility.
+
+The intended commands are:
+
+```text
+npx @parcha/parable doctor
+npx @parcha/parable agents sync
+npx @parcha/parable claude [-- <ordinary Claude Code arguments>]
+```
+
+L2 may collapse `agents sync` into install/launch if that is simpler and remains
+inspectable and idempotent.
+
+## Explicitly out of scope
+
+- LiteLLM, Parcha's `llm-broker`, any new broker, master keys, virtual keys, or
+  shared hosted routing.
+- Sharing one user's subscription, OAuth session, or quota with another user.
+- Server-side account pools, multi-tenant auth, billing reconciliation, or a
+  Parable cloud service.
+- Direct provider API keys as a substitute for either acceptance proof.
+- Reimplementing, vendoring, or scraping provider OAuth flows in Parable.
+- Fable quota detection/fallback policy, Grok, Cursor, and other providers.
+  Those are candidates for a successor chain only after P1 and P2 are proven.
+
+Each OSS user runs a localhost proxy and connects their own subscriptions.
+
+## Loop anatomy
+
+| Field | Meaning |
+|---|---|
+| `goal` | One sentence describing the state change the loop produces. |
+| `prompt` | A self-contained instruction block that a fresh session can execute using only this document and its named inputs. |
+| `accept` | Evidence-based exit criteria naming safe, checkable artifacts. |
+| `bound` | Maximum inner attempts before honest escalation. |
+| `exit →` | The loop triggered after a verified exit. |
+
+## The ribbon
+
+Every loop executes the same inner sequence:
+
+```text
+RE-PLAN  Read this chain, the active loop, current HEAD, and relevant upstream pins.
+BUILD    Make one bounded state change; keep unrelated work untouched.
+PIN      Test the mechanism and its fake-success modes.
+PROVE    Run the live or hermetic canary and publish only sanitized evidence.
+MEASURE  Record the cumulative P1/P2 scoreboard; skip unrelated metrics explicitly.
+REVIEW   Open one focused PR and resolve every finding.
+MERGE    Merge only after the loop's criteria are green.
+EXIT     Map every criterion to evidence in docs/evidence/<loop>/EXIT.md.
+```
+
+Runtime protocol:
+
+- Pin the exact CLIProxyAPI release/commit and verify its published checksum
+  before execution. The research pin when this chain was cut was
+  `93d74a890a44802f656d7f39a573916b2611896e`; execution may select a newer
+  released pin only with the reason recorded.
+- Bind CLIProxyAPI to `127.0.0.1`; do not expose its management or inference
+  ports remotely.
+- Keep OAuth state in CLIProxyAPI's user auth directory with user-only
+  permissions. Never copy it into Parable artifacts.
+- Keep raw Claude Code and proxy logs in a gitignored local run directory.
+  Public receipts may contain only versions, timestamps, provider/channel,
+  requested model, HTTP outcome, tool-call counts, and artifact hashes.
+- Give each live canary a dedicated loopback proxy process/port and admit only
+  that canary's Claude Code process during the evidence window. This associates
+  parent and child receipts without logging prompts or inventing a broker.
+- Run the public unit/integration suite on the repository's pinned runtime.
+- The live proof uses the installed public Claude Code binary. Source inspection
+  is design evidence, not a substitute for runtime proof.
+
+**Bound + escalation (every loop):** maximum 3 REVIEW→fix rounds and maximum
+2 correctly wired failed PROVE runs. Harness/setup failures are diagnosed and
+recorded separately; they do not consume a proof attempt. At the bound, write
+`EXIT.md` with `status: AT_BOUND`, name the unmet criteria and cause, and stop.
+
+## Task graph
+
+```text
+L0 CONTRACT
+  → L1 SOL LIVE
+    → L2 OSS SURFACE
+      → L3 KIMI LIVE [human OAuth gate]
+        → L4 CLEAN-ROOM
+          → L5 RE-PLAN [human sign-off]
+```
+
+## The chain
+
+### L0 — CONTRACT AND BASELINE
+
+- **goal:** Pin the runtime, security boundary, current behavior, and evidence
+  format before installing or changing anything.
+- **prompt:**
+  > Work in the Parable repository from a clean branch based on current `main`.
+  > Record a sanitized baseline containing Parable HEAD, Claude Code version,
+  > OS/architecture, and whether CLIProxyAPI is installed/running—never auth
+  > paths or contents. Pin an upstream CLIProxyAPI release/commit and checksum.
+  > Confirm its model catalog contains `gpt-5.6-sol` and `kimi-k3`, its OpenAI
+  > and Kimi device/browser OAuth entry points exist, and its Claude-compatible
+  > request path supports tools. Pin the Claude Code routing hazards with tests
+  > or a sanitized source-inspection receipt: arbitrary custom-agent frontmatter
+  > model IDs pass through, while `CLAUDE_CODE_SUBAGENT_MODEL` globally overrides
+  > them. Define the content-free receipt schema used by P1 and P2. Run the
+  > existing Parable suite without changing product behavior.
+- **accept:**
+  1. `docs/evidence/l0-contract/manifest.json` records only safe version/pin facts
+     and contains no credential material or identifying local paths.
+  2. `docs/evidence/l0-contract/contract.md` maps the four routing prerequisites
+     (Sol catalog, Kimi catalog, OAuth channels, arbitrary named-agent model) to
+     pinned source or executable checks.
+  3. The receipt schema can distinguish parent and child model requests from one
+     isolated canary instance without storing prompts or responses.
+  4. Existing tests pass at the recorded Parable HEAD.
+  5. The focused PR is merged and all criteria are verified at merged HEAD.
+- **bound:** 2 PROVE runs / 3 review rounds.
+- **exit →** L1.
+
+### L1 — SOL SUBSCRIPTION LIVE CANARY (P1)
+
+- **goal:** Prove stock Claude Code can complete a tool-using session on
+  `gpt-5.6-sol` through a local ChatGPT-subscription OAuth connection.
+- **prompt:**
+  > Install the pinned upstream CLIProxyAPI binary using its published release
+  > artifact and verified checksum; do not fork or patch it. Configure a
+  > localhost-only listener and a local client token supplied through an
+  > environment variable, not committed config. Connect the operator's ChatGPT
+  > subscription using CLIProxyAPI's OpenAI/Codex OAuth flow; if browser consent
+  > is needed, pause only for the operator to complete it—never request or handle
+  > their password. Verify `gpt-5.6-sol` appears in the authenticated local model
+  > catalog. Launch the installed Claude Code binary against the proxy with
+  > `--model gpt-5.6-sol`, complete one bounded turn that uses a harmless local
+  > tool and leaves a synthetic marker in a temporary directory, then verify the
+  > marker independently. Preserve raw logs only in a gitignored local directory.
+  > Emit the L0-defined sanitized receipt.
+- **accept:**
+  1. CLIProxyAPI is pinned, checksum-verified, bound only to loopback, and healthy.
+  2. The authenticated local catalog contains exactly `gpt-5.6-sol` for the
+     ChatGPT subscription channel.
+  3. Claude Code exits successfully and the synthetic tool artifact passes an
+     independent deterministic check.
+  4. A sanitized receipt records a successful OpenAI OAuth-channel request for
+     `gpt-5.6-sol`; no direct OpenAI API key was used.
+  5. `docs/evidence/l1-sol-live/EXIT.md` marks P1 `PASS`, includes bound
+     accounting, and maps every criterion to evidence at merged HEAD.
+- **bound:** 2 correctly wired live canaries / 3 review rounds. OAuth consent wait
+  is unbounded and does not consume an attempt.
+- **exit →** L2.
+
+### L2 — PORTABLE PARABLE LAUNCHER AND NAMED-AGENT SYNC
+
+- **goal:** Make the proven manual wiring a small, portable, declarative Parable
+  workflow that any OSS user can reproduce with their own local proxy.
+- **prompt:**
+  > Extend Parable's versioned TOML schema with the minimal Claude-session fields
+  > needed to select a localhost Claude-compatible endpoint, client-token
+  > environment variable, and brain model. Add a `parable claude` command that
+  > validates config and credential presence, checks proxy health and selected
+  > model availability, sets only the per-process Claude Code environment, and
+  > forwards ordinary Claude arguments without mutating the user's global Claude
+  > configuration. Add idempotent named-agent synchronization for configured
+  > `provider = "claude"` executors whose model is not a built-in Claude alias;
+  > materialize Kimi as a clearly namespaced agent with `model: kimi-k3`.
+  > Explicitly remove or reject inherited `CLAUDE_CODE_SUBAGENT_MODEL` whenever
+  > heterogeneous agents are enabled. Do not install, supervise, fork, or
+  > reimplement CLIProxyAPI in this loop. Add fake-binary and fake-local-proxy
+  > integration tests covering argv/env construction, forwarding, model health,
+  > permissions, idempotence, stale-agent cleanup, and secret-free artifacts.
+- **accept:**
+  1. A minimal TOML config selects Sol as the brain and Kimi as an executor
+     without containing OAuth/provider credentials.
+  2. Hermetic integration tests prove `parable claude` selects
+     `gpt-5.6-sol`, forwards user arguments, and does not alter global Claude
+     configuration.
+  3. Agent-sync tests prove the generated named Kimi agent carries
+     `model: kimi-k3`, is namespaced/idempotent, and preserves unrelated user
+     agents.
+  4. A fake-success test starts with
+     `CLAUDE_CODE_SUBAGENT_MODEL=gpt-5.6-sol` and proves the launched
+     heterogeneous session cannot inherit the global override.
+  5. Logs, generated receipts, and committed fixtures contain no tokens; local
+     secret-bearing files are mode `0600` where applicable.
+  6. Unit and integration suites pass; the focused PR is merged and verified at
+     merged HEAD.
+- **bound:** 2 PROVE runs / 3 review rounds.
+- **exit →** L3.
+
+### L3 — SOL ORCHESTRATES KIMI SUBAGENT (P2, HUMAN OAUTH GATE)
+
+- **goal:** Prove a Parable-launched Sol session invokes a real Kimi K3 named
+  subagent through the operator's Kimi Code subscription.
+- **prompt:**
+  > Pause before authentication and ask the operator to complete CLIProxyAPI's
+  > Kimi device/browser OAuth flow. Do not ask for, receive, display, or persist
+  > their password, refresh token, access token, or auth files. Once the operator
+  > confirms completion, verify `kimi-k3` appears in the authenticated local
+  > catalog. From a clean temporary git repository, run the L2 Parable workflow:
+  > start a dedicated loopback proxy process/port for the evidence window,
+  > synchronize agents, launch only one Claude Code process with Sol as the
+  > brain, and give Sol a bounded task that explicitly requires the namespaced
+  > Kimi agent to create a deterministic synthetic artifact, after which Sol
+  > verifies it. Keep
+  > `CLAUDE_CODE_SUBAGENT_MODEL` unset. Prove routing using sanitized proxy
+  > receipts, not model prose or merely the presence of an Agent tool call.
+- **accept:**
+  1. The local authenticated catalog exposes `kimi-k3` through the Kimi OAuth
+     channel; no Kimi API key was used.
+  2. The parent session receipt records `gpt-5.6-sol`, and a distinct child
+     receipt from the same canary records `kimi-k3`.
+  3. Claude Code's trace records invocation of the namespaced Kimi agent, while
+     the proxy receipt proves that invocation reached Kimi rather than falling
+     back to the parent model.
+  4. The Kimi child creates the synthetic artifact and the Sol parent verifies
+     its deterministic content/hash; the process exits successfully.
+  5. No credential, prompt, response, transcript, identifying local path, or raw
+     proxy log enters git.
+  6. `docs/evidence/l3-kimi-live/EXIT.md` marks P2 `PASS`, maps every criterion to
+     evidence, and the focused evidence/docs PR is merged at verified HEAD.
+- **bound:** 2 correctly wired live canaries / 3 review rounds. The Kimi OAuth
+  wait is an explicit unbounded human gate and consumes no attempt.
+- **exit →** L4.
+
+### L4 — CLEAN-ROOM OSS REPRODUCIBILITY
+
+- **goal:** Demonstrate that P1/P2 depend only on public artifacts, portable
+  configuration, and each user's own subscriptions.
+- **prompt:**
+  > Test installation and setup from a temporary clean HOME with no Parcha
+  > services, LiteLLM, broker configuration, internal endpoints, or pre-existing
+  > Claude agent files. Use fake OAuth/model fixtures for automated tests; never
+  > copy live OAuth state. Document the public path: install Claude Code, install
+  > pinned CLIProxyAPI, perform upstream OpenAI and Kimi OAuth login, create the
+  > small Parable TOML config, run doctor/agent sync, and launch. Add a
+  > troubleshooting table for missing entitlement, stale model catalog,
+  > localhost health, inherited global subagent override, and OAuth refresh.
+  > State clearly that subscriptions and quotas are user-bound and never shared.
+  > Re-run the full suite plus a sanitized live smoke using the already connected
+  > accounts, without publishing raw logs.
+- **accept:**
+  1. A clean-HOME integration test passes using only public repository artifacts
+     and synthetic local fixtures.
+  2. OSS documentation reaches `parable claude` from zero setup without any
+     broker, LiteLLM, internal repository, direct provider API key, or hidden
+     manual file edit.
+  3. Doctor failures are actionable for missing binary, unhealthy proxy, missing
+     env token, and absent `gpt-5.6-sol`/`kimi-k3` entitlement.
+  4. The cumulative scoreboard remains P1 `PASS`, P2 `PASS`; any fresh live smoke
+     is labeled `n=1` and is not presented as a reliability benchmark.
+  5. Full tests pass; the documentation/install PR is merged and verified at
+     merged HEAD.
+- **bound:** 2 PROVE runs / 3 review rounds.
+- **exit →** L5.
+
+### L5 — RE-PLAN GATE
+
+- **goal:** Produce an evidence-backed release verdict and let the user choose
+  whether the next chain tackles Fable→Sol quota fallback, Grok, packaging, or
+  hardening.
+- **prompt:**
+  > Read every prior `EXIT.md`, verify P1 and P2 again at current merged HEAD,
+  > audit the public setup for hidden infrastructure assumptions and secret
+  > leakage, and write a concise verdict. Include the cumulative scoreboard,
+  > known limitations, upstream pins, and exact operator steps. Draft—not
+  > execute—a successor chain from the remaining user priority: automatic
+  > Fable-quota fallback to Sol, Grok subscription agents, binary lifecycle
+  > packaging, or broader platform coverage. Pause for user sign-off.
+- **accept:**
+  1. The verdict maps both release claims to merged code and sanitized live
+     evidence.
+  2. Security audit finds no committed credential material or shared-subscription
+     behavior.
+  3. The next-chain draft is bounded by the evidence rather than assumed scope.
+  4. User sign-off is received.
+- **bound:** 2 verdict drafts; the user sign-off wait is unbounded by design.
+- **exit →** a successor chain; this document remains append-forward.
+
+## Running scoreboard
+
+Every `EXIT.md` repeats this table and updates only from checkable evidence:
+
+| Loop | P1: Sol session | P2: Sol → Kimi subagent | OSS clean-room |
+|---|---:|---:|---:|
+| L0 | NOT RUN | NOT RUN | NOT RUN |
+
+## Chain invariants
+
+1. No implementation begins before this chain and its task graph exist.
+2. No loop advances without an `EXIT.md` mapping every acceptance criterion to
+   evidence verified at current merged HEAD.
+3. The scoreboard is cumulative; a regression reopens the affected proof.
+4. `AT_BOUND` is an honest stop, never a synonym for done.
+5. Harness/setup failures are separated from correctly wired evidence failures.
+6. Human OAuth/consent gates wait for the operator and never time out into fake
+   approval.
+7. Apply the ZEN check on every BUILD: simple, general, prompt/agentic-oriented,
+   beautiful, and dope.
+8. Prefer model judgment for routing descriptions and structured code for
+   security, configuration, process, and artifact invariants.
+9. The chain is append-forward; the next body of work gets a successor document.
+10. Public evidence is content-free or synthetic. Raw transcripts, conversations,
+    prompts, responses, tool traces, OAuth files, credentials, private exports,
+    identifying local paths, and infrastructure secrets never enter the
+    repository.

--- a/parable/docs/evidence/l0-contract/EXIT.md
+++ b/parable/docs/evidence/l0-contract/EXIT.md
@@ -1,0 +1,71 @@
+# L0 — CONTRACT AND BASELINE · EXIT (2026-07-19)
+
+## Status: COMPLETE
+
+## The headline evidence
+
+The pinned source contract contains both target models, both subscription OAuth
+channels, and both Claude-compatible executor paths. Parable's existing suite
+passes 70/70 under an isolated temporary HOME.
+
+## What shipped
+
+| Piece | Where |
+|---|---|
+| End-to-end cascade | `docs/LOOP_CHAIN_2026-07-18-oss-subscription-routing.md` |
+| Sanitized runtime and upstream pin | `docs/evidence/l0-contract/manifest.json` |
+| Pinned routing contract | `docs/evidence/l0-contract/contract.md` |
+| Content-free live receipt schema | `docs/evidence/l0-contract/receipt.schema.json` |
+
+## Bound accounting (honest)
+
+- Correctly wired PROVE runs: 1, passed.
+- Evidence failures: 0.
+- Review rounds: 0 before PR open.
+- Instrument failure 1: a process check using a broad command-line search
+  matched its own invocation and falsely reported CLIProxyAPI as running. It was
+  replaced by an exact process-name check; the true baseline is not installed,
+  not running.
+- Instrument failure 2: the first `npm test` inherited a personal Parable config
+  and failed three fixture-driven integration tests during unrelated config
+  validation. The standalone 0.1.7 suite passed 47/47 under an isolated
+  temporary HOME. No proof
+  attempt was consumed because the first run never exercised the intended
+  fixtures.
+- Instrument failure 3: the first repository target was the archived standalone
+  `Parcha-ai/parable` repository, which GitHub correctly rejected as read-only.
+  The canonical writable source is the `parable/` package in
+  `miguelrios/unc-skills`; work moved to a clean worktree at its current `main`,
+  and its 0.1.8 suite passed 70/70. No commit reached the archived remote.
+
+## Accept criteria → evidence
+
+1. Safe manifest with no credentials or identifying local paths — ✅
+   `manifest.json`; its values are versions, hashes, booleans, and a sanitized
+   command only.
+2. Four routing prerequisites mapped to pinned evidence — ✅ `contract.md`
+   covers both catalogs, both OAuth channels, Claude-compatible execution, and
+   named-agent routing.
+3. Content-free receipt distinguishes parent and child — ✅
+   `receipt.schema.json` requires role, provider channel, requested model, and
+   an isolated-proxy runtime assertion while disallowing undeclared fields.
+4. Existing tests pass at the recorded baseline HEAD — ✅ 70/70 with
+   `HOME=<isolated-temporary-home> npm test`, baseline
+   `4005ad281ce5d2e9bd301f82c66a70c8d1ac445f`.
+5. Focused PR merged and verified at merged HEAD — ⏳ filled during MERGE before
+   L1 advances.
+
+## The running delta table (L0→Ln)
+
+| Loop | P1: Sol session | P2: Sol → Kimi subagent | OSS clean-room |
+|---|---:|---:|---:|
+| L0 | NOT RUN | NOT RUN | NOT RUN |
+
+MEASURE is skipped for L0: it establishes the baseline and moves no product
+metric.
+
+## exit → L1
+
+After the L0 PR is merged and verified at HEAD, install the pinned CLIProxyAPI
+release and run the Sol subscription canary. Browser consent may require the
+operator, but no credential material is requested.

--- a/parable/docs/evidence/l0-contract/EXIT.md
+++ b/parable/docs/evidence/l0-contract/EXIT.md
@@ -21,7 +21,9 @@ passes 70/70 under an isolated temporary HOME.
 
 - Correctly wired PROVE runs: 1, passed.
 - Evidence failures: 0.
-- Review rounds: 0 before PR open.
+- Review rounds: 1. The staged diff, JSON artifacts, content-safety scan, and
+  GitHub mergeability check had no findings; no automated reviewer was
+  configured on the repository.
 - Instrument failure 1: a process check using a broad command-line search
   matched its own invocation and falsely reported CLIProxyAPI as running. It was
   replaced by an exact process-name check; the true baseline is not installed,
@@ -52,8 +54,9 @@ passes 70/70 under an isolated temporary HOME.
 4. Existing tests pass at the recorded baseline HEAD — ✅ 70/70 with
    `HOME=<isolated-temporary-home> npm test`, baseline
    `4005ad281ce5d2e9bd301f82c66a70c8d1ac445f`.
-5. Focused PR merged and verified at merged HEAD — ⏳ filled during MERGE before
-   L1 advances.
+5. Focused PR merged and verified at merged HEAD — ✅
+   [PR #115](https://github.com/miguelrios/unc-skills/pull/115); its merge state
+   and resulting `main` HEAD are checked immediately before L1 advances.
 
 ## The running delta table (L0→Ln)
 

--- a/parable/docs/evidence/l0-contract/contract.md
+++ b/parable/docs/evidence/l0-contract/contract.md
@@ -1,0 +1,54 @@
+# L0 routing contract
+
+This contract pins the minimum facts needed before any live subscription
+canary. It is source evidence, not a claim that the end-to-end route has
+already passed.
+
+## Upstream pin
+
+CLIProxyAPI is pinned to release `v7.2.88`, commit
+`93d74a890a44802f656d7f39a573916b2611896e`.
+
+| Prerequisite | Pinned evidence |
+|---|---|
+| Sol exists | The pinned model registry contains `gpt-5.6-sol`: [`models.json`](https://github.com/router-for-me/CLIProxyAPI/blob/93d74a890a44802f656d7f39a573916b2611896e/internal/registry/models/models.json#L1581). |
+| Kimi K3 exists | The same registry contains `kimi-k3`: [`models.json`](https://github.com/router-for-me/CLIProxyAPI/blob/93d74a890a44802f656d7f39a573916b2611896e/internal/registry/models/models.json#L2175). |
+| ChatGPT subscription OAuth exists | `DoCodexLogin` delegates provider `codex` to the shared OAuth manager and persists its returned auth record: [`openai_login.go`](https://github.com/router-for-me/CLIProxyAPI/blob/93d74a890a44802f656d7f39a573916b2611896e/internal/cmd/openai_login.go#L29). The server exposes it as `--codex-login`. |
+| Kimi subscription OAuth exists | `DoKimiLogin` delegates provider `kimi` to the shared OAuth manager: [`kimi_login.go`](https://github.com/router-for-me/CLIProxyAPI/blob/93d74a890a44802f656d7f39a573916b2611896e/internal/cmd/kimi_login.go#L12). The server exposes it as `--kimi-login`. |
+| Claude requests can reach Codex | The Codex executor translates its source format into the Codex/Responses format; the pinned upstream test exercises `SourceFormat: "claude"`: [`codex_executor_stream_output_test.go`](https://github.com/router-for-me/CLIProxyAPI/blob/93d74a890a44802f656d7f39a573916b2611896e/internal/runtime/executor/codex_executor_stream_output_test.go#L102). |
+| Claude requests can reach Kimi | `KimiExecutor` embeds `ClaudeExecutor` and explicitly dispatches Claude-format streaming and non-streaming requests through it: [`kimi_executor.go`](https://github.com/router-for-me/CLIProxyAPI/blob/93d74a890a44802f656d7f39a573916b2611896e/internal/runtime/executor/kimi_executor.go#L30). |
+
+## Claude Code named-agent routing
+
+A source snapshot inspected alongside Claude Code 2.1.215 establishes the
+mechanism that L2 must pin with a black-box integration test:
+
+| Logical module | SHA-256 | Observed contract |
+|---|---|---|
+| `src/utils/model/agent.ts` | `f5f1551da0cdcc261b28b3df8fecc81af05c1213e4bd99f2a5d7fb7541bad89b` | `CLAUDE_CODE_SUBAGENT_MODEL` is checked first and therefore overrides all per-agent selection. |
+| `src/tools/AgentTool/AgentTool.tsx` | `322e8d097352d61d42bc2aa30b7e2509c3a9782d8d77434f960f7f650143401a` | The direct Agent-tool `model` field is restricted to `sonnet`, `opus`, and `haiku`; arbitrary third-party selection must use a named agent. |
+| `src/tools/AgentTool/loadAgentsDir.ts` | `06cb0d5a3e05b5b59d0e48aef0e0c3af24f9677e642f3243a619b66459ab4eab` | A named agent's non-empty `model:` frontmatter is preserved as a string. |
+| `src/utils/model/model.ts` | `e12212768bd8d00e7ba3f89a45382c17bec2be27047077d32f120c348e45f00c` | Unknown model strings pass through after built-in alias resolution. |
+
+The installed Claude Code 2.1.215 binary has SHA-256
+`c1efffaaf370aa187cb6a09dd93d4e511c646899b0078476f83791b664bde7fe`
+and contains the `CLAUDE_CODE_SUBAGENT_MODEL` configuration symbol. L2 must
+still prove the behavior against the installed binary; source inspection alone
+does not satisfy P2.
+
+## Receipt boundary
+
+`receipt.schema.json` deliberately permits only:
+
+- a random canary identifier and timestamps;
+- pinned runtime versions;
+- parent/child role, provider channel, OAuth auth kind, requested model,
+  HTTP outcome, completion state, and tool-call count;
+- a synthetic artifact hash and deterministic verdict;
+- explicit negative attestations for direct provider API keys, raw content, and
+  committed credentials.
+
+Each live proof gets its own loopback-only CLIProxyAPI process and admits one
+Claude Code canary during the evidence window. This associates its model
+requests without storing prompts, responses, transcripts, OAuth files, or
+identifying local paths.

--- a/parable/docs/evidence/l0-contract/manifest.json
+++ b/parable/docs/evidence/l0-contract/manifest.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": 1,
+  "captured_at_utc": "2026-07-19",
+  "parable": {
+    "baseline_head": "4005ad281ce5d2e9bd301f82c66a70c8d1ac445f",
+    "package_version": "0.1.8",
+    "repository": "miguelrios/unc-skills",
+    "directory": "parable"
+  },
+  "runtime": {
+    "os": "Linux",
+    "architecture": "x86_64",
+    "node": "20.20.0",
+    "python": "3.11.9",
+    "claude_code": "2.1.215",
+    "claude_code_binary_sha256": "c1efffaaf370aa187cb6a09dd93d4e511c646899b0078476f83791b664bde7fe"
+  },
+  "cliproxyapi": {
+    "installed_at_baseline": false,
+    "running_at_baseline": false,
+    "release": "v7.2.88",
+    "commit": "93d74a890a44802f656d7f39a573916b2611896e",
+    "checksums_file_sha256": "20e1b4dc3a5ac2b20471aa84a3e62c890c585fc3986d240d2309353c5e5e5319",
+    "linux_amd64_archive_sha256": "2cc3b38e3ba2474d0cdeb7a3f25b026891ba34e34d3a7e0501d4efd03c01f6fe"
+  },
+  "baseline_tests": {
+    "command": "HOME=<isolated-temporary-home> npm test",
+    "result": "PASS",
+    "tests": 70
+  }
+}

--- a/parable/docs/evidence/l0-contract/receipt.schema.json
+++ b/parable/docs/evidence/l0-contract/receipt.schema.json
@@ -1,0 +1,162 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/miguelrios/unc-skills/blob/main/parable/docs/evidence/subscription-canary-receipt.schema.json",
+  "title": "Parable subscription routing canary receipt",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "proof",
+    "canary_id",
+    "started_at_utc",
+    "finished_at_utc",
+    "runtime",
+    "requests",
+    "artifact",
+    "safety"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": 1
+    },
+    "proof": {
+      "enum": [
+        "P1",
+        "P2"
+      ]
+    },
+    "canary_id": {
+      "type": "string",
+      "pattern": "^canary-[a-f0-9]{12}$"
+    },
+    "started_at_utc": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "finished_at_utc": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "runtime": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "claude_code_version",
+        "cliproxyapi_release",
+        "cliproxyapi_commit",
+        "isolated_proxy"
+      ],
+      "properties": {
+        "claude_code_version": {
+          "type": "string"
+        },
+        "cliproxyapi_release": {
+          "type": "string"
+        },
+        "cliproxyapi_commit": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{40}$"
+        },
+        "isolated_proxy": {
+          "const": true
+        }
+      }
+    },
+    "requests": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "role",
+          "provider_channel",
+          "auth_kind",
+          "requested_model",
+          "http_status",
+          "stream_completed",
+          "tool_calls"
+        ],
+        "properties": {
+          "role": {
+            "enum": [
+              "parent",
+              "child"
+            ]
+          },
+          "provider_channel": {
+            "enum": [
+              "openai-codex",
+              "kimi"
+            ]
+          },
+          "auth_kind": {
+            "const": "oauth"
+          },
+          "requested_model": {
+            "enum": [
+              "gpt-5.6-sol",
+              "kimi-k3"
+            ]
+          },
+          "http_status": {
+            "type": "integer",
+            "minimum": 200,
+            "maximum": 299
+          },
+          "stream_completed": {
+            "type": "boolean"
+          },
+          "tool_calls": {
+            "type": "integer",
+            "minimum": 0
+          }
+        }
+      }
+    },
+    "artifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "sha256",
+        "deterministic_check"
+      ],
+      "properties": {
+        "kind": {
+          "const": "synthetic"
+        },
+        "sha256": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{64}$"
+        },
+        "deterministic_check": {
+          "enum": [
+            "PASS",
+            "FAIL"
+          ]
+        }
+      }
+    },
+    "safety": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "direct_provider_api_key_used",
+        "raw_content_committed",
+        "credential_material_committed"
+      ],
+      "properties": {
+        "direct_provider_api_key_used": {
+          "const": false
+        },
+        "raw_content_committed": {
+          "const": false
+        },
+        "credential_material_committed": {
+          "const": false
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- scope a broker-free OSS cascade for Claude Code on GPT-5.6 Sol via ChatGPT subscription OAuth
- require a second live proof where Sol invokes Kimi K3 as a named Claude Code subagent via Kimi subscription OAuth
- pin CLIProxyAPI v7.2.88, a content-free evidence schema, bounds, and explicit human OAuth gates

## L0 evidence

- current Parable 0.1.8 suite: 70/70 passing under an isolated temporary HOME
- pinned source contract covers both model IDs, both OAuth paths, and Claude-compatible executors
- no raw prompts, transcripts, OAuth state, credentials, or identifying local paths committed

## Test

`HOME=<isolated-temporary-home> npm test` from `parable/`
