### PR TITLE
feat(recall): make v2 ingest and forget crash safe

### DIFF
--- a/.github/workflows/recall-ci.yml
+++ b/.github/workflows/recall-ci.yml
@@ -49,6 +49,7 @@ jobs:
           for test in \
             e2e_brainstore.py \
             e2e_v2_canonical_plane.py \
+            e2e_v2_lifecycle.py \
             e2e_session_source_l1.py \
             e2e_semantic_l2.py \
             e2e_capture_mcp.py \

--- a/recall/Dockerfile
+++ b/recall/Dockerfile
@@ -13,7 +13,7 @@ RUN python -m pip install --no-cache-dir --disable-pip-version-check --no-compil
 
 COPY --chown=10001:10001 server/recall_server /opt/recall/recall_server
 COPY --chown=10001:10001 server/schema /opt/recall/schema
-COPY --chown=10001:10001 contracts /opt/contracts
+COPY --chown=10001:10001 contracts /opt/recall/contracts
 COPY --chown=10001:10001 privacy /opt/recall/privacy
 COPY --chown=10001:10001 skills/recall/scripts/recall.py /opt/skills/recall/scripts/recall.py
 

--- a/recall/Dockerfile
+++ b/recall/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.12-slim-bookworm@sha256:d50fb7611f86d04a3b0471b46d7557818d88983fc3
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
-    PYTHONPATH=/opt/recall
+    PYTHONPATH=/opt/recall:/opt
 
 WORKDIR /opt/recall
 
@@ -13,7 +13,7 @@ RUN python -m pip install --no-cache-dir --disable-pip-version-check --no-compil
 
 COPY --chown=10001:10001 server/recall_server /opt/recall/recall_server
 COPY --chown=10001:10001 server/schema /opt/recall/schema
-COPY --chown=10001:10001 contracts /opt/recall/contracts
+COPY --chown=10001:10001 contracts /opt/contracts
 COPY --chown=10001:10001 privacy /opt/recall/privacy
 COPY --chown=10001:10001 skills/recall/scripts/recall.py /opt/skills/recall/scripts/recall.py
 

--- a/recall/connectors/registry.py
+++ b/recall/connectors/registry.py
@@ -21,6 +21,7 @@ PRIVACY_MODES = {"off", "scrub", "drop"}
 CHECKPOINTS = {"none", "ack_cursor"}
 DELETIONS = {"explicit_receipt", "explicit_export_reference"}
 RUNTIME_ERROR_CODES = {
+    "archive_identity_forgotten", "archive_invalid_reference", "archive_unavailable",
     "brain_invalid_acknowledgement", "brain_unauthorized", "brain_unavailable",
     "connector_disabled", "connector_invalid_page", "connector_rate_limited",
     "connector_spool_error", "connector_unavailable",

--- a/recall/connectors/sdk.py
+++ b/recall/connectors/sdk.py
@@ -15,6 +15,7 @@ from typing import Any, Protocol
 from urllib.parse import urlparse
 
 from client.mac import canonical_envelope
+from contracts.v2 import ContractError, validate_contract
 from privacy.policy import PrivacyPolicy, summarize_receipts
 
 
@@ -458,11 +459,26 @@ class BrainWriter(Protocol):
     def ingest(self, events: list[dict[str, Any]]) -> dict[str, Any]: ...
 
 
+class RawArchiveWriter(Protocol):
+    def put_raw(
+        self,
+        *,
+        tenant_id: str,
+        source_id: str,
+        native_id: str,
+        payload: bytes,
+        media_type: str,
+        created_at: str,
+    ) -> dict[str, Any]: ...
+
+
 class ConnectorRunner:
-    """ACK-gated runtime. Connector payloads cross privacy before SQLite or Brain."""
+    """ACK-gated runtime with raw archive before private spool and Brain."""
 
     def __init__(self, *, connector: PullConnector, brain: BrainWriter, spool_path: Path,
-                 privacy: PrivacyPolicy | None = None, enabled: bool = True):
+                 privacy: PrivacyPolicy | None = None, enabled: bool = True,
+                 archive: RawArchiveWriter | None = None, tenant_id: str | None = None,
+                 principal_id: str = "owner"):
         connector_id = getattr(connector, "connector_id", None)
         source_id = getattr(connector, "source_id", None)
         if not isinstance(connector_id, str) or not CONNECTOR_ID.fullmatch(connector_id):
@@ -471,8 +487,19 @@ class ConnectorRunner:
             raise ConnectorContractError("source_id is invalid")
         if not isinstance(enabled, bool):
             raise ConnectorContractError("enabled must be boolean")
+        if (archive is None) != (tenant_id is None):
+            raise ConnectorContractError("archive and tenant_id must be configured together")
+        if tenant_id is not None and (
+            not isinstance(tenant_id, str) or not IDENTITY.fullmatch(tenant_id)
+        ):
+            raise ConnectorContractError("tenant_id is invalid")
+        if not isinstance(principal_id, str) or not IDENTITY.fullmatch(principal_id):
+            raise ConnectorContractError("principal_id is invalid")
         self.connector = connector
         self.brain = brain
+        self.archive = archive
+        self.tenant_id = tenant_id
+        self.principal_id = principal_id
         self.connector_id = connector_id
         self.source_id = source_id
         self.privacy = privacy or PrivacyPolicy(mode="off")
@@ -532,22 +559,81 @@ class ConnectorRunner:
     def _clear_error(self) -> None:
         self.db.execute("DELETE FROM meta WHERE key='last_error_code'")
 
