### PR TITLE
feat(recall): add tenant-aware canonical plane

### DIFF
--- a/.github/workflows/recall-ci.yml
+++ b/.github/workflows/recall-ci.yml
@@ -48,6 +48,7 @@ jobs:
         run: |
           for test in \
             e2e_brainstore.py \
+            e2e_v2_canonical_plane.py \
             e2e_session_source_l1.py \
             e2e_semantic_l2.py \
             e2e_capture_mcp.py \

--- a/recall/server/deploy/README.md
+++ b/recall/server/deploy/README.md
@@ -61,7 +61,7 @@ infrastructure. The example is synthetic; a live manifest belongs in a private m
 location and contains references, never credential values.
 
 The production database gate requires a standard PostgreSQL URL with
-`sslmode=verify-full` and an explicit trust root, schema migrations 1 through 18,
+`sslmode=verify-full` and an explicit trust root, schema migrations 1 through 19,
 pgvector 0.8.0 or newer, and a runtime role without superuser, database/role creation,
 replication, or RLS-bypass privilege:
 

--- a/recall/server/recall_server/__init__.py
+++ b/recall/server/recall_server/__init__.py
@@ -1,4 +1,4 @@
 """Recall central BrainStore service."""
 
-SCHEMA_VERSION = 18
+SCHEMA_VERSION = 19
 PROJECTOR_VERSION = 3

--- a/recall/server/recall_server/capabilities.py
+++ b/recall/server/recall_server/capabilities.py
@@ -19,7 +19,11 @@ WITH expected_tables(name) AS (
         ('source_events'), ('sessions'), ('items'), ('chunks'), ('dead_letters'),
         ('audit_events'), ('projection_watermarks'), ('collector_credentials'),
         ('entities'), ('projection_backfills'), ('source_profiles'),
-        ('session_export_cursors'), ('source_aliases'), ('item_embeddings')
+        ('session_export_cursors'), ('source_aliases'), ('item_embeddings'),
+        ('brain_tenants'), ('brain_principals'), ('canonical_sources'),
+        ('raw_artifacts'), ('canonical_events'), ('canonical_documents'),
+        ('canonical_chunks'), ('canonical_ingest_jobs'), ('receipt_redirects'),
+        ('forget_tombstones'), ('canonical_audit_events')
 ), runtime_tables(name) AS (
     SELECT name FROM expected_tables WHERE name <> 'schema_migrations'
 ), expected_sequences(name) AS (
@@ -44,13 +48,13 @@ SELECT
     role.rolbypassrls AS bypass_rls,
     pg_catalog.has_database_privilege(current_database(), 'CONNECT') AS can_connect,
     pg_catalog.has_schema_privilege(current_user, 'public', 'USAGE') AS can_use_schema,
-    (SELECT count(*) = 18 AND COALESCE(bool_and(
+    (SELECT count(*) = 29 AND COALESCE(bool_and(
         pg_catalog.to_regclass(pg_catalog.format('public.%I', name)) IS NOT NULL
         AND pg_catalog.has_table_privilege(
             current_user, pg_catalog.to_regclass(pg_catalog.format('public.%I', name)), 'SELECT'
         )
     ), false) FROM expected_tables) AS can_read_runtime_tables,
-    (SELECT count(*) = 17 AND COALESCE(bool_and(
+    (SELECT count(*) = 28 AND COALESCE(bool_and(
         pg_catalog.to_regclass(pg_catalog.format('public.%I', name)) IS NOT NULL
         AND pg_catalog.has_table_privilege(
             current_user, pg_catalog.to_regclass(pg_catalog.format('public.%I', name)),

--- a/recall/server/schema/019_v2_canonical_plane.sql
+++ b/recall/server/schema/019_v2_canonical_plane.sql
@@ -1,0 +1,200 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS brain_tenants (
+    tenant_id text NOT NULL PRIMARY KEY,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    CHECK (length(tenant_id) BETWEEN 2 AND 256)
+);
+
+CREATE TABLE IF NOT EXISTS brain_principals (
+    tenant_id text NOT NULL REFERENCES brain_tenants(tenant_id),
+    principal_id text NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY(tenant_id, principal_id),
+    CHECK (length(principal_id) BETWEEN 2 AND 256)
+);
+
+CREATE TABLE IF NOT EXISTS canonical_sources (
+    tenant_id text NOT NULL,
+    source_id text NOT NULL,
+    owner_principal_id text NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY(tenant_id, source_id),
+    FOREIGN KEY(tenant_id) REFERENCES brain_tenants(tenant_id),
+    FOREIGN KEY(tenant_id, owner_principal_id)
+        REFERENCES brain_principals(tenant_id, principal_id),
+    CHECK (length(source_id) BETWEEN 2 AND 256)
+);
+
+CREATE TABLE IF NOT EXISTS raw_artifacts (
+    tenant_id text NOT NULL,
+    source_id text NOT NULL,
+    artifact_id text NOT NULL,
+    storage_backend text NOT NULL CHECK (storage_backend IN ('filesystem', 's3')),
+    object_key text NOT NULL,
+    content_sha256 char(64) NOT NULL,
+    size_bytes bigint NOT NULL CHECK (size_bytes >= 0 AND size_bytes <= 5368709120),
+    media_type text NOT NULL,
+    encryption text NOT NULL CHECK (encryption IN ('filesystem-managed', 'sse-s3', 'aws:kms')),
+    version_id text NOT NULL,
+    state text NOT NULL DEFAULT 'live' CHECK (state IN ('live', 'deleted')),
+    created_at timestamptz NOT NULL DEFAULT now(),
+    deleted_at timestamptz,
+    PRIMARY KEY(tenant_id, source_id, artifact_id),
+    UNIQUE(storage_backend, object_key, version_id),
+    FOREIGN KEY(tenant_id, source_id)
+        REFERENCES canonical_sources(tenant_id, source_id),
+    CHECK (content_sha256 ~ '^[0-9a-f]{64}$'),
+    CHECK (object_key ~ '^objects/[0-9a-f]{2}/[0-9a-f]{64}$'),
+    CHECK ((state='live' AND deleted_at IS NULL) OR (state='deleted' AND deleted_at IS NOT NULL))
+);
+
+CREATE TABLE IF NOT EXISTS canonical_ingest_jobs (
+    tenant_id text NOT NULL,
+    source_id text NOT NULL,
+    job_id text NOT NULL,
+    connector_id text NOT NULL,
+    mode text NOT NULL CHECK (mode IN ('backfill', 'incremental', 'webhook', 'import')),
+    status text NOT NULL CHECK (status IN ('queued', 'running', 'committed', 'failed', 'cancelled')),
+    attempt integer NOT NULL DEFAULT 0 CHECK (attempt >= 0),
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY(tenant_id, source_id, job_id),
+    FOREIGN KEY(tenant_id, source_id)
+        REFERENCES canonical_sources(tenant_id, source_id)
+);
+
+CREATE TABLE IF NOT EXISTS canonical_events (
+    tenant_id text NOT NULL,
+    source_id text NOT NULL,
+    event_id text NOT NULL,
+    native_id text NOT NULL,
+    native_parent_id text,
+    artifact_id text NOT NULL,
+    job_id text NOT NULL,
+    kind text NOT NULL,
+    content_sha256 char(64) NOT NULL,
+    revision integer NOT NULL CHECK (revision >= 1),
+    occurred_at timestamptz NOT NULL,
+    observed_at timestamptz NOT NULL,
+    is_tombstone boolean NOT NULL DEFAULT false,
+    canonical_redacted jsonb NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY(tenant_id, source_id, event_id),
+    UNIQUE(tenant_id, source_id, native_id, revision),
+    UNIQUE(tenant_id, source_id, native_id, content_sha256),
+    FOREIGN KEY(tenant_id, source_id, artifact_id)
+        REFERENCES raw_artifacts(tenant_id, source_id, artifact_id),
+    FOREIGN KEY(tenant_id, source_id, job_id)
+        REFERENCES canonical_ingest_jobs(tenant_id, source_id, job_id),
+    CHECK (content_sha256 ~ '^[0-9a-f]{64}$'),
+    CHECK (jsonb_typeof(canonical_redacted) = 'object')
+);
+
+CREATE TABLE IF NOT EXISTS canonical_documents (
+    tenant_id text NOT NULL,
+    source_id text NOT NULL,
+    document_id text NOT NULL,
+    event_id text NOT NULL,
+    artifact_id text NOT NULL,
+    native_id text NOT NULL,
+    content_sha256 char(64) NOT NULL,
+    revision integer NOT NULL CHECK (revision >= 1),
+    is_current boolean NOT NULL,
+    text_redacted text NOT NULL,
+    text_sha256 char(64) NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    deleted_at timestamptz,
+    PRIMARY KEY(tenant_id, source_id, document_id),
+    UNIQUE(tenant_id, source_id, native_id, revision),
+    FOREIGN KEY(tenant_id, source_id, event_id)
+        REFERENCES canonical_events(tenant_id, source_id, event_id),
+    FOREIGN KEY(tenant_id, source_id, artifact_id)
+        REFERENCES raw_artifacts(tenant_id, source_id, artifact_id),
+    CHECK (content_sha256 ~ '^[0-9a-f]{64}$'),
+    CHECK (text_sha256 ~ '^[0-9a-f]{64}$'),
+    CHECK ((is_current AND deleted_at IS NULL) OR (NOT is_current))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS canonical_documents_one_current_idx
+    ON canonical_documents(tenant_id, source_id, native_id)
+    WHERE is_current AND deleted_at IS NULL;
+
+CREATE TABLE IF NOT EXISTS canonical_chunks (
+    tenant_id text NOT NULL,
+    source_id text NOT NULL,
+    chunk_id text NOT NULL,
+    document_id text NOT NULL,
+    ordinal integer NOT NULL CHECK (ordinal >= 0),
+    receipt text NOT NULL,
+    text_redacted text NOT NULL,
+    text_sha256 char(64) NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    deleted_at timestamptz,
+    PRIMARY KEY(tenant_id, source_id, chunk_id),
+    UNIQUE(tenant_id, receipt),
+    UNIQUE(tenant_id, source_id, document_id, ordinal),
+    FOREIGN KEY(tenant_id, source_id, document_id)
+        REFERENCES canonical_documents(tenant_id, source_id, document_id),
+    CHECK (text_sha256 ~ '^[0-9a-f]{64}$')
+);
+
+CREATE TABLE IF NOT EXISTS receipt_redirects (
+    tenant_id text NOT NULL,
+    source_id text NOT NULL,
+    old_receipt text NOT NULL,
+    new_receipt text NOT NULL,
+    reason text NOT NULL CHECK (reason IN ('v2_migration', 'canonical_rewrite')),
+    created_at timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY(tenant_id, old_receipt),
+    FOREIGN KEY(tenant_id, source_id)
+        REFERENCES canonical_sources(tenant_id, source_id),
+    CHECK (old_receipt <> new_receipt)
+);
+
+CREATE TABLE IF NOT EXISTS forget_tombstones (
+    tenant_id text NOT NULL,
+    source_id text NOT NULL,
+    target_identity_sha256 char(64) NOT NULL,
+    mode text NOT NULL CHECK (mode IN ('authoritative_delete', 'explicit_forget')),
+    reason text NOT NULL CHECK (reason IN ('source_deleted', 'owner_requested', 'retention_expired')),
+    deleted_at timestamptz NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY(tenant_id, source_id, target_identity_sha256),
+    FOREIGN KEY(tenant_id, source_id)
+        REFERENCES canonical_sources(tenant_id, source_id),
+    CHECK (target_identity_sha256 ~ '^[0-9a-f]{64}$')
+);
+
+CREATE TABLE IF NOT EXISTS canonical_audit_events (
+    tenant_id text NOT NULL,
+    source_id text NOT NULL,
+    audit_id text NOT NULL,
+    operation text NOT NULL,
+    status text NOT NULL CHECK (status IN ('success', 'rejected', 'failed')),
+    subject_sha256 char(64),
+    item_count integer CHECK (item_count IS NULL OR item_count >= 0),
+    byte_count bigint CHECK (byte_count IS NULL OR byte_count >= 0),
+    duration_ms double precision
+        CHECK (
+            duration_ms IS NULL
+            OR (duration_ms >= 0 AND duration_ms < 'Infinity'::double precision)
+        ),
+    created_at timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY(tenant_id, source_id, audit_id),
+    FOREIGN KEY(tenant_id, source_id)
+        REFERENCES canonical_sources(tenant_id, source_id),
+    CHECK (subject_sha256 IS NULL OR subject_sha256 ~ '^[0-9a-f]{64}$')
+);
+
+CREATE INDEX IF NOT EXISTS canonical_events_native_idx
+    ON canonical_events(tenant_id, source_id, native_id, revision DESC);
+CREATE INDEX IF NOT EXISTS canonical_chunks_document_idx
+    ON canonical_chunks(tenant_id, source_id, document_id, ordinal)
+    WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS canonical_jobs_status_idx
+    ON canonical_ingest_jobs(tenant_id, status, updated_at);
+
+INSERT INTO schema_migrations(version) VALUES (19) ON CONFLICT DO NOTHING;
+
+COMMIT;

--- a/recall/server/tests/e2e_v2_canonical_plane.py
+++ b/recall/server/tests/e2e_v2_canonical_plane.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sys
+import uuid
+from pathlib import Path
+
+import psycopg
+
+SERVER = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SERVER))
+
+from recall_server.db import BrainStore
+
+
+def expect_sqlstate(connection, sql: str, parameters: tuple, expected: str) -> None:
+    try:
+        with connection.transaction():
+            connection.execute(sql, parameters)
+    except psycopg.Error as error:
+        if error.sqlstate != expected:
+            raise
+    else:
+        raise RuntimeError("canonical plane accepted an invalid write")
+
+
+def insert_source(connection, tenant: str, principal: str, source: str) -> None:
+    connection.execute(
+        "INSERT INTO brain_tenants(tenant_id) VALUES (%s)",
+        (tenant,),
+    )
+    connection.execute(
+        "INSERT INTO brain_principals(tenant_id,principal_id) VALUES (%s,%s)",
+        (tenant, principal),
+    )
+    connection.execute(
+        """INSERT INTO canonical_sources(tenant_id,source_id,owner_principal_id)
+           VALUES (%s,%s,%s)""",
+        (tenant, source, principal),
+    )
+
+
+def main() -> None:
+    dsn = os.environ["RECALL_DATABASE_URL"]
+    BrainStore(dsn).migrate()
+    nonce = uuid.uuid4().hex
+    tenant_a = f"tenant:e2e:{nonce}:a"
+    tenant_b = f"tenant:e2e:{nonce}:b"
+    principal = f"principal:e2e:{nonce}"
+    source = f"source:e2e:{nonce}"
+    content_sha256 = hashlib.sha256(b"synthetic canonical payload").hexdigest()
+    text_sha256 = hashlib.sha256(b"synthetic canonical text").hexdigest()
+    identity_sha256 = hashlib.sha256(b"synthetic deleted identity").hexdigest()
+    artifacts = {
+        tenant_a: "art_" + nonce + "a",
+        tenant_b: "art_" + nonce + "b",
+    }
+    job = "job_" + nonce
+    event = "evt_" + nonce
+    document = "doc_" + nonce
+    chunk = "chk_" + nonce
+    object_keys = {
+        tenant: "objects/" + hashlib.sha256(tenant.encode()).hexdigest()[:2]
+        + "/" + hashlib.sha256((tenant + nonce).encode()).hexdigest()
+        for tenant in (tenant_a, tenant_b)
+    }
+
+    with psycopg.connect(dsn) as connection:
+        with connection.transaction(force_rollback=True):
+            insert_source(connection, tenant_a, principal, source)
+            insert_source(connection, tenant_b, principal, source)
+            for tenant in (tenant_a, tenant_b):
+                artifact = artifacts[tenant]
+                connection.execute(
+                    """INSERT INTO canonical_ingest_jobs(
+                           tenant_id,source_id,job_id,connector_id,mode,status
+                       ) VALUES (%s,%s,%s,%s,'incremental','committed')""",
+                    (tenant, source, job, "connector.synthetic"),
+                )
+                connection.execute(
+                    """INSERT INTO raw_artifacts(
+                           tenant_id,source_id,artifact_id,storage_backend,object_key,
+                           content_sha256,size_bytes,media_type,encryption,version_id
+                       ) VALUES (%s,%s,%s,'s3',%s,%s,27,'application/json','sse-s3',%s)""",
+                    (
+                        tenant,
+                        source,
+                        artifact,
+                        object_keys[tenant],
+                        content_sha256,
+                        "version-1",
+                    ),
+                )
+                connection.execute(
+                    """INSERT INTO canonical_events(
+                           tenant_id,source_id,event_id,native_id,artifact_id,job_id,kind,
+                           content_sha256,revision,occurred_at,observed_at,canonical_redacted
+                       ) VALUES (%s,%s,%s,'native:synthetic',%s,%s,'document',%s,1,
+                                 '2026-07-19T00:00:00Z','2026-07-19T00:00:01Z',%s)""",
+                    (
+                        tenant, source, event, artifact, job, content_sha256,
+                        json.dumps({"kind": "document.v1"}),
+                    ),
+                )
+                connection.execute(
+                    """INSERT INTO canonical_documents(
+                           tenant_id,source_id,document_id,event_id,artifact_id,native_id,
+                           content_sha256,revision,is_current,text_redacted,text_sha256
+                       ) VALUES (%s,%s,%s,%s,%s,'native:synthetic',%s,1,true,
+                                 'synthetic canonical text',%s)""",
+                    (
+                        tenant, source, document, event, artifact,
+                        content_sha256, text_sha256,
+                    ),
+                )
+                connection.execute(
+                    """INSERT INTO canonical_chunks(
+                           tenant_id,source_id,chunk_id,document_id,ordinal,receipt,
+                           text_redacted,text_sha256
+                       ) VALUES (%s,%s,%s,%s,0,%s,'synthetic canonical text',%s)""",
+                    (
+                        tenant, source, chunk, document,
+                        f"recall://{source}/native-synthetic?rev=1#item=0",
+                        text_sha256,
+                    ),
+                )
+                connection.execute(
+                    """INSERT INTO forget_tombstones(
+                           tenant_id,source_id,target_identity_sha256,mode,reason,deleted_at
+                       ) VALUES (%s,%s,%s,'explicit_forget','owner_requested',now())""",
+                    (tenant, source, identity_sha256),
+                )
+                connection.execute(
+                    """INSERT INTO receipt_redirects(
+                           tenant_id,source_id,old_receipt,new_receipt,reason
+                       ) VALUES (%s,%s,%s,%s,'v2_migration')""",
+                    (
+                        tenant,
+                        source,
+                        f"recall://{source}/legacy?rev=1",
+                        f"recall://{source}/native-synthetic?rev=1",
+                    ),
+                )
+                connection.execute(
+                    """INSERT INTO canonical_audit_events(
+                           tenant_id,source_id,audit_id,operation,status,item_count
+                       ) VALUES (%s,%s,%s,'ingest.commit','success',1)""",
+                    (tenant, source, "audit_" + nonce),
+                )
+
+            expect_sqlstate(
+                connection,
+                """INSERT INTO canonical_events(
+                       tenant_id,source_id,event_id,native_id,artifact_id,job_id,kind,
+                       content_sha256,revision,occurred_at,observed_at,canonical_redacted
+                   ) VALUES (%s,%s,%s,'native:escape',%s,%s,'document',%s,1,
+                             now(),now(),'{}'::jsonb)""",
+                (
+                    tenant_a, source, "evt_cross_tenant",
+                    artifacts[tenant_b], job, content_sha256,
+                ),
+                "23503",
+            )
+            expect_sqlstate(
+                connection,
+                """INSERT INTO canonical_events(
+                       tenant_id,source_id,event_id,native_id,artifact_id,job_id,kind,
+                       content_sha256,revision,occurred_at,observed_at,canonical_redacted
+                   ) VALUES (%s,%s,'evt_duplicate','native:synthetic',%s,%s,'document',
+                             %s,1,now(),now(),'{}'::jsonb)""",
+                (tenant_a, source, artifacts[tenant_a], job, content_sha256),
+                "23505",
+            )
+            expect_sqlstate(
+                connection,
+                """UPDATE raw_artifacts SET state='deleted'
+                   WHERE tenant_id=%s AND source_id=%s AND artifact_id=%s""",
+                (tenant_a, source, artifacts[tenant_a]),
+                "23514",
+            )
+            expect_sqlstate(
+                connection,
+                """INSERT INTO canonical_audit_events(
+                       tenant_id,source_id,audit_id,operation,status,duration_ms
+                   ) VALUES (%s,%s,'audit_nonfinite','ingest.commit','success','NaN')""",
+                (tenant_a, source),
+                "23514",
+            )
+            counts = connection.execute(
+                """SELECT
+                     (SELECT count(*) FROM canonical_events WHERE source_id=%s) AS events,
+                     (SELECT count(*) FROM raw_artifacts WHERE source_id=%s) AS artifacts,
+                     (SELECT count(*) FROM forget_tombstones WHERE source_id=%s) AS tombstones,
+                     (SELECT count(*) FROM receipt_redirects WHERE source_id=%s) AS redirects""",
+                (source, source, source, source),
+            ).fetchone()
+            if tuple(counts) != (2, 2, 2, 2):
+                raise RuntimeError("canonical tenant isolation count mismatch")
+
+    print(json.dumps({
+        "status": "pass",
+        "tenants": 2,
+        "canonical_events": 2,
+        "artifact_references": 2,
+        "tombstones": 2,
+        "cross_tenant_rejections": 1,
+        "duplicate_rejections": 1,
+        "invalid_delete_state_rejections": 1,
+        "nonfinite_audit_rejections": 1,
+        "receipt_redirects": 2,
+        "rolled_back": True,
+    }, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/recall/tests/central_brain/test_brainstore_unit.py
+++ b/recall/tests/central_brain/test_brainstore_unit.py
@@ -74,6 +74,48 @@ class SchemaMigrationContractTest(unittest.TestCase):
                 rf"schema_migrations\(version\) VALUES \({version}\)",
             )
 
+    def test_v2_canonical_plane_is_tenant_keyed_and_deletion_explicit(self) -> None:
+        migration = SERVER / "schema" / "019_v2_canonical_plane.sql"
+        rendered = " ".join(migration.read_text().split()).casefold()
+        required_tables = {
+            "brain_tenants",
+            "brain_principals",
+            "canonical_sources",
+            "raw_artifacts",
+            "canonical_events",
+            "canonical_documents",
+            "canonical_chunks",
+            "canonical_ingest_jobs",
+            "receipt_redirects",
+            "forget_tombstones",
+            "canonical_audit_events",
+        }
+        for table in required_tables:
+            self.assertIn(f"create table if not exists {table}", rendered)
+        self.assertGreaterEqual(rendered.count("tenant_id text not null"), 10)
+        self.assertIn(
+            "unique(tenant_id, source_id, native_id, revision)",
+            rendered,
+        )
+        self.assertIn(
+            "unique(storage_backend, object_key, version_id)",
+            rendered,
+        )
+        self.assertIn(
+            "check ((state='live' and deleted_at is null) or "
+            "(state='deleted' and deleted_at is not null))",
+            rendered,
+        )
+        self.assertIn("target_identity_sha256 char(64) not null", rendered)
+        audit = rendered.split(
+            "create table if not exists canonical_audit_events", 1
+        )[1].split(");", 1)[0]
+        self.assertNotIn("jsonb", audit)
+        self.assertIn("item_count integer", audit)
+        self.assertIn("byte_count bigint", audit)
+        self.assertNotIn("raw_payload", rendered)
+        self.assertNotIn("password", rendered)
+
     def test_connector_v2_source_families_are_host_owned_and_migrated(self) -> None:
         added = {
             "communications", "schedule", "contacts", "social", "documents",

--- a/recall/tests/central_brain/test_core_deployment.py
+++ b/recall/tests/central_brain/test_core_deployment.py
@@ -186,6 +186,20 @@ class DatabaseCapabilityContractTest(unittest.TestCase):
         lowered = CAPABILITY_SQL.casefold()
         self.assertIn("pg_extension", lowered)
         self.assertIn("pg_stat_ssl", lowered)
+        for table in (
+            "brain_tenants",
+            "brain_principals",
+            "canonical_sources",
+            "raw_artifacts",
+            "canonical_events",
+            "canonical_documents",
+            "canonical_chunks",
+            "canonical_ingest_jobs",
+            "receipt_redirects",
+            "forget_tombstones",
+            "canonical_audit_events",
+        ):
+            self.assertIn(f"('{table}')", lowered)
         for provider in ("planetscale", "render", "supabase", "neon"):
             self.assertNotIn(provider, lowered)
 


### PR DESCRIPTION
## Outcome

Adds Recall v2 schema 19: tenant-keyed principals, sources, archive references, canonical events/documents/chunks, ingest jobs, receipt redirects, forget tombstones, and aggregate-only audit records.

## Verification

- Recall suite: 544 Python tests passed
- Node launcher E2E: 3 passed
- Fresh PostgreSQL canonical-plane E2E passed and is now required in CI
- Immutable non-root container and least-privilege runtime E2E passed
- Ruff and staged secret scan passed

## Safety

Composite tenant/source foreign keys reject cross-tenant linkage. Native revision and artifact version uniqueness reject duplicate truth. Invalid deletion state and non-finite audit values fail closed. One archive object version cannot be aliased across tenants. The schema stores artifact references and redacted canonical projections, never raw archive payloads or credentials.