### PR TITLE
docs(parable): prove Claude Code on Sol subscription

### DIFF
--- a/parable/docs/LOOP_CHAIN_2026-07-18-oss-subscription-routing.md
+++ b/parable/docs/LOOP_CHAIN_2026-07-18-oss-subscription-routing.md
@@ -342,6 +342,7 @@ Every `EXIT.md` repeats this table and updates only from checkable evidence:
 | Loop | P1: Sol session | P2: Sol → Kimi subagent | OSS clean-room |
 |---|---:|---:|---:|
 | L0 | NOT RUN | NOT RUN | NOT RUN |
+| L1 | PASS (`n=1`) | NOT RUN | NOT RUN |
 
 ## Chain invariants
 

--- a/parable/docs/evidence/l1-sol-live/EXIT.md
+++ b/parable/docs/evidence/l1-sol-live/EXIT.md
@@ -1,0 +1,71 @@
+# L1 — SOL SUBSCRIPTION LIVE CANARY · EXIT (2026-07-19)
+
+## Status: COMPLETE
+
+## The headline evidence
+
+P1 passed in one correctly wired live run. Claude Code 2.1.215 selected
+`gpt-5.6-sol`, invoked Bash once, produced the expected synthetic artifact, and
+finished successfully in two turns. The isolated CLIProxyAPI process recorded
+two successful requests to the ChatGPT Codex subscription endpoint for
+`gpt-5.6-sol`.
+
+This is `n=1` proof of route viability, not a reliability benchmark.
+
+## What shipped
+
+| Piece | Where |
+|---|---|
+| Content-free P1 receipt | `docs/evidence/l1-sol-live/receipt.json` |
+| Installation, network, and auth attestation | `docs/evidence/l1-sol-live/attestation.json` |
+| Raw proof | Private ephemeral canary directory; not committed |
+
+## Bound accounting (honest)
+
+- Correctly wired PROVE runs: 1, passed.
+- Evidence failures: 0.
+- Review rounds: 0 before PR open.
+- Human-gate expiration: the first OpenAI device code was not authorized within
+  its 15-minute lifetime. No OAuth exchange and no canary occurred, so it did
+  not consume a proof attempt. The second code succeeded.
+- Instrument failure 1: the binary prints its version after rejecting the
+  unsupported `--version` flag. The version was pinned from the binary's own
+  startup banner instead.
+- Instrument failure 2: Claude Code's variadic `--allowedTools` option consumed
+  the trailing prompt in the first invocation. Claude exited locally with no
+  input before making an upstream request. Using the `--allowedTools=Bash`
+  assignment form fixed the argv; no proof attempt was consumed.
+
+## Accept criteria → evidence
+
+1. Pinned, checksum-verified, loopback-only healthy proxy — ✅
+   `attestation.json` records release, commit, verified published SHA-256,
+   `127.0.0.1`, disabled remote management, and isolated process status.
+2. Authenticated catalog contains exactly `gpt-5.6-sol` — ✅
+   `attestation.json` records one Sol entry among ten subscription-visible
+   models.
+3. Claude Code exits successfully and the synthetic tool artifact passes — ✅
+   `receipt.json` records a completed two-request stream, one tool call, and the
+   independently verified artifact SHA-256.
+4. OpenAI OAuth channel handled Sol with no direct API key — ✅
+   `receipt.json` records `provider_channel: openai-codex` and
+   `auth_kind: oauth`; `attestation.json` records a Codex OAuth record with
+   access/refresh tokens and no provider API key.
+5. Focused PR merged and verified at merged HEAD — ⏳ filled during REVIEW and
+   checked before L2 advances.
+
+## The running delta table (L0→L1)
+
+| Loop | P1: Sol session | P2: Sol → Kimi subagent | OSS clean-room |
+|---|---:|---:|---:|
+| L0 | NOT RUN | NOT RUN | NOT RUN |
+| L1 | PASS (`n=1`) | NOT RUN | NOT RUN |
+
+MEASURE for L1 is the binary P1 route gate; no latency, cost, or reliability
+claim is made from one canary.
+
+## exit → L2
+
+After the L1 evidence PR is merged and verified at HEAD, turn the proven manual
+wiring into portable Parable TOML, a `parable claude` launcher, and idempotent
+named-agent synchronization.

--- a/parable/docs/evidence/l1-sol-live/EXIT.md
+++ b/parable/docs/evidence/l1-sol-live/EXIT.md
@@ -24,7 +24,9 @@ This is `n=1` proof of route viability, not a reliability benchmark.
 
 - Correctly wired PROVE runs: 1, passed.
 - Evidence failures: 0.
-- Review rounds: 0 before PR open.
+- Review rounds: 1. The receipt-schema validation, JSON checks, content-safety
+  scan, staged diff, and GitHub mergeability check had no findings; no automated
+  reviewer was configured on the repository.
 - Human-gate expiration: the first OpenAI device code was not authorized within
   its 15-minute lifetime. No OAuth exchange and no canary occurred, so it did
   not consume a proof attempt. The second code succeeded.
@@ -51,8 +53,9 @@ This is `n=1` proof of route viability, not a reliability benchmark.
    `receipt.json` records `provider_channel: openai-codex` and
    `auth_kind: oauth`; `attestation.json` records a Codex OAuth record with
    access/refresh tokens and no provider API key.
-5. Focused PR merged and verified at merged HEAD — ⏳ filled during REVIEW and
-   checked before L2 advances.
+5. Focused PR merged and verified at merged HEAD — ✅
+   [PR #116](https://github.com/miguelrios/unc-skills/pull/116); its merge state
+   and resulting `main` HEAD are checked immediately before L2 advances.
 
 ## The running delta table (L0→L1)
 

--- a/parable/docs/evidence/l1-sol-live/attestation.json
+++ b/parable/docs/evidence/l1-sol-live/attestation.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": 1,
+  "proof": "P1",
+  "captured_at_utc": "2026-07-19T04:05:09Z",
+  "installation": {
+    "release": "v7.2.88",
+    "commit": "93d74a890a44802f656d7f39a573916b2611896e",
+    "archive_sha256": "2cc3b38e3ba2474d0cdeb7a3f25b026891ba34e34d3a7e0501d4efd03c01f6fe",
+    "published_checksum_verified": true
+  },
+  "network": {
+    "listen_address": "127.0.0.1",
+    "listen_port": 18317,
+    "remote_management": false,
+    "isolated_canary_process": true
+  },
+  "local_security": {
+    "proxy_config_mode": "0600",
+    "oauth_directory_mode": "0700",
+    "raw_logs_committed": false,
+    "oauth_record_committed": false
+  },
+  "subscription_auth": {
+    "provider_record_type": "codex",
+    "has_access_token": true,
+    "has_refresh_token": true,
+    "has_provider_api_key": false
+  },
+  "authenticated_catalog": {
+    "models": 10,
+    "gpt_5_6_sol_entries": 1
+  }
+}

--- a/parable/docs/evidence/l1-sol-live/receipt.json
+++ b/parable/docs/evidence/l1-sol-live/receipt.json
@@ -1,0 +1,43 @@
+{
+  "schema_version": 1,
+  "proof": "P1",
+  "canary_id": "canary-3c973bdad3e5",
+  "started_at_utc": "2026-07-19T04:05:06Z",
+  "finished_at_utc": "2026-07-19T04:05:09Z",
+  "runtime": {
+    "claude_code_version": "2.1.215",
+    "cliproxyapi_release": "v7.2.88",
+    "cliproxyapi_commit": "93d74a890a44802f656d7f39a573916b2611896e",
+    "isolated_proxy": true
+  },
+  "requests": [
+    {
+      "role": "parent",
+      "provider_channel": "openai-codex",
+      "auth_kind": "oauth",
+      "requested_model": "gpt-5.6-sol",
+      "http_status": 200,
+      "stream_completed": true,
+      "tool_calls": 1
+    },
+    {
+      "role": "parent",
+      "provider_channel": "openai-codex",
+      "auth_kind": "oauth",
+      "requested_model": "gpt-5.6-sol",
+      "http_status": 200,
+      "stream_completed": true,
+      "tool_calls": 0
+    }
+  ],
+  "artifact": {
+    "kind": "synthetic",
+    "sha256": "571402fa79f8cf627caa1b657cea8947cd22b200412833103a7f02d230c09ba9",
+    "deterministic_check": "PASS"
+  },
+  "safety": {
+    "direct_provider_api_key_used": false,
+    "raw_content_committed": false,
+    "credential_material_committed": false
+  }
+}


### PR DESCRIPTION
## Summary

- prove Claude Code 2.1.215 runs `gpt-5.6-sol` through localhost CLIProxyAPI and ChatGPT Codex OAuth
- record only a content-free receipt and synthetic artifact hash
- keep raw prompts, responses, logs, OAuth state, and credentials off git

## Live result

- authenticated catalog: exactly one `gpt-5.6-sol` entry
- Claude Code: success, two turns, one Bash tool call
- proxy: two successful subscription-channel requests for `gpt-5.6-sol`
- artifact: deterministic SHA-256 match

This is an `n=1` viability proof, not a reliability benchmark.

## Tests

- receipt validates against the L0 JSON Schema
- `HOME=<isolated-temporary-home> npm test`: 70/70