-    def _event(self, record: ConnectorRecord, content: dict[str, Any], provenance: dict[str, Any]) -> dict[str, Any]:
+    @staticmethod
+    def _raw_payload(record: ConnectorRecord) -> bytes:
+        return json.dumps(
+            {
+                "schema_version": record.schema_version,
+                "native_id": record.native_id,
+                "native_parent_id": record.native_parent_id,
+                "occurred_at": record.occurred_at,
+                "content": record.content,
+                "provenance": record.provenance,
+                "deleted": record.deleted,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+            allow_nan=False,
+        ).encode()
+
+    def _archive_raw(self, record: ConnectorRecord) -> dict[str, Any] | None:
+        if self.archive is None:
+            return None
+        payload = self._raw_payload(record)
+        try:
+            candidate = self.archive.put_raw(
+                tenant_id=self.tenant_id,
+                source_id=self.source_id,
+                native_id=record.native_id,
+                payload=payload,
+                media_type="application/json",
+                created_at=record.occurred_at,
+            )
+        except Exception as error:
+            if getattr(error, "error_code", None) == "archive_identity_forgotten":
+                raise ConnectorRunError("archive_identity_forgotten") from None
+            raise ConnectorRunError("archive_unavailable") from None
+        try:
+            reference = validate_contract(candidate, expected="recall.artifact-ref.v1")
+        except ContractError:
+            raise ConnectorRunError("archive_invalid_reference") from None
+        expected = {
+            "tenant_id": self.tenant_id,
+            "source_id": self.source_id,
+            "content_sha256": hashlib.sha256(payload).hexdigest(),
+            "size_bytes": len(payload),
+            "media_type": "application/json",
+            "created_at": record.occurred_at,
+        }
+        if any(reference.get(key) != value for key, value in expected.items()):
+            raise ConnectorRunError("archive_invalid_reference")
+        return reference
+
+    def _event(
+        self,
+        record: ConnectorRecord,
+        content: dict[str, Any],
+        provenance: dict[str, Any],
+        artifact_ref: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
         provenance = {
             **provenance,
             "connector_id": self.connector_id,
             "connector_schema_version": record.schema_version,
         }
+        if artifact_ref is not None:
+            provenance["artifact_ref"] = artifact_ref
         if record.deleted:
             return canonical_envelope(
                 source_id=self.source_id, native_id=record.native_id, kind="tombstone",
-                content={"target_native_id": record.native_id}, principal_id="owner",
+                content={"target_native_id": record.native_id}, principal_id=self.principal_id,
                 visibility="private", occurred_at=record.occurred_at,
                 provenance=provenance, parent=record.native_parent_id,
             )
         return canonical_envelope(
             source_id=self.source_id, native_id=record.native_id, kind="connector_record",
-            content=content, principal_id="owner", visibility="private",
+            content=content, principal_id=self.principal_id, visibility="private",
             occurred_at=record.occurred_at, provenance=provenance,
             parent=record.native_parent_id,
         )
@@ -565,20 +651,51 @@ class ConnectorRunner:
         events = []
         dropped = 0
         deduplicated = 0
+        archived = 0
+        forgotten = 0
         for record in page.records:
+            was_forgotten = False
             provenance_decision = PrivacyPolicy(mode="scrub").apply(record.provenance)
             safe_provenance = provenance_decision.value
             if record.deleted:
                 decision = PrivacyPolicy(mode="off").apply({"content": {}, "provenance": safe_provenance})
-                event = self._event(record, {}, decision.value["provenance"])
+                try:
+                    artifact_ref = self._archive_raw(record)
+                except ConnectorRunError as error:
+                    if error.error_code != "archive_identity_forgotten":
+                        raise
+                    artifact_ref = None
+                    event = None
+                    forgotten += 1
+                    was_forgotten = True
+                else:
+                    archived += int(artifact_ref is not None)
+                    event = self._event(record, {}, decision.value["provenance"], artifact_ref)
             else:
                 decision = self.privacy.apply({"content": record.content, "provenance": safe_provenance})
-                event = None if decision.action == "drop" else self._event(
-                    record, decision.value["content"], decision.value["provenance"]
-                )
+                if decision.action == "drop":
+                    event = None
+                else:
+                    try:
+                        artifact_ref = self._archive_raw(record)
+                    except ConnectorRunError as error:
+                        if error.error_code != "archive_identity_forgotten":
+                            raise
+                        artifact_ref = None
+                        event = None
+                        forgotten += 1
+                        was_forgotten = True
+                    else:
+                        archived += int(artifact_ref is not None)
+                        event = self._event(
+                            record,
+                            decision.value["content"],
+                            decision.value["provenance"],
+                            artifact_ref,
+                        )
             receipts.append(decision.receipt())
             if event is None:
-                dropped += 1
+                dropped += int(not was_forgotten)
             elif self._acknowledged(event):
                 deduplicated += 1
             else:
@@ -597,7 +714,8 @@ class ConnectorRunner:
                 self._commit_page(page_id, page.next_cursor)
         return {
             "privacy": privacy, "staged": len(events), "dropped": dropped,
-            "deduplicated": deduplicated,
+            "deduplicated": deduplicated, "archived": archived,
+            "forgotten": forgotten,
         }
 
     def _commit_page(self, page_id: int, cursor: str | None) -> None:
@@ -681,6 +799,9 @@ class ConnectorRunner:
             raise ConnectorContractError("pull must return ConnectorPage")
         try:
             staged = self._stage(page, cursor)
+        except ConnectorRunError as error:
+            self._record_error(error.error_code)
+            raise
         except ConnectorContractError:
             self._record_error("connector_invalid_page")
             raise

--- a/recall/server/deploy/README.md
+++ b/recall/server/deploy/README.md
@@ -61,7 +61,7 @@ infrastructure. The example is synthetic; a live manifest belongs in a private m
 location and contains references, never credential values.
 
 The production database gate requires a standard PostgreSQL URL with
-`sslmode=verify-full` and an explicit trust root, schema migrations 1 through 19,
+`sslmode=verify-full` and an explicit trust root, schema migrations 1 through 20,
 pgvector 0.8.0 or newer, and a runtime role without superuser, database/role creation,
 replication, or RLS-bypass privilege:
 

--- a/recall/server/recall_server/__init__.py
+++ b/recall/server/recall_server/__init__.py
@@ -1,4 +1,4 @@
 """Recall central BrainStore service."""
 
-SCHEMA_VERSION = 19
+SCHEMA_VERSION = 20
 PROJECTOR_VERSION = 3

--- a/recall/server/recall_server/archive.py
+++ b/recall/server/recall_server/archive.py
@@ -13,6 +13,8 @@ from pathlib import Path
 from typing import Any, BinaryIO, Protocol
 from urllib.parse import urlsplit
 
+from contracts.v2 import ContractError, validate_contract
+
 
 DEFAULT_MAXIMUM_BYTES = 64 * 1024 * 1024
 IDENTITY_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9:._/@+-]{1,255}")
@@ -47,7 +49,6 @@ class ArchiveRequest:
     tenant_id: str
     source_id: str
     native_id: str
-    revision: int
     media_type: str
     payload: bytes
 
@@ -55,8 +56,6 @@ class ArchiveRequest:
         for value in (self.tenant_id, self.source_id, self.native_id):
             if not isinstance(value, str) or not IDENTITY_RE.fullmatch(value):
                 raise ValueError("archive identity is invalid")
-        if not isinstance(self.revision, int) or isinstance(self.revision, bool) or self.revision < 1:
-            raise ValueError("archive revision is invalid")
         if not isinstance(self.media_type, str) or not MEDIA_TYPE_RE.fullmatch(self.media_type):
             raise ValueError("archive media type is invalid")
         if not isinstance(self.payload, bytes):
@@ -111,7 +110,6 @@ def _identity(
         request.tenant_id.encode(),
         request.source_id.encode(),
         request.native_id.encode(),
-        str(request.revision).encode(),
         content_sha256.encode(),
     ))
     digest = hmac.new(namespace_key, b"artifact\0" + message, hashlib.sha256).hexdigest()
@@ -127,6 +125,19 @@ def _metadata(reference: ArtifactReference) -> dict[str, str]:
         "size_bytes": str(reference.size_bytes),
         "media_type_sha256": hashlib.sha256(reference.media_type.encode()).hexdigest(),
     }
+
+
+def _verify_metadata(reference: ArtifactReference, actual: Any) -> None:
+    expected = _metadata(reference)
+    if not isinstance(actual, dict):
+        raise ArchiveCorruption("archive metadata mismatch")
+    for key in ("tenant_scope_sha256", "source_scope_sha256"):
+        if not isinstance(actual.get(key), str) or not hmac.compare_digest(
+            actual[key], expected[key],
+        ):
+            raise ArchiveNotFound("archive object not found")
+    if actual != expected:
+        raise ArchiveCorruption("archive metadata mismatch")
 
 
 class _ArchiveStore:
@@ -211,6 +222,68 @@ class _ArchiveStore:
             content_sha256=digest,
         )
 
+    def put_raw(
+        self,
+        *,
+        tenant_id: str,
+        source_id: str,
+        native_id: str,
+        payload: bytes,
+        media_type: str,
+        created_at: str,
+    ) -> dict[str, Any]:
+        """Connector-facing gateway: write once, then return the closed public reference."""
+        reference = self.put(ArchiveRequest(
+            tenant_id=tenant_id,
+            source_id=source_id,
+            native_id=native_id,
+            media_type=media_type,
+            payload=payload,
+        ))
+        return reference.to_contract(
+            tenant_id=tenant_id,
+            source_id=source_id,
+            created_at=created_at,
+        )
+
+    def delete_raw(self, value: dict[str, Any]) -> bool:
+        """Delete one contract reference without exposing archive namespace material."""
+        try:
+            reference = validate_contract(value, expected="recall.artifact-ref.v1")
+        except ContractError:
+            raise ArchiveNotFound("archive object not found") from None
+        if reference["storage_backend"] != self.storage_backend:
+            raise ArchiveNotFound("archive object not found")
+        internal = ArtifactReference(
+            artifact_id=reference["artifact_id"],
+            tenant_scope_sha256=_scope_digest(
+                self._namespace_key, b"tenant", reference["tenant_id"],
+            ),
+            source_scope_sha256=_scope_digest(
+                self._namespace_key, b"source", reference["source_id"],
+            ),
+            storage_backend=reference["storage_backend"],
+            object_key=reference["object_key"],
+            content_sha256=reference["content_sha256"],
+            size_bytes=reference["size_bytes"],
+            media_type=reference["media_type"],
+            encryption=reference["encryption"],
+            version_id=reference["version_id"],
+        )
+        try:
+            self.read(
+                internal,
+                tenant_id=reference["tenant_id"],
+                source_id=reference["source_id"],
+            )
+        except ArchiveNotFound:
+            return False
+        return self.delete(
+            internal,
+            tenant_id=reference["tenant_id"],
+            source_id=reference["source_id"],
+        )
+
 
 class _BytesReader:
     def __init__(self, payload: bytes) -> None:
@@ -254,7 +327,7 @@ def _read_bounded(
 
 class FilesystemArchiveStore(_ArchiveStore):
     storage_backend = "filesystem"
-    encryption = "filesystem-managed"
+    encryption = "filesystem-owner-only"
 
     def __init__(
         self,
@@ -347,8 +420,7 @@ class FilesystemArchiveStore(_ArchiveStore):
             payload = data_path.read_bytes()
         except (FileNotFoundError, json.JSONDecodeError) as error:
             raise ArchiveNotFound("archive object not found") from error
-        if metadata != _metadata(reference):
-            raise ArchiveCorruption("archive metadata mismatch")
+        _verify_metadata(reference, metadata)
         if len(payload) != reference.size_bytes or not hmac.compare_digest(
             hashlib.sha256(payload).hexdigest(), reference.content_sha256,
         ):
@@ -410,7 +482,7 @@ class S3ArchiveStore(_ArchiveStore):
         self.endpoint_url = endpoint_url
         self.client = client
         self.kms_key_id = kms_key_id
-        self.encryption = "aws:kms" if kms_key_id else "sse-s3"
+        self.encryption = "sse-kms" if kms_key_id else "sse-s3"
 
     def put_stream(
         self,
@@ -495,8 +567,7 @@ class S3ArchiveStore(_ArchiveStore):
             raise
         except Exception as error:
             raise ArchiveError("archive provider request failed") from error
-        if response.get("Metadata") != _metadata(reference):
-            raise ArchiveCorruption("archive metadata mismatch")
+        _verify_metadata(reference, response.get("Metadata"))
         body = response.get("Body")
         if body is None or response.get("ContentLength") != reference.size_bytes:
             raise ArchiveCorruption("archive metadata mismatch")

--- a/recall/server/recall_server/canonical.py
+++ b/recall/server/recall_server/canonical.py
@@ -1,0 +1,606 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from typing import Any, Protocol
+from urllib.parse import unquote, urlsplit
+
+from contracts.v2 import ContractError, IDENTITY_RE, validate_contract
+
+from .db import BrainStore
+from .projectors import validate_envelope
+
+
+class CanonicalLifecycleError(RuntimeError):
+    """Stable, content-free failure at a v2 lifecycle boundary."""
+
+    def __init__(self, error_code: str):
+        self.error_code = error_code
+        super().__init__(error_code)
+
+
+class ArchiveLifecycle(Protocol):
+    def put_raw(
+        self,
+        *,
+        tenant_id: str,
+        source_id: str,
+        native_id: str,
+        payload: bytes,
+        media_type: str,
+        created_at: str,
+    ) -> dict[str, Any]: ...
+
+    def delete_raw(self, reference: dict[str, Any]) -> bool: ...
+
+
+def _identity_sha256(tenant_id: str, source_id: str, native_id: str) -> str:
+    return hashlib.sha256(
+        "\x1f".join((tenant_id, source_id, native_id)).encode()
+    ).hexdigest()
+
+
+def _opaque(prefix: str, *values: str) -> str:
+    digest = hashlib.sha256("\x1f".join(values).encode()).hexdigest()
+    return f"{prefix}_{digest[:32]}"
+
+
+def _timestamp(value: Any) -> str:
+    if isinstance(value, datetime):
+        return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+    if isinstance(value, str):
+        return value
+    raise CanonicalLifecycleError("canonical_state_invalid")
+
+
+def _native_from_receipt(receipt: str, source_id: str) -> str:
+    parsed = urlsplit(receipt)
+    if parsed.scheme != "recall" or parsed.netloc != source_id:
+        raise CanonicalLifecycleError("forget_target_invalid")
+    native_id = unquote(parsed.path.lstrip("/"))
+    if not native_id or not IDENTITY_RE.fullmatch(native_id):
+        raise CanonicalLifecycleError("forget_target_invalid")
+    return native_id
+
+
+class CanonicalArchiveGateway:
+    """Serialize archive writes with the canonical forget fence."""
+
+    def __init__(
+        self,
+        store: BrainStore,
+        archive: ArchiveLifecycle,
+        *,
+        tenant_id: str,
+        principal_id: str,
+    ):
+        CanonicalPlane._validate_host_identity(
+            tenant_id, principal_id, "source:placeholder",
+        )
+        self.store = store
+        self.archive = archive
+        self.tenant_id = tenant_id
+        self.principal_id = principal_id
+
+    def put_raw(
+        self,
+        *,
+        tenant_id: str,
+        source_id: str,
+        native_id: str,
+        payload: bytes,
+        media_type: str,
+        created_at: str,
+    ) -> dict[str, Any]:
+        if tenant_id != self.tenant_id:
+            raise CanonicalLifecycleError("archive_authority_forbidden")
+        CanonicalPlane._validate_host_identity(
+            tenant_id, self.principal_id, source_id,
+        )
+        if not isinstance(native_id, str) or not IDENTITY_RE.fullmatch(native_id):
+            raise CanonicalLifecycleError("archive_identity_invalid")
+        identity_sha256 = _identity_sha256(tenant_id, source_id, native_id)
+        with self.store.connect() as conn:
+            with conn.transaction():
+                CanonicalPlane._register_source(
+                    conn,
+                    tenant_id=tenant_id,
+                    principal_id=self.principal_id,
+                    source_id=source_id,
+                )
+                conn.execute(
+                    """SELECT pg_advisory_xact_lock(hashtextextended(%s,0))""",
+                    (f"v2\x1f{tenant_id}\x1f{source_id}\x1f{native_id}",),
+                )
+                forgotten = conn.execute(
+                    """SELECT 1 FROM forget_tombstones
+                       WHERE tenant_id=%s AND source_id=%s
+                         AND target_identity_sha256=%s""",
+                    (tenant_id, source_id, identity_sha256),
+                ).fetchone()
+                if forgotten:
+                    raise CanonicalLifecycleError("archive_identity_forgotten")
+                return self.archive.put_raw(
+                    tenant_id=tenant_id,
+                    source_id=source_id,
+                    native_id=native_id,
+                    payload=payload,
+                    media_type=media_type,
+                    created_at=created_at,
+                )
+
+
+class CanonicalPlane:
+    """Tenant-aware v2 canonical ingest and crash-resumable authoritative forget."""
+
+    def __init__(self, store: BrainStore, archive: ArchiveLifecycle):
+        self.store = store
+        self.archive = archive
+
+    @staticmethod
+    def _validate_host_identity(
+        tenant_id: str,
+        principal_id: str,
+        source_id: str,
+    ) -> None:
+        if not all(
+            isinstance(value, str) and IDENTITY_RE.fullmatch(value)
+            for value in (tenant_id, principal_id, source_id)
+        ):
+            raise CanonicalLifecycleError("canonical_authority_invalid")
+
+    @staticmethod
+    def _register_source(
+        conn: Any,
+        *,
+        tenant_id: str,
+        principal_id: str,
+        source_id: str,
+    ) -> None:
+        conn.execute(
+            "INSERT INTO brain_tenants(tenant_id) VALUES (%s) ON CONFLICT DO NOTHING",
+            (tenant_id,),
+        )
+        conn.execute(
+            """INSERT INTO brain_principals(tenant_id,principal_id)
+               VALUES (%s,%s) ON CONFLICT DO NOTHING""",
+            (tenant_id, principal_id),
+        )
+        conn.execute(
+            """INSERT INTO canonical_sources(tenant_id,source_id,owner_principal_id)
+               VALUES (%s,%s,%s) ON CONFLICT DO NOTHING""",
+            (tenant_id, source_id, principal_id),
+        )
+        owner = conn.execute(
+            """SELECT owner_principal_id
+               FROM canonical_sources
+               WHERE tenant_id=%s AND source_id=%s""",
+            (tenant_id, source_id),
+        ).fetchone()
+        if owner is None or owner["owner_principal_id"] != principal_id:
+            raise CanonicalLifecycleError("canonical_authority_forbidden")
+
+    def ingest_document(
+        self,
+        *,
+        tenant_id: str,
+        principal_id: str,
+        connector_id: str,
+        artifact_ref: dict[str, Any],
+        envelope: dict[str, Any],
+        text_redacted: str,
+    ) -> dict[str, Any]:
+        self._validate_host_identity(tenant_id, principal_id, envelope.get("source_id"))
+        if not isinstance(connector_id, str) or not IDENTITY_RE.fullmatch(connector_id):
+            raise CanonicalLifecycleError("canonical_connector_invalid")
+        if not isinstance(text_redacted, str) or len(text_redacted.encode()) > 1_000_000:
+            raise CanonicalLifecycleError("canonical_text_invalid")
+        try:
+            artifact = validate_contract(
+                artifact_ref, expected="recall.artifact-ref.v1",
+            )
+            event = validate_envelope(envelope)
+        except (ContractError, ValueError):
+            raise CanonicalLifecycleError("canonical_contract_invalid") from None
+        source_id = event["source_id"]
+        native_id = event["native_id"]
+        if (
+            artifact["tenant_id"] != tenant_id
+            or artifact["source_id"] != source_id
+            or event["principal_id"] != principal_id
+            or event.get("provenance", {}).get("artifact_ref") != artifact
+        ):
+            raise CanonicalLifecycleError("canonical_lineage_invalid")
+        raw_sha256 = artifact["content_sha256"]
+        identity_sha256 = _identity_sha256(tenant_id, source_id, native_id)
+        event_id = _opaque("evt", tenant_id, source_id, native_id, raw_sha256)
+        job_id = _opaque("job", tenant_id, source_id, connector_id, event_id)
+        document_id = _opaque("doc", tenant_id, source_id, event_id)
+        chunk_id = _opaque("chk", tenant_id, source_id, document_id, "0")
+        text_sha256 = hashlib.sha256(text_redacted.encode()).hexdigest()
+
+        with self.store.connect() as conn:
+            with conn.transaction():
+                self._register_source(
+                    conn,
+                    tenant_id=tenant_id,
+                    principal_id=principal_id,
+                    source_id=source_id,
+                )
+                forgotten = conn.execute(
+                    """SELECT 1 FROM forget_tombstones
+                       WHERE tenant_id=%s AND source_id=%s
+                         AND target_identity_sha256=%s""",
+                    (tenant_id, source_id, identity_sha256),
+                ).fetchone()
+                if forgotten:
+                    raise CanonicalLifecycleError("canonical_identity_forgotten")
+                conn.execute(
+                    """SELECT pg_advisory_xact_lock(hashtextextended(%s,0))""",
+                    (f"v2\x1f{tenant_id}\x1f{source_id}\x1f{native_id}",),
+                )
+                conn.execute(
+                    """INSERT INTO raw_artifacts(
+                           tenant_id,source_id,artifact_id,storage_backend,object_key,
+                           content_sha256,size_bytes,media_type,encryption,version_id,created_at
+                       ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
+                       ON CONFLICT(tenant_id,source_id,artifact_id) DO NOTHING""",
+                    (
+                        tenant_id, source_id, artifact["artifact_id"],
+                        artifact["storage_backend"], artifact["object_key"],
+                        raw_sha256, artifact["size_bytes"], artifact["media_type"],
+                        artifact["encryption"], artifact["version_id"],
+                        artifact["created_at"],
+                    ),
+                )
+                stored_artifact = conn.execute(
+                    """SELECT storage_backend,object_key,content_sha256,size_bytes,
+                              media_type,encryption,version_id,state
+                       FROM raw_artifacts
+                       WHERE tenant_id=%s AND source_id=%s AND artifact_id=%s""",
+                    (tenant_id, source_id, artifact["artifact_id"]),
+                ).fetchone()
+                expected_artifact = {
+                    key: artifact[key]
+                    for key in (
+                        "storage_backend", "object_key", "content_sha256", "size_bytes",
+                        "media_type", "encryption", "version_id",
+                    )
+                }
+                if (
+                    stored_artifact is None
+                    or stored_artifact["state"] != "live"
+                    or any(
+                        stored_artifact[key] != value
+                        for key, value in expected_artifact.items()
+                    )
+                ):
+                    raise CanonicalLifecycleError("canonical_artifact_conflict")
+                existing = conn.execute(
+                    """SELECT revision FROM canonical_events
+                       WHERE tenant_id=%s AND source_id=%s
+                         AND native_id=%s AND content_sha256=%s""",
+                    (tenant_id, source_id, native_id, raw_sha256),
+                ).fetchone()
+                if existing:
+                    revision = existing["revision"]
+                    return {
+                        "status": "committed",
+                        "inserted": 0,
+                        "duplicate_events": 1,
+                        "revision": revision,
+                        "receipt": (
+                            f"recall://{source_id}/{native_id}?rev={revision}#item=0"
+                        ),
+                        "replay": True,
+                    }
+                row = conn.execute(
+                    """SELECT COALESCE(max(revision),0)+1 AS revision
+                       FROM canonical_events
+                       WHERE tenant_id=%s AND source_id=%s AND native_id=%s""",
+                    (tenant_id, source_id, native_id),
+                ).fetchone()
+                revision = row["revision"]
+                receipt = f"recall://{source_id}/{native_id}?rev={revision}#item=0"
+                conn.execute(
+                    """INSERT INTO canonical_ingest_jobs(
+                           tenant_id,source_id,job_id,connector_id,mode,status,
+                           attempt,created_at,updated_at
+                       ) VALUES (%s,%s,%s,%s,'incremental','committed',1,now(),now())
+                       ON CONFLICT(tenant_id,source_id,job_id) DO NOTHING""",
+                    (tenant_id, source_id, job_id, connector_id),
+                )
+                conn.execute(
+                    """INSERT INTO canonical_events(
+                           tenant_id,source_id,event_id,native_id,native_parent_id,
+                           artifact_id,job_id,kind,content_sha256,revision,
+                           occurred_at,observed_at,is_tombstone,canonical_redacted
+                       ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,false,%s)""",
+                    (
+                        tenant_id, source_id, event_id, native_id,
+                        event.get("native_parent_id"), artifact["artifact_id"], job_id,
+                        event["kind"], raw_sha256, revision, event["occurred_at"],
+                        event["observed_at"], json.dumps(event),
+                    ),
+                )
+                conn.execute(
+                    """UPDATE canonical_documents
+                       SET is_current=false
+                       WHERE tenant_id=%s AND source_id=%s AND native_id=%s
+                         AND is_current""",
+                    (tenant_id, source_id, native_id),
+                )
+                conn.execute(
+                    """INSERT INTO canonical_documents(
+                           tenant_id,source_id,document_id,event_id,artifact_id,native_id,
+                           content_sha256,revision,is_current,text_redacted,text_sha256
+                       ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,true,%s,%s)""",
+                    (
+                        tenant_id, source_id, document_id, event_id,
+                        artifact["artifact_id"], native_id, raw_sha256, revision,
+                        text_redacted, text_sha256,
+                    ),
+                )
+                conn.execute(
+                    """INSERT INTO canonical_chunks(
+                           tenant_id,source_id,chunk_id,document_id,ordinal,receipt,
+                           text_redacted,text_sha256
+                       ) VALUES (%s,%s,%s,%s,0,%s,%s,%s)""",
+                    (
+                        tenant_id, source_id, chunk_id, document_id, receipt,
+                        text_redacted, text_sha256,
+                    ),
+                )
+                conn.execute(
+                    """INSERT INTO canonical_audit_events(
+                           tenant_id,source_id,audit_id,operation,status,
+                           subject_sha256,item_count,byte_count
+                       ) VALUES (%s,%s,%s,'ingest.commit','success',%s,1,%s)""",
+                    (
+                        tenant_id, source_id,
+                        _opaque("audit", tenant_id, source_id, event_id, "ingest"),
+                        identity_sha256, artifact["size_bytes"],
+                    ),
+                )
+        return {
+            "status": "committed",
+            "inserted": 1,
+            "duplicate_events": 0,
+            "revision": revision,
+            "receipt": receipt,
+            "replay": False,
+        }
+
+    def _archive_references(
+        self,
+        conn: Any,
+        *,
+        tenant_id: str,
+        source_id: str,
+        native_id: str,
+    ) -> list[dict[str, Any]]:
+        rows = conn.execute(
+            """SELECT DISTINCT artifact.tenant_id,artifact.source_id,
+                       artifact.artifact_id,artifact.storage_backend,artifact.object_key,
+                       artifact.content_sha256,artifact.size_bytes,artifact.media_type,
+                       artifact.encryption,artifact.version_id,artifact.created_at
+               FROM canonical_events event
+               JOIN raw_artifacts artifact
+                 USING(tenant_id,source_id,artifact_id)
+               WHERE event.tenant_id=%s AND event.source_id=%s
+                 AND event.native_id=%s
+               ORDER BY artifact.artifact_id""",
+            (tenant_id, source_id, native_id),
+        ).fetchall()
+        return [
+            {
+                "contract": "recall.artifact-ref.v1",
+                "schema_version": 1,
+                **{
+                    key: row[key]
+                    for key in (
+                        "tenant_id", "source_id", "artifact_id", "storage_backend",
+                        "object_key", "content_sha256", "size_bytes", "media_type",
+                        "encryption", "version_id",
+                    )
+                },
+                "created_at": _timestamp(row["created_at"]),
+            }
+            for row in rows
+        ]
+
+    def forget(self, request: dict[str, Any]) -> dict[str, Any]:
+        try:
+            value = validate_contract(request, expected="recall.forget-request.v1")
+        except ContractError:
+            raise CanonicalLifecycleError("forget_contract_invalid") from None
+        tenant_id = value["tenant_id"]
+        principal_id = value["principal_id"]
+        source_id = value["source_id"]
+        native_id = _native_from_receipt(value["target_receipt"], source_id)
+        target_sha256 = _identity_sha256(tenant_id, source_id, native_id)
+        reason = value["reason"]
+
+        with self.store.connect() as conn:
+            with conn.transaction():
+                owner = conn.execute(
+                    """SELECT owner_principal_id FROM canonical_sources
+                       WHERE tenant_id=%s AND source_id=%s""",
+                    (tenant_id, source_id),
+                ).fetchone()
+                if owner is None or owner["owner_principal_id"] != principal_id:
+                    raise CanonicalLifecycleError("forget_authority_forbidden")
+                conn.execute(
+                    """SELECT pg_advisory_xact_lock(hashtextextended(%s,0))""",
+                    (f"v2\x1f{tenant_id}\x1f{source_id}\x1f{native_id}",),
+                )
+                prior = conn.execute(
+                    """SELECT target_identity_sha256,status
+                       FROM forget_tombstones
+                       WHERE tenant_id=%s AND source_id=%s AND idempotency_key=%s""",
+                    (tenant_id, source_id, value["idempotency_key"]),
+                ).fetchone()
+                if prior and prior["target_identity_sha256"] != target_sha256:
+                    raise CanonicalLifecycleError("forget_idempotency_conflict")
+                tombstone = conn.execute(
+                    """SELECT status FROM forget_tombstones
+                       WHERE tenant_id=%s AND source_id=%s
+                         AND target_identity_sha256=%s
+                       FOR UPDATE""",
+                    (tenant_id, source_id, target_sha256),
+                ).fetchone()
+                if tombstone and tombstone["status"] == "deleted":
+                    return {
+                        "status": "deleted",
+                        "replay": True,
+                        "raw_deleted": 0,
+                        "projections_deleted": 0,
+                    }
+                target = conn.execute(
+                    """SELECT document.native_id
+                       FROM canonical_chunks chunk
+                       JOIN canonical_documents document
+                         USING(tenant_id,source_id,document_id)
+                       WHERE chunk.tenant_id=%s AND chunk.source_id=%s
+                         AND chunk.receipt=%s""",
+                    (tenant_id, source_id, value["target_receipt"]),
+                ).fetchone()
+                if target is None or target["native_id"] != native_id:
+                    raise CanonicalLifecycleError("forget_target_not_found")
+                if tombstone is None:
+                    conn.execute(
+                        """INSERT INTO forget_tombstones(
+                               tenant_id,source_id,target_identity_sha256,mode,reason,
+                               deleted_at,status,idempotency_key
+                           ) VALUES (%s,%s,%s,%s,%s,%s,'deleting',%s)""",
+                        (
+                            tenant_id, source_id, target_sha256, value["mode"], reason,
+                            value["requested_at"], value["idempotency_key"],
+                        ),
+                    )
+                references = self._archive_references(
+                    conn,
+                    tenant_id=tenant_id,
+                    source_id=source_id,
+                    native_id=native_id,
+                )
+                projection_count = conn.execute(
+                    """SELECT count(*) AS count
+                       FROM canonical_chunks chunk
+                       JOIN canonical_documents document
+                         USING(tenant_id,source_id,document_id)
+                       WHERE document.tenant_id=%s AND document.source_id=%s
+                         AND document.native_id=%s AND chunk.deleted_at IS NULL""",
+                    (tenant_id, source_id, native_id),
+                ).fetchone()["count"]
+                conn.execute(
+                    """UPDATE canonical_chunks chunk
+                       SET deleted_at=COALESCE(chunk.deleted_at,%s)
+                       FROM canonical_documents document
+                       WHERE chunk.tenant_id=document.tenant_id
+                         AND chunk.source_id=document.source_id
+                         AND chunk.document_id=document.document_id
+                         AND document.tenant_id=%s AND document.source_id=%s
+                         AND document.native_id=%s""",
+                    (value["requested_at"], tenant_id, source_id, native_id),
+                )
+                conn.execute(
+                    """UPDATE canonical_documents
+                       SET is_current=false,
+                           deleted_at=COALESCE(deleted_at,%s)
+                       WHERE tenant_id=%s AND source_id=%s AND native_id=%s""",
+                    (value["requested_at"], tenant_id, source_id, native_id),
+                )
+                conn.execute(
+                    """UPDATE raw_artifacts artifact
+                       SET state='deleting'
+                       FROM canonical_events event
+                       WHERE artifact.tenant_id=event.tenant_id
+                         AND artifact.source_id=event.source_id
+                         AND artifact.artifact_id=event.artifact_id
+                         AND event.tenant_id=%s AND event.source_id=%s
+                         AND event.native_id=%s AND artifact.state='live'""",
+                    (tenant_id, source_id, native_id),
+                )
+
+        try:
+            for reference in references:
+                self.archive.delete_raw(reference)
+        except Exception:
+            with self.store.connect() as conn:
+                conn.execute(
+                    """INSERT INTO canonical_audit_events(
+                           tenant_id,source_id,audit_id,operation,status,
+                           subject_sha256,item_count
+                       ) VALUES (%s,%s,%s,'forget.archive','failed',%s,%s)
+                       ON CONFLICT DO NOTHING""",
+                    (
+                        tenant_id, source_id,
+                        _opaque(
+                            "audit", tenant_id, source_id, target_sha256,
+                            value["idempotency_key"], "failed",
+                        ),
+                        target_sha256, len(references),
+                    ),
+                )
+            raise CanonicalLifecycleError("archive_delete_failed") from None
+
+        with self.store.connect() as conn:
+            with conn.transaction():
+                conn.execute(
+                    """DELETE FROM canonical_chunks chunk
+                       USING canonical_documents document
+                       WHERE chunk.tenant_id=document.tenant_id
+                         AND chunk.source_id=document.source_id
+                         AND chunk.document_id=document.document_id
+                         AND document.tenant_id=%s AND document.source_id=%s
+                         AND document.native_id=%s""",
+                    (tenant_id, source_id, native_id),
+                )
+                conn.execute(
+                    """DELETE FROM canonical_documents
+                       WHERE tenant_id=%s AND source_id=%s AND native_id=%s""",
+                    (tenant_id, source_id, native_id),
+                )
+                conn.execute(
+                    """DELETE FROM canonical_events
+                       WHERE tenant_id=%s AND source_id=%s AND native_id=%s""",
+                    (tenant_id, source_id, native_id),
+                )
+                artifact_ids = [reference["artifact_id"] for reference in references]
+                if artifact_ids:
+                    conn.execute(
+                        """DELETE FROM raw_artifacts
+                           WHERE tenant_id=%s AND source_id=%s
+                             AND artifact_id=ANY(%s)""",
+                        (tenant_id, source_id, artifact_ids),
+                    )
+                conn.execute(
+                    """UPDATE forget_tombstones
+                       SET status='deleted',completed_at=now()
+                       WHERE tenant_id=%s AND source_id=%s
+                         AND target_identity_sha256=%s""",
+                    (tenant_id, source_id, target_sha256),
+                )
+                conn.execute(
+                    """INSERT INTO canonical_audit_events(
+                           tenant_id,source_id,audit_id,operation,status,
+                           subject_sha256,item_count,byte_count
+                       ) VALUES (%s,%s,%s,'forget.commit','success',%s,%s,%s)""",
+                    (
+                        tenant_id, source_id,
+                        _opaque(
+                            "audit", tenant_id, source_id, target_sha256,
+                            value["idempotency_key"], "success",
+                        ),
+                        target_sha256, projection_count,
+                        sum(reference["size_bytes"] for reference in references),
+                    ),
+                )
+        return {
+            "status": "deleted",
+            "replay": False,
+            "raw_deleted": len(references),
+            "projections_deleted": projection_count,
+        }

--- a/recall/server/schema/020_v2_lifecycle_guards.sql
+++ b/recall/server/schema/020_v2_lifecycle_guards.sql
@@ -1,0 +1,100 @@
+BEGIN;
+
+ALTER TABLE raw_artifacts
+    DROP CONSTRAINT IF EXISTS raw_artifacts_encryption_check,
+    DROP CONSTRAINT IF EXISTS raw_artifacts_state_check,
+    DROP CONSTRAINT IF EXISTS raw_artifacts_check,
+    DROP CONSTRAINT IF EXISTS raw_artifacts_lifecycle_check;
+
+ALTER TABLE raw_artifacts
+    ADD CONSTRAINT raw_artifacts_encryption_check
+        CHECK (encryption IN ('filesystem-owner-only', 'sse-s3', 'sse-kms', 'sse-c')),
+    ADD CONSTRAINT raw_artifacts_state_check
+        CHECK (state IN ('live', 'deleting', 'deleted')),
+    ADD CONSTRAINT raw_artifacts_lifecycle_check
+        CHECK (
+            (state IN ('live', 'deleting') AND deleted_at IS NULL)
+            OR (state='deleted' AND deleted_at IS NOT NULL)
+        );
+
+ALTER TABLE canonical_ingest_jobs
+    DROP CONSTRAINT IF EXISTS canonical_ingest_jobs_mode_check,
+    DROP CONSTRAINT IF EXISTS canonical_ingest_jobs_status_check;
+
+ALTER TABLE canonical_ingest_jobs
+    ADD CONSTRAINT canonical_ingest_jobs_mode_check
+        CHECK (mode IN ('backfill', 'incremental', 'reconcile', 'forget')),
+    ADD CONSTRAINT canonical_ingest_jobs_status_check
+        CHECK (status IN ('queued', 'leased', 'committed', 'retryable', 'parked', 'failed'));
+
+ALTER TABLE forget_tombstones
+    DROP CONSTRAINT IF EXISTS forget_tombstones_reason_check,
+    DROP CONSTRAINT IF EXISTS forget_tombstones_status_check,
+    DROP CONSTRAINT IF EXISTS forget_tombstones_completion_check,
+    DROP CONSTRAINT IF EXISTS forget_tombstones_idempotency_check;
+
+ALTER TABLE forget_tombstones
+    ADD COLUMN IF NOT EXISTS status text NOT NULL DEFAULT 'deleted',
+    ADD COLUMN IF NOT EXISTS idempotency_key text,
+    ADD COLUMN IF NOT EXISTS completed_at timestamptz;
+
+UPDATE forget_tombstones
+SET completed_at=deleted_at
+WHERE status='deleted' AND completed_at IS NULL;
+
+ALTER TABLE forget_tombstones
+    ADD CONSTRAINT forget_tombstones_reason_check
+        CHECK (reason IN ('upstream_deleted', 'owner_requested', 'retention_expired')),
+    ADD CONSTRAINT forget_tombstones_status_check
+        CHECK (status IN ('deleting', 'deleted')),
+    ADD CONSTRAINT forget_tombstones_completion_check
+        CHECK (
+            (status='deleting' AND completed_at IS NULL)
+            OR (status='deleted' AND completed_at IS NOT NULL)
+        ),
+    ADD CONSTRAINT forget_tombstones_idempotency_check
+        CHECK (idempotency_key IS NULL OR length(idempotency_key) BETWEEN 1 AND 200);
+
+CREATE UNIQUE INDEX IF NOT EXISTS forget_tombstones_idempotency_idx
+    ON forget_tombstones(tenant_id, source_id, idempotency_key)
+    WHERE idempotency_key IS NOT NULL;
+
+CREATE OR REPLACE FUNCTION recall_v2_reject_forgotten_event()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    target_sha256 text;
+BEGIN
+    target_sha256 := encode(
+        sha256(convert_to(
+            NEW.tenant_id || chr(31) || NEW.source_id || chr(31) || NEW.native_id,
+            'UTF8'
+        )),
+        'hex'
+    );
+    IF EXISTS (
+        SELECT 1
+        FROM forget_tombstones tombstone
+        WHERE tombstone.tenant_id=NEW.tenant_id
+          AND tombstone.source_id=NEW.source_id
+          AND tombstone.target_identity_sha256=target_sha256
+    ) THEN
+        RAISE EXCEPTION USING
+            ERRCODE='23514',
+            MESSAGE='canonical identity was forgotten';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS canonical_events_reject_forgotten
+    ON canonical_events;
+CREATE TRIGGER canonical_events_reject_forgotten
+BEFORE INSERT ON canonical_events
+FOR EACH ROW
+EXECUTE FUNCTION recall_v2_reject_forgotten_event();
+
+INSERT INTO schema_migrations(version) VALUES (20) ON CONFLICT DO NOTHING;
+
+COMMIT;

--- a/recall/server/tests/e2e_v2_canonical_plane.py
+++ b/recall/server/tests/e2e_v2_canonical_plane.py
@@ -129,8 +129,10 @@ def main() -> None:
                 )
                 connection.execute(
                     """INSERT INTO forget_tombstones(
-                           tenant_id,source_id,target_identity_sha256,mode,reason,deleted_at
-                       ) VALUES (%s,%s,%s,'explicit_forget','owner_requested',now())""",
+                           tenant_id,source_id,target_identity_sha256,mode,reason,
+                           deleted_at,status,completed_at
+                       ) VALUES (%s,%s,%s,'explicit_forget','owner_requested',
+                                 now(),'deleted',now())""",
                     (tenant, source, identity_sha256),
                 )
                 connection.execute(

--- a/recall/server/tests/e2e_v2_lifecycle.py
+++ b/recall/server/tests/e2e_v2_lifecycle.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sys
+import tempfile
+import uuid
+from pathlib import Path
+
+import psycopg
+
+SERVER = Path(__file__).resolve().parents[1]
+ROOT = SERVER.parent
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(SERVER))
+
+from recall_server.archive import FilesystemArchiveStore
+from recall_server.canonical import (
+    CanonicalArchiveGateway,
+    CanonicalLifecycleError,
+    CanonicalPlane,
+)
+from recall_server.db import BrainStore
+from recall_server.projectors import canonical_json
+
+
+class LoseDeleteAcknowledgementOnce:
+    def __init__(self, archive: FilesystemArchiveStore):
+        self.archive = archive
+        self.lose_once = True
+
+    def put_raw(self, **kwargs):
+        return self.archive.put_raw(**kwargs)
+
+    def delete_raw(self, reference):
+        removed = self.archive.delete_raw(reference)
+        if self.lose_once:
+            self.lose_once = False
+            raise OSError("synthetic lost archive acknowledgement")
+        return removed
+
+
+def main() -> None:
+    dsn = os.environ["RECALL_DATABASE_URL"]
+    store = BrainStore(dsn)
+    store.migrate()
+    nonce = uuid.uuid4().hex
+    tenant_id = f"tenant:lifecycle:{nonce}"
+    principal_id = f"principal:lifecycle:{nonce}"
+    source_id = f"source:lifecycle:{nonce}"
+    native_id = "native:lifecycle"
+    raw_canary = "raw-secret-canary-lifecycle-91"
+    redacted_text = "safe lifecycle context"
+    created_at = "2026-07-19T12:00:00Z"
+
+    with tempfile.TemporaryDirectory() as temporary:
+        archive_store = FilesystemArchiveStore(
+            Path(temporary) / "archive",
+            namespace_key=b"l" * 32,
+        )
+        unreliable_archive = LoseDeleteAcknowledgementOnce(archive_store)
+        gateway = CanonicalArchiveGateway(
+            store,
+            unreliable_archive,
+            tenant_id=tenant_id,
+            principal_id=principal_id,
+        )
+        raw_payload = json.dumps({
+            "native_id": native_id,
+            "content": {"text": raw_canary},
+        }, sort_keys=True, separators=(",", ":")).encode()
+        artifact = gateway.put_raw(
+            tenant_id=tenant_id,
+            source_id=source_id,
+            native_id=native_id,
+            payload=raw_payload,
+            media_type="application/json",
+            created_at=created_at,
+        )
+        content = {"text": redacted_text}
+        event = {
+            "schema_version": 1,
+            "source_id": source_id,
+            "native_id": native_id,
+            "native_parent_id": native_id,
+            "kind": "connector_record",
+            "occurred_at": created_at,
+            "observed_at": created_at,
+            "principal_id": principal_id,
+            "visibility": "private",
+            "content_type": "application/json",
+            "content": content,
+            "provenance": {
+                "connector_id": "synthetic.lifecycle",
+                "connector_schema_version": 1,
+                "artifact_ref": artifact,
+            },
+            "content_sha256": hashlib.sha256(canonical_json(content)).hexdigest(),
+        }
+        plane = CanonicalPlane(store, unreliable_archive)
+        first = plane.ingest_document(
+            tenant_id=tenant_id,
+            principal_id=principal_id,
+            connector_id="synthetic.lifecycle",
+            artifact_ref=artifact,
+            envelope=event,
+            text_redacted=redacted_text,
+        )
+        replay = plane.ingest_document(
+            tenant_id=tenant_id,
+            principal_id=principal_id,
+            connector_id="synthetic.lifecycle",
+            artifact_ref=artifact,
+            envelope=event,
+            text_redacted=redacted_text,
+        )
+        if first["inserted"] != 1 or replay["replay"] is not True:
+            raise RuntimeError("canonical ingest replay contract failed")
+        with store.connect() as connection:
+            raw_leaks = connection.execute(
+                """SELECT
+                     (SELECT count(*) FROM canonical_events
+                       WHERE tenant_id=%s AND canonical_redacted::text LIKE %s)
+                   + (SELECT count(*) FROM canonical_documents
+                       WHERE tenant_id=%s AND text_redacted LIKE %s)
+                   + (SELECT count(*) FROM canonical_chunks
+                       WHERE tenant_id=%s AND text_redacted LIKE %s) AS count""",
+                (
+                    tenant_id, f"%{raw_canary}%",
+                    tenant_id, f"%{raw_canary}%",
+                    tenant_id, f"%{raw_canary}%",
+                ),
+            ).fetchone()["count"]
+        if raw_leaks:
+            raise RuntimeError("raw archive bytes crossed into canonical projections")
+        forget = {
+            "contract": "recall.forget-request.v1",
+            "schema_version": 1,
+            "tenant_id": tenant_id,
+            "principal_id": principal_id,
+            "source_id": source_id,
+            "target_receipt": first["receipt"],
+            "mode": "explicit_forget",
+            "reason": "owner_requested",
+            "requested_at": "2026-07-19T12:05:00Z",
+            "idempotency_key": "forget-lifecycle-" + nonce,
+        }
+        try:
+            plane.forget(forget)
+        except CanonicalLifecycleError as error:
+            if error.error_code != "archive_delete_failed":
+                raise
+        else:
+            raise RuntimeError("lost archive acknowledgement did not interrupt forget")
+
+        with store.connect() as connection:
+            state = connection.execute(
+                """SELECT
+                     (SELECT count(*) FROM canonical_chunks chunk
+                       JOIN canonical_documents document
+                         USING(tenant_id,source_id,document_id)
+                       WHERE document.tenant_id=%s AND document.source_id=%s
+                         AND document.native_id=%s AND chunk.deleted_at IS NULL) AS live_chunks,
+                     (SELECT status FROM forget_tombstones
+                       WHERE tenant_id=%s AND source_id=%s) AS forget_status,
+                     (SELECT state FROM raw_artifacts
+                       WHERE tenant_id=%s AND source_id=%s) AS artifact_state""",
+                (
+                    tenant_id, source_id, native_id,
+                    tenant_id, source_id,
+                    tenant_id, source_id,
+                ),
+            ).fetchone()
+        if tuple(state.values()) != (0, "deleting", "deleting"):
+            raise RuntimeError("forget crash fence did not fail closed")
+        if (archive_store.root / artifact["object_key"] / "data").exists():
+            raise RuntimeError("raw object survived completed archive deletion")
+        try:
+            gateway.put_raw(
+                tenant_id=tenant_id,
+                source_id=source_id,
+                native_id=native_id,
+                payload=raw_payload,
+                media_type="application/json",
+                created_at=created_at,
+            )
+        except CanonicalLifecycleError as error:
+            if error.error_code != "archive_identity_forgotten":
+                raise
+        else:
+            raise RuntimeError("archive gateway resurrected a forgotten identity")
+
+        completed = plane.forget(forget)
+        replayed_forget = plane.forget(forget)
+        if completed["raw_deleted"] != 1 or replayed_forget["replay"] is not True:
+            raise RuntimeError("forget retry contract failed")
+        with store.connect() as connection:
+            counts = connection.execute(
+                """SELECT
+                     (SELECT count(*) FROM raw_artifacts
+                       WHERE tenant_id=%s AND source_id=%s) AS artifacts,
+                     (SELECT count(*) FROM canonical_events
+                       WHERE tenant_id=%s AND source_id=%s) AS events,
+                     (SELECT count(*) FROM canonical_documents
+                       WHERE tenant_id=%s AND source_id=%s) AS documents,
+                     (SELECT count(*) FROM canonical_chunks
+                       WHERE tenant_id=%s AND source_id=%s) AS chunks,
+                     (SELECT count(*) FROM forget_tombstones
+                       WHERE tenant_id=%s AND source_id=%s AND status='deleted') AS tombstones""",
+                (
+                    tenant_id, source_id, tenant_id, source_id,
+                    tenant_id, source_id, tenant_id, source_id,
+                    tenant_id, source_id,
+                ),
+            ).fetchone()
+            if tuple(counts.values()) != (0, 0, 0, 0, 1):
+                raise RuntimeError("authoritative forget left canonical evidence behind")
+            try:
+                with connection.transaction():
+                    connection.execute(
+                        """INSERT INTO canonical_events(
+                               tenant_id,source_id,event_id,native_id,artifact_id,job_id,
+                               kind,content_sha256,revision,occurred_at,observed_at,
+                               canonical_redacted
+                           ) VALUES (%s,%s,%s,%s,'art_missing','job_missing','document',
+                                     %s,2,now(),now(),'{}'::jsonb)""",
+                        (
+                            tenant_id, source_id, "evt_resurrection", native_id,
+                            hashlib.sha256(b"resurrection").hexdigest(),
+                        ),
+                    )
+            except psycopg.Error as error:
+                if error.sqlstate != "23514":
+                    raise
+            else:
+                raise RuntimeError("database trigger accepted forgotten identity")
+        if raw_canary in json.dumps({
+            "first": first,
+            "completed": completed,
+            "replayed_forget": replayed_forget,
+        }):
+            raise RuntimeError("lifecycle result leaked raw content")
+    store.close()
+    print(json.dumps({
+        "status": "pass",
+        "archive_before_canonical": True,
+        "ingest_replay": True,
+        "forget_crash_fenced": True,
+        "forget_retry": True,
+        "raw_versions_remaining": 0,
+        "derived_rows_remaining": 0,
+        "resurrection_rejections": 2,
+        "public_payload_canary_leaks": 0,
+    }, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/recall/tests/central_brain/test_brainstore_unit.py
+++ b/recall/tests/central_brain/test_brainstore_unit.py
@@ -116,6 +116,20 @@ class SchemaMigrationContractTest(unittest.TestCase):
         self.assertNotIn("raw_payload", rendered)
         self.assertNotIn("password", rendered)
 
+    def test_v2_lifecycle_migration_fences_resurrection_and_resumes_forget(self) -> None:
+        migration = SERVER / "schema" / "020_v2_lifecycle_guards.sql"
+        rendered = " ".join(migration.read_text().split()).casefold()
+        self.assertIn("state in ('live', 'deleting', 'deleted')", rendered)
+        self.assertIn(
+            "encryption in ('filesystem-owner-only', 'sse-s3', 'sse-kms', 'sse-c')",
+            rendered,
+        )
+        self.assertIn("status in ('deleting', 'deleted')", rendered)
+        self.assertIn("forget_tombstones_idempotency_idx", rendered)
+        self.assertIn("recall_v2_reject_forgotten_event", rendered)
+        self.assertIn("before insert on canonical_events", rendered)
+        self.assertIn("errcode='23514'", rendered)
+
     def test_connector_v2_source_families_are_host_owned_and_migrated(self) -> None:
         added = {
             "communications", "schedule", "contacts", "social", "documents",

--- a/recall/tests/test_archive_store_v2.py
+++ b/recall/tests/test_archive_store_v2.py
@@ -27,7 +27,6 @@ def request(**overrides) -> ArchiveRequest:
         "tenant_id": TENANT,
         "source_id": SOURCE,
         "native_id": "native:synthetic-1",
-        "revision": 1,
         "media_type": "application/json",
         "payload": PAYLOAD,
     }
@@ -124,7 +123,7 @@ class ArchiveStoreParityTest(unittest.TestCase):
         for store in (self.filesystem, self.s3):
             first = store.put(request())
             replay = store.put(request())
-            changed = store.put(request(revision=2, payload=PAYLOAD + b"\n"))
+            changed = store.put(request(payload=PAYLOAD + b"\n"))
 
             self.assertEqual(first.artifact_id, replay.artifact_id)
             self.assertEqual(first.object_key, replay.object_key)
@@ -182,6 +181,26 @@ class ArchiveStoreParityTest(unittest.TestCase):
         data_path.write_bytes(b"tampered")
         with self.assertRaises(ArchiveCorruption):
             self.filesystem.read(reference, tenant_id=TENANT, source_id=SOURCE)
+
+    def test_contract_gateway_delete_is_idempotent_and_tenant_safe(self):
+        for store in (self.filesystem, self.s3):
+            reference = store.put_raw(
+                tenant_id=TENANT,
+                source_id=SOURCE,
+                native_id="native:gateway-delete",
+                payload=PAYLOAD,
+                media_type="application/json",
+                created_at="2026-07-19T00:00:00Z",
+            )
+            forged = {**reference, "tenant_id": "tenant:other"}
+            self.assertFalse(store.delete_raw(forged))
+            internal = store.put(request(native_id="native:gateway-delete"))
+            self.assertEqual(
+                store.read(internal, tenant_id=TENANT, source_id=SOURCE),
+                PAYLOAD,
+            )
+            self.assertTrue(store.delete_raw(reference))
+            self.assertFalse(store.delete_raw(reference))
 
     def test_filesystem_rejects_a_symlinked_parent(self):
         with tempfile.TemporaryDirectory() as temporary:

--- a/recall/tests/test_connector_sdk.py
+++ b/recall/tests/test_connector_sdk.py
@@ -21,6 +21,7 @@ from connectors.sdk import (
     seed_acknowledged_records,
 )
 from privacy.policy import PrivacyPolicy
+from server.recall_server.archive import FilesystemArchiveStore
 
 
 class SyntheticConnector:
@@ -67,6 +68,55 @@ class FakeBrain:
             "status": "committed", "inserted": inserted,
             "duplicate_events": duplicates, "receipts": receipts, "replay": False,
         }
+
+
+class FakeArchive:
+    def __init__(self):
+        self.calls = 0
+        self.objects: dict[str, bytes] = {}
+        self.fail_before_commit = False
+        self.fail_after_commit = False
+        self.invalid_reference = False
+        self.reject_forgotten = False
+
+    def put_raw(
+        self,
+        *,
+        tenant_id: str,
+        source_id: str,
+        native_id: str,
+        payload: bytes,
+        media_type: str,
+        created_at: str,
+    ) -> dict:
+        self.calls += 1
+        if self.reject_forgotten:
+            raise ConnectorRunError("archive_identity_forgotten")
+        if self.fail_before_commit:
+            raise OSError("synthetic archive unavailable with private detail")
+        digest = hashlib.sha256(payload).hexdigest()
+        self.objects.setdefault(digest, payload)
+        if self.fail_after_commit:
+            self.fail_after_commit = False
+            raise OSError("synthetic archive acknowledgement lost")
+        reference = {
+            "contract": "recall.artifact-ref.v1",
+            "schema_version": 1,
+            "tenant_id": tenant_id,
+            "source_id": source_id,
+            "artifact_id": "art_" + digest[:16],
+            "storage_backend": "s3",
+            "object_key": f"objects/{digest[:2]}/{digest}",
+            "content_sha256": digest,
+            "size_bytes": len(payload),
+            "media_type": media_type,
+            "encryption": "sse-s3",
+            "version_id": "version-" + digest[:16],
+            "created_at": created_at,
+        }
+        if self.invalid_reference:
+            reference["tenant_id"] = "tenant:wrong"
+        return reference
 
 
 def record(native_id: str, text: str, *, deleted: bool = False,
@@ -183,6 +233,191 @@ class ConnectorRunnerTest(unittest.TestCase):
         recovered.run_once()
         self.assertEqual(connector.pulls, [None, "page-1"])
         recovered.close()
+
+    def test_raw_archive_precedes_private_spool_and_brain(self) -> None:
+        canary = "archive-raw-canary-77"
+        connector = SyntheticConnector({
+            None: ConnectorPage(
+                records=(record("archive-one", f"api_key={canary} safe context"),),
+                next_cursor="done",
+                has_more=False,
+            ),
+        })
+        archive = FakeArchive()
+        brain = FakeBrain()
+        runner = ConnectorRunner(
+            connector=connector,
+            brain=brain,
+            archive=archive,
+            tenant_id="tenant:synthetic",
+            principal_id="principal:owner",
+            spool_path=self.spool,
+            privacy=PrivacyPolicy(mode="scrub"),
+        )
+        result = runner.run_once()
+        self.assertEqual(result["archived"], 1)
+        self.assertEqual(len(archive.objects), 1)
+        self.assertIn(canary.encode(), next(iter(archive.objects.values())))
+        event = next(iter(brain.events.values()))
+        self.assertNotIn(canary, json.dumps(event))
+        self.assertNotIn(canary.encode(), self.spool_bytes())
+        artifact = event["provenance"]["artifact_ref"]
+        self.assertEqual(artifact["tenant_id"], "tenant:synthetic")
+        self.assertEqual(artifact["source_id"], connector.source_id)
+        runner.close()
+
+    def test_archive_failure_never_stages_calls_brain_or_moves_cursor(self) -> None:
+        connector = SyntheticConnector({
+            None: ConnectorPage(
+                records=(record("archive-failure", "safe"),),
+                next_cursor="done",
+                has_more=False,
+            ),
+        })
+        archive = FakeArchive()
+        archive.fail_before_commit = True
+        brain = FakeBrain()
+        runner = ConnectorRunner(
+            connector=connector,
+            brain=brain,
+            archive=archive,
+            tenant_id="tenant:synthetic",
+            principal_id="principal:owner",
+            spool_path=self.spool,
+        )
+        with self.assertRaisesRegex(ConnectorRunError, "archive_unavailable"):
+            runner.run_once()
+        self.assertEqual(brain.calls, 0)
+        self.assertEqual(runner.doctor()["pending"], 0)
+        self.assertFalse(runner.doctor()["checkpointed"])
+        runner.close()
+
+    def test_lost_archive_ack_replays_one_object_then_commits(self) -> None:
+        connector = SyntheticConnector({
+            None: ConnectorPage(
+                records=(record("archive-replay", "safe"),),
+                next_cursor="done",
+                has_more=False,
+            ),
+        })
+        archive = FakeArchive()
+        archive.fail_after_commit = True
+        brain = FakeBrain()
+        runner = ConnectorRunner(
+            connector=connector,
+            brain=brain,
+            archive=archive,
+            tenant_id="tenant:synthetic",
+            principal_id="principal:owner",
+            spool_path=self.spool,
+        )
+        with self.assertRaisesRegex(ConnectorRunError, "archive_unavailable"):
+            runner.run_once()
+        self.assertEqual(len(archive.objects), 1)
+        self.assertEqual(runner.doctor()["pending"], 0)
+        self.assertEqual(runner.run_once()["acked"], 1)
+        self.assertEqual(len(archive.objects), 1)
+        self.assertEqual(archive.calls, 2)
+        self.assertEqual(brain.calls, 1)
+        self.assertTrue(runner.doctor()["checkpointed"])
+        runner.close()
+
+    def test_archive_configuration_and_reference_fail_closed(self) -> None:
+        connector = SyntheticConnector({
+            None: ConnectorPage(
+                records=(record("archive-invalid", "safe"),),
+                next_cursor="done",
+                has_more=False,
+            ),
+        })
+        with self.assertRaisesRegex(ConnectorContractError, "configured together"):
+            ConnectorRunner(
+                connector=connector,
+                brain=FakeBrain(),
+                archive=FakeArchive(),
+                spool_path=self.spool,
+            )
+        with self.assertRaisesRegex(ConnectorContractError, "configured together"):
+            ConnectorRunner(
+                connector=connector,
+                brain=FakeBrain(),
+                tenant_id="tenant:synthetic",
+                spool_path=self.spool,
+            )
+
+        archive = FakeArchive()
+        archive.invalid_reference = True
+        runner = ConnectorRunner(
+            connector=connector,
+            brain=FakeBrain(),
+            archive=archive,
+            tenant_id="tenant:synthetic",
+            principal_id="principal:owner",
+            spool_path=self.spool,
+        )
+        with self.assertRaisesRegex(ConnectorRunError, "archive_invalid_reference"):
+            runner.run_once()
+        self.assertEqual(runner.doctor()["pending"], 0)
+        self.assertEqual(runner.doctor()["last_error_code"], "archive_invalid_reference")
+        runner.close()
+
+    def test_filesystem_archive_gateway_runs_end_to_end(self) -> None:
+        canary = "real-filesystem-raw-canary-32"
+        connector = SyntheticConnector({
+            None: ConnectorPage(
+                records=(record("archive-real", f"api_key={canary} context"),),
+                next_cursor="done",
+                has_more=False,
+            ),
+        })
+        archive = FilesystemArchiveStore(
+            Path(self.temporary.name) / "raw-archive",
+            namespace_key=b"n" * 32,
+        )
+        brain = FakeBrain()
+        runner = ConnectorRunner(
+            connector=connector,
+            brain=brain,
+            archive=archive,
+            tenant_id="tenant:synthetic",
+            principal_id="principal:owner",
+            spool_path=self.spool,
+            privacy=PrivacyPolicy(mode="scrub"),
+        )
+        self.assertEqual(runner.run_once()["archived"], 1)
+        event = next(iter(brain.events.values()))
+        reference = event["provenance"]["artifact_ref"]
+        stored = archive.root / reference["object_key"] / "data"
+        self.assertIn(canary.encode(), stored.read_bytes())
+        self.assertNotIn(canary, json.dumps(event))
+        self.assertNotIn(canary.encode(), self.spool_bytes())
+        runner.close()
+
+    def test_forgotten_archive_identity_is_suppressed_and_cursor_advances(self) -> None:
+        connector = SyntheticConnector({
+            None: ConnectorPage(
+                records=(record("forgotten-one", "must not resurrect"),),
+                next_cursor="done",
+                has_more=False,
+            ),
+        })
+        archive = FakeArchive()
+        archive.reject_forgotten = True
+        brain = FakeBrain()
+        runner = ConnectorRunner(
+            connector=connector,
+            brain=brain,
+            archive=archive,
+            tenant_id="tenant:synthetic",
+            principal_id="principal:owner",
+            spool_path=self.spool,
+        )
+        result = runner.run_once()
+        self.assertEqual(result["forgotten"], 1)
+        self.assertEqual(result["staged"], 0)
+        self.assertEqual(brain.calls, 0)
+        self.assertTrue(runner.doctor()["checkpointed"])
+        runner.close()
 
     def test_reordered_acknowledged_record_is_not_resubmitted(self) -> None:
         repeated = record("reordered-one", "same acknowledged content")


### PR DESCRIPTION
## Summary
- archive exact selected raw records before privacy/spool/Brain while keeping raw bytes out of canonical projections
- add tenant-aware canonical ingest plus crash-resumable authoritative forget
- fence forgotten identities in both the archive gateway and PostgreSQL, with filesystem/S3 parity

## Verification
- 550 Python tests and 3 Node tests pass
- fresh PostgreSQL canonical-plane and lifecycle E2E pass
- lost archive ACK, cursor ordering, tenant-forged deletion, raw canary, retry, and zero-resurrection gates pass
- migrations 1-20 replay cleanly