### PR TITLE
feat(recall): prove v2 restore and tenant isolation

### DIFF
--- a/.github/workflows/recall-ci.yml
+++ b/.github/workflows/recall-ci.yml
@@ -50,6 +50,7 @@ jobs:
             e2e_brainstore.py \
             e2e_v2_canonical_plane.py \
             e2e_v2_lifecycle.py \
+            e2e_v2_isolation.py \
             e2e_session_source_l1.py \
             e2e_semantic_l2.py \
             e2e_capture_mcp.py \

--- a/recall/server/deploy/README.md
+++ b/recall/server/deploy/README.md
@@ -401,3 +401,15 @@ Back up and run a blank-database restore proof:
 RECALL_DATABASE_URL=... recall/server/scripts/backup_restore.sh backup /secure/backup/dir
 RECALL_RESTORE_DATABASE_URL=... recall/server/scripts/backup_restore.sh restore-test /secure/backup/dir
 ```
+
+The database fingerprint covers both legacy events and every v2 canonical truth, projection,
+redirect, and forget-fence table. The laptop OSS profile backs up its exact raw archive separately
+and proves it into an empty root:
+
+```bash
+python -m recall_server.archive_snapshot backup /private/archive /secure/archive-snapshot
+python -m recall_server.archive_snapshot restore-test /secure/archive-snapshot /private/empty-restore
+```
+
+Both commands emit aggregate counts and fingerprints only. The restore refuses a symlink, a
+non-owner-only tree, tampered bytes or metadata, and any nonempty destination.

--- a/recall/server/recall_server/archive.py
+++ b/recall/server/recall_server/archive.py
@@ -348,6 +348,19 @@ class FilesystemArchiveStore(_ArchiveStore):
             raise ValueError("archive root must be an owner-only directory")
         self.root = root.resolve()
 
+    @staticmethod
+    def _ensure_private_directory(path: Path) -> None:
+        try:
+            path.mkdir(mode=0o700, exist_ok=True)
+            details = path.lstat()
+            if stat.S_ISLNK(details.st_mode) or not stat.S_ISDIR(details.st_mode):
+                raise ArchiveCorruption("archive object path is unsafe")
+            path.chmod(0o700)
+        except ArchiveCorruption:
+            raise
+        except OSError as error:
+            raise ArchiveCorruption("archive object path is unsafe") from error
+
     def put_stream(
         self,
         request: ArchiveRequest,
@@ -370,8 +383,11 @@ class FilesystemArchiveStore(_ArchiveStore):
             version_id="fs-" + content_sha256[:32],
         )
         directory = self.root / reference.object_key
-        directory.mkdir(parents=True, mode=0o700, exist_ok=True)
-        directory.chmod(0o700)
+        relative = directory.relative_to(self.root)
+        current = self.root
+        for component in relative.parts:
+            current = current / component
+            self._ensure_private_directory(current)
         metadata = json.dumps(_metadata(reference), sort_keys=True, separators=(",", ":")).encode()
         self._publish(directory / "data", payload)
         self._publish(directory / "metadata.json", metadata)

--- a/recall/server/recall_server/archive_snapshot.py
+++ b/recall/server/recall_server/archive_snapshot.py
@@ -1,0 +1,358 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import shutil
+import stat
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+OBJECT_KEY_RE = re.compile(r"objects/[0-9a-f]{2}/[0-9a-f]{64}\Z")
+SHA256_RE = re.compile(r"[0-9a-f]{64}\Z")
+ARTIFACT_ID_RE = re.compile(r"art_[0-9a-f]{32}\Z")
+METADATA_KEYS = {
+    "artifact_id",
+    "tenant_scope_sha256",
+    "source_scope_sha256",
+    "content_sha256",
+    "size_bytes",
+    "media_type_sha256",
+}
+
+
+class ArchiveSnapshotError(RuntimeError):
+    """Content-free archive snapshot failure."""
+
+
+def _directory(path: Path, *, label: str) -> None:
+    try:
+        details = path.lstat()
+    except OSError as error:
+        raise ArchiveSnapshotError(f"{label} is unavailable") from error
+    if (
+        stat.S_ISLNK(details.st_mode)
+        or not stat.S_ISDIR(details.st_mode)
+        or stat.S_IMODE(details.st_mode) != 0o700
+    ):
+        raise ArchiveSnapshotError(f"{label} is unsafe")
+
+
+def _open_regular(path: Path) -> tuple[int, int]:
+    try:
+        details = path.lstat()
+    except OSError as error:
+        raise ArchiveSnapshotError("archive object is unavailable") from error
+    if (
+        stat.S_ISLNK(details.st_mode)
+        or not stat.S_ISREG(details.st_mode)
+        or stat.S_IMODE(details.st_mode) != 0o600
+    ):
+        raise ArchiveSnapshotError("archive object is unsafe")
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(path, flags)
+        opened = os.fstat(descriptor)
+        if (opened.st_dev, opened.st_ino) != (details.st_dev, details.st_ino):
+            os.close(descriptor)
+            raise ArchiveSnapshotError("archive object changed during verification")
+        return descriptor, opened.st_size
+    except OSError as error:
+        raise ArchiveSnapshotError("archive object is unavailable") from error
+
+
+def _read_regular(path: Path, *, maximum_bytes: int) -> bytes:
+    descriptor, size = _open_regular(path)
+    try:
+        if size > maximum_bytes:
+            raise ArchiveSnapshotError("archive metadata integrity failed")
+        chunks: list[bytes] = []
+        while True:
+            chunk = os.read(descriptor, min(65_536, maximum_bytes + 1))
+            if not chunk:
+                return b"".join(chunks)
+            chunks.append(chunk)
+    finally:
+        os.close(descriptor)
+
+
+def _hash_regular(path: Path, *, expected_bytes: int) -> str:
+    descriptor, size = _open_regular(path)
+    digest = hashlib.sha256()
+    try:
+        if size != expected_bytes:
+            raise ArchiveSnapshotError("archive object integrity failed")
+        while True:
+            chunk = os.read(descriptor, 1_048_576)
+            if not chunk:
+                return digest.hexdigest()
+            digest.update(chunk)
+    finally:
+        os.close(descriptor)
+
+
+def _copy_regular(source: Path, destination: Path) -> None:
+    source_descriptor, _size = _open_regular(source)
+    destination_descriptor = -1
+    try:
+        destination_descriptor = os.open(
+            destination,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0),
+            0o600,
+        )
+        while True:
+            chunk = os.read(source_descriptor, 1_048_576)
+            if not chunk:
+                break
+            view = memoryview(chunk)
+            while view:
+                written = os.write(destination_descriptor, view)
+                if written <= 0:
+                    raise ArchiveSnapshotError("archive copy failed")
+                view = view[written:]
+        os.fsync(destination_descriptor)
+    except ArchiveSnapshotError:
+        raise
+    except OSError as error:
+        raise ArchiveSnapshotError("archive copy failed") from error
+    finally:
+        os.close(source_descriptor)
+        if destination_descriptor >= 0:
+            os.close(destination_descriptor)
+
+
+def _metadata(value: bytes) -> dict[str, str]:
+    try:
+        parsed = json.loads(value)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ArchiveSnapshotError("archive metadata integrity failed") from error
+    if not isinstance(parsed, dict) or set(parsed) != METADATA_KEYS:
+        raise ArchiveSnapshotError("archive metadata integrity failed")
+    strings = {
+        "artifact_id": ARTIFACT_ID_RE,
+        "tenant_scope_sha256": SHA256_RE,
+        "source_scope_sha256": SHA256_RE,
+        "content_sha256": SHA256_RE,
+        "media_type_sha256": SHA256_RE,
+    }
+    if any(
+        not isinstance(parsed[key], str) or not pattern.fullmatch(parsed[key])
+        for key, pattern in strings.items()
+    ):
+        raise ArchiveSnapshotError("archive metadata integrity failed")
+    size = parsed["size_bytes"]
+    if not isinstance(size, str) or not size.isdigit() or int(size) > 5 * 1024**3:
+        raise ArchiveSnapshotError("archive metadata integrity failed")
+    return parsed
+
+
+def _object_directories(root: Path) -> list[Path]:
+    _directory(root, label="archive root")
+    if {entry.name for entry in root.iterdir()} - {"objects", "manifest.json"}:
+        raise ArchiveSnapshotError("archive object layout is unsafe")
+    objects = root / "objects"
+    if not objects.exists():
+        return []
+    _directory(objects, label="archive object root")
+    directories: list[Path] = []
+    for prefix in sorted(objects.iterdir()):
+        _directory(prefix, label="archive prefix")
+        if not re.fullmatch(r"[0-9a-f]{2}", prefix.name):
+            raise ArchiveSnapshotError("archive object layout is unsafe")
+        for object_dir in sorted(prefix.iterdir()):
+            _directory(object_dir, label="archive object directory")
+            relative = object_dir.relative_to(root).as_posix()
+            if not OBJECT_KEY_RE.fullmatch(relative) or object_dir.name[:2] != prefix.name:
+                raise ArchiveSnapshotError("archive object layout is unsafe")
+            directories.append(object_dir)
+    return directories
+
+
+def verify_filesystem_archive(root: Path) -> dict[str, int | str]:
+    root = Path(root)
+    digest = hashlib.sha256()
+    object_count = 0
+    byte_count = 0
+    for object_dir in _object_directories(root):
+        entries = {entry.name for entry in object_dir.iterdir()}
+        if entries != {"data", "metadata.json"}:
+            raise ArchiveSnapshotError("archive object layout is unsafe")
+        metadata_bytes = _read_regular(
+            object_dir / "metadata.json",
+            maximum_bytes=16_384,
+        )
+        metadata = _metadata(metadata_bytes)
+        size_bytes = int(metadata["size_bytes"])
+        content_sha256 = _hash_regular(
+            object_dir / "data",
+            expected_bytes=size_bytes,
+        )
+        if metadata["content_sha256"] != content_sha256:
+            raise ArchiveSnapshotError("archive object integrity failed")
+        object_key = object_dir.relative_to(root).as_posix()
+        digest.update(object_key.encode())
+        digest.update(b"\0")
+        digest.update(hashlib.sha256(metadata_bytes).digest())
+        digest.update(bytes.fromhex(content_sha256))
+        object_count += 1
+        byte_count += size_bytes
+    return {
+        "object_count": object_count,
+        "byte_count": byte_count,
+        "archive_fingerprint": digest.hexdigest(),
+    }
+
+
+def _copy_archive(source: Path, destination: Path) -> None:
+    destination.mkdir(mode=0o700)
+    objects = destination / "objects"
+    objects.mkdir(mode=0o700)
+    for object_dir in _object_directories(source):
+        relative = object_dir.relative_to(source)
+        target = destination / relative
+        target.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        target.parent.chmod(0o700)
+        target.mkdir(mode=0o700)
+        for name in ("data", "metadata.json"):
+            _copy_regular(object_dir / name, target / name)
+
+
+def _empty_destination(path: Path) -> None:
+    if not path.exists():
+        return
+    _directory(path, label="archive destination")
+    if any(path.iterdir()):
+        raise ArchiveSnapshotError("archive destination must be empty")
+
+
+def backup_filesystem_archive(source: Path, destination: Path) -> dict[str, Any]:
+    source = Path(source)
+    source = source if source.is_absolute() else Path.cwd() / source
+    destination = Path(destination)
+    if not destination.is_absolute():
+        raise ArchiveSnapshotError("archive destination is unsafe")
+    if source == destination or source in destination.parents:
+        raise ArchiveSnapshotError("archive destination is unsafe")
+    destination_parent = destination.parent
+    _directory(destination_parent, label="archive destination parent")
+    _empty_destination(destination)
+    before = verify_filesystem_archive(source)
+    stage = Path(tempfile.mkdtemp(prefix=".archive-backup-", dir=destination_parent))
+    stage.chmod(0o700)
+    try:
+        stage.rmdir()
+        _copy_archive(source, stage)
+        after = verify_filesystem_archive(stage)
+        if before != after:
+            raise ArchiveSnapshotError("archive backup integrity failed")
+        manifest = {
+            "schema_version": 1,
+            **before,
+        }
+        manifest_path = stage / "manifest.json"
+        manifest_path.write_text(
+            json.dumps(manifest, sort_keys=True, separators=(",", ":")) + "\n"
+        )
+        manifest_path.chmod(0o600)
+        if destination.exists():
+            destination.rmdir()
+        os.replace(stage, destination)
+        return {"status": "pass", **before}
+    except Exception:
+        shutil.rmtree(stage, ignore_errors=True)
+        raise
+
+
+def _load_manifest(snapshot: Path) -> dict[str, Any]:
+    raw = _read_regular(snapshot / "manifest.json", maximum_bytes=16_384)
+    try:
+        manifest = json.loads(raw)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ArchiveSnapshotError("archive snapshot integrity failed") from error
+    if (
+        not isinstance(manifest, dict)
+        or set(manifest) != {
+            "schema_version", "object_count", "byte_count", "archive_fingerprint",
+        }
+        or manifest["schema_version"] != 1
+        or type(manifest["object_count"]) is not int
+        or type(manifest["byte_count"]) is not int
+        or not isinstance(manifest["archive_fingerprint"], str)
+        or not SHA256_RE.fullmatch(manifest["archive_fingerprint"])
+    ):
+        raise ArchiveSnapshotError("archive snapshot integrity failed")
+    return manifest
+
+
+def restore_filesystem_archive(snapshot: Path, destination: Path) -> dict[str, Any]:
+    snapshot = Path(snapshot)
+    destination = Path(destination)
+    _directory(snapshot, label="archive snapshot")
+    if not destination.is_absolute():
+        raise ArchiveSnapshotError("archive destination is unsafe")
+    _directory(destination.parent, label="archive destination parent")
+    _empty_destination(destination)
+    manifest = _load_manifest(snapshot)
+    current = verify_filesystem_archive(snapshot)
+    expected = {
+        key: manifest[key]
+        for key in ("object_count", "byte_count", "archive_fingerprint")
+    }
+    if current != expected:
+        raise ArchiveSnapshotError("archive snapshot integrity failed")
+    stage = Path(tempfile.mkdtemp(prefix=".archive-restore-", dir=destination.parent))
+    stage.rmdir()
+    try:
+        _copy_archive(snapshot, stage)
+        restored = verify_filesystem_archive(stage)
+        if restored != expected:
+            raise ArchiveSnapshotError("archive restore integrity failed")
+        if destination.exists():
+            destination.rmdir()
+        os.replace(stage, destination)
+        return {"status": "pass", **restored}
+    except Exception:
+        shutil.rmtree(stage, ignore_errors=True)
+        raise
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(prog="recall-archive-snapshot")
+    operations = parser.add_subparsers(dest="operation", required=True)
+    backup = operations.add_parser("backup")
+    backup.add_argument("source", type=Path)
+    backup.add_argument("destination", type=Path)
+    restore = operations.add_parser("restore-test")
+    restore.add_argument("snapshot", type=Path)
+    restore.add_argument("destination", type=Path)
+    verify = operations.add_parser("verify")
+    verify.add_argument("archive", type=Path)
+    arguments = parser.parse_args()
+    try:
+        if arguments.operation == "backup":
+            result = backup_filesystem_archive(
+                arguments.source,
+                arguments.destination,
+            )
+        elif arguments.operation == "restore-test":
+            result = restore_filesystem_archive(
+                arguments.snapshot,
+                arguments.destination,
+            )
+        else:
+            result = {"status": "pass", **verify_filesystem_archive(arguments.archive)}
+    except ArchiveSnapshotError:
+        print(json.dumps({
+            "status": "failed",
+            "error_code": "archive_snapshot_failed",
+        }, sort_keys=True))
+        raise SystemExit(2) from None
+    print(json.dumps(result, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/recall/server/scripts/backup_restore.sh
+++ b/recall/server/scripts/backup_restore.sh
@@ -5,6 +5,7 @@ umask 077
 MODE=${1:-}
 BACKUP_DIR=${2:-}
 TOOLS_IMAGE=${PG_TOOLS_IMAGE:-postgres:17-alpine}
+DATABASE_PROFILE=${RECALL_DATABASE_PROFILE:-production}
 SCRIPT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
 LIBPQ_ENV="$SCRIPT_DIR/libpq_env.py"
 
@@ -17,28 +18,72 @@ usage() {
 fingerprint() {
   local url_env=$1
   local snapshot=${2:-}
+  local snapshot_sql=''
   if [ -n "$snapshot" ]; then
-    python3 "$LIBPQ_ENV" exec --url-env "$url_env" -- \
-      psql -XAtq -v ON_ERROR_STOP=1 <<SQL
+    snapshot_sql="SET TRANSACTION SNAPSHOT '$snapshot';"
+  fi
+    python3 "$LIBPQ_ENV" exec --url-env "$url_env" --profile "$DATABASE_PROFILE" -- \
+    psql -XAtq -v ON_ERROR_STOP=1 <<SQL
 BEGIN ISOLATION LEVEL REPEATABLE READ READ ONLY;
-SET TRANSACTION SNAPSHOT '$snapshot';
-SELECT count(*) || ':' || COALESCE(md5(string_agg(source_id || ':' || native_id || ':' || revision || ':' || content_sha256, '|' ORDER BY id)), md5('')) FROM source_events;
+$snapshot_sql
+WITH fingerprints(name,row_count,digest) AS (
+  SELECT 'schema_migrations',count(*),
+    COALESCE(md5(string_agg(md5(row_to_json(value)::text),'' ORDER BY version)),md5(''))
+    FROM schema_migrations value
+  UNION ALL SELECT 'source_events',count(*),
+    COALESCE(md5(string_agg(md5(row_to_json(value)::text),'' ORDER BY id)),md5(''))
+    FROM source_events value
+  UNION ALL SELECT 'brain_tenants',count(*),
+    COALESCE(md5(string_agg(md5(row_to_json(value)::text),'' ORDER BY tenant_id)),md5(''))
+    FROM brain_tenants value
+  UNION ALL SELECT 'brain_principals',count(*),
+    COALESCE(md5(string_agg(md5(row_to_json(value)::text),'' ORDER BY tenant_id,principal_id)),md5(''))
+    FROM brain_principals value
+  UNION ALL SELECT 'canonical_sources',count(*),
+    COALESCE(md5(string_agg(md5(row_to_json(value)::text),'' ORDER BY tenant_id,source_id)),md5(''))
+    FROM canonical_sources value
+  UNION ALL SELECT 'raw_artifacts',count(*),
+    COALESCE(md5(string_agg(md5(row_to_json(value)::text),'' ORDER BY tenant_id,source_id,artifact_id)),md5(''))
+    FROM raw_artifacts value
+  UNION ALL SELECT 'canonical_ingest_jobs',count(*),
+    COALESCE(md5(string_agg(md5(row_to_json(value)::text),'' ORDER BY tenant_id,source_id,job_id)),md5(''))
+    FROM canonical_ingest_jobs value
+  UNION ALL SELECT 'canonical_events',count(*),
+    COALESCE(md5(string_agg(md5(row_to_json(value)::text),'' ORDER BY tenant_id,source_id,event_id)),md5(''))
+    FROM canonical_events value
+  UNION ALL SELECT 'canonical_documents',count(*),
+    COALESCE(md5(string_agg(md5(row_to_json(value)::text),'' ORDER BY tenant_id,source_id,document_id)),md5(''))
+    FROM canonical_documents value
+  UNION ALL SELECT 'canonical_chunks',count(*),
+    COALESCE(md5(string_agg(md5(row_to_json(value)::text),'' ORDER BY tenant_id,source_id,chunk_id)),md5(''))
+    FROM canonical_chunks value
+  UNION ALL SELECT 'receipt_redirects',count(*),
+    COALESCE(md5(string_agg(md5(row_to_json(value)::text),'' ORDER BY tenant_id,old_receipt)),md5(''))
+    FROM receipt_redirects value
+  UNION ALL SELECT 'forget_tombstones',count(*),
+    COALESCE(md5(string_agg(md5(row_to_json(value)::text),'' ORDER BY tenant_id,source_id,target_identity_sha256)),md5(''))
+    FROM forget_tombstones value
+  UNION ALL SELECT 'canonical_audit_events',count(*),
+    COALESCE(md5(string_agg(md5(row_to_json(value)::text),'' ORDER BY tenant_id,source_id,audit_id)),md5(''))
+    FROM canonical_audit_events value
+)
+SELECT COALESCE(sum(row_count),0) || ':' ||
+       md5(string_agg(name || ':' || row_count || ':' || digest,'|' ORDER BY name))
+FROM fingerprints;
 COMMIT;
 SQL
-    return
-  fi
-  python3 "$LIBPQ_ENV" exec --url-env "$url_env" -- \
-    psql -At -v ON_ERROR_STOP=1 -c \
-    "SELECT count(*) || ':' || COALESCE(md5(string_agg(source_id || ':' || native_id || ':' || revision || ':' || content_sha256, '|' ORDER BY id)), md5('')) FROM source_events"
 }
 
 snapshot_newest_epoch() {
   local url_env=$1 snapshot=$2
-  python3 "$LIBPQ_ENV" exec --url-env "$url_env" -- \
+  python3 "$LIBPQ_ENV" exec --url-env "$url_env" --profile "$DATABASE_PROFILE" -- \
     psql -XAtq -v ON_ERROR_STOP=1 <<SQL
 BEGIN ISOLATION LEVEL REPEATABLE READ READ ONLY;
 SET TRANSACTION SNAPSHOT '$snapshot';
-SELECT COALESCE(extract(epoch FROM max(created_at))::bigint,0) FROM source_events;
+SELECT GREATEST(
+  COALESCE((SELECT extract(epoch FROM max(created_at))::bigint FROM source_events),0),
+  COALESCE((SELECT extract(epoch FROM max(created_at))::bigint FROM canonical_events),0)
+);
 COMMIT;
 SQL
 }
@@ -66,7 +111,7 @@ case "$MODE" in
     started=$(date -u +%s)
     started_ms=$(date -u +%s%3N)
     (
-      python3 "$LIBPQ_ENV" exec --url-env RECALL_DATABASE_URL -- \
+      python3 "$LIBPQ_ENV" exec --url-env RECALL_DATABASE_URL --profile "$DATABASE_PROFILE" -- \
         psql -XAtq -v ON_ERROR_STOP=1 <<SQL
 BEGIN ISOLATION LEVEL REPEATABLE READ READ ONLY;
 SELECT pg_export_snapshot();
@@ -82,9 +127,9 @@ SQL
     done
     read -r database_snapshot < "$snapshot_output"
     case "$database_snapshot" in ''|*[!A-Fa-f0-9-]*) echo "invalid exported database snapshot" >&2; exit 1;; esac
-    source_fingerprint=$(fingerprint RECALL_DATABASE_URL "$database_snapshot")
+    database_fingerprint=$(fingerprint RECALL_DATABASE_URL "$database_snapshot")
     newest_epoch=$(snapshot_newest_epoch RECALL_DATABASE_URL "$database_snapshot")
-    python3 "$LIBPQ_ENV" write --url-env RECALL_DATABASE_URL \
+    python3 "$LIBPQ_ENV" write --url-env RECALL_DATABASE_URL --profile "$DATABASE_PROFILE" \
       --output "$stage/libpq.env"
     docker run --rm --network host --env-file "$stage/libpq.env" "$TOOLS_IMAGE" \
       pg_dump --snapshot="$database_snapshot" --format=custom --no-owner >"$stage/brain.dump"
@@ -95,12 +140,12 @@ SQL
     completed=$(date -u +%s)
     completed_ms=$(date -u +%s%3N)
     BACKUP_DIR="$stage" STARTED="$started" COMPLETED="$completed" STARTED_MS="$started_ms" COMPLETED_MS="$completed_ms" DUMP_SHA="$dump_sha" \
-      SOURCE_FINGERPRINT="$source_fingerprint" NEWEST_EPOCH="$newest_epoch" TOOLS_IMAGE="$TOOLS_IMAGE" DATABASE_SNAPSHOT="$database_snapshot" \
+      DATABASE_FINGERPRINT="$database_fingerprint" NEWEST_EPOCH="$newest_epoch" TOOLS_IMAGE="$TOOLS_IMAGE" DATABASE_SNAPSHOT="$database_snapshot" \
       python3 - <<'PY'
 import json, os
 from pathlib import Path
 manifest = {
-    "schema_version": 1,
+    "schema_version": 2,
     "started_epoch": int(os.environ["STARTED"]),
     "completed_epoch": int(os.environ["COMPLETED"]),
     "duration_seconds": int(os.environ["COMPLETED"]) - int(os.environ["STARTED"]),
@@ -108,7 +153,7 @@ manifest = {
     "newest_event_epoch": int(os.environ["NEWEST_EPOCH"]),
     "rpo_seconds_at_backup": max(0, int(os.environ["COMPLETED"]) - int(os.environ["NEWEST_EPOCH"])),
     "dump_sha256": os.environ["DUMP_SHA"],
-    "source_fingerprint": os.environ["SOURCE_FINGERPRINT"],
+    "database_fingerprint": os.environ["DATABASE_FINGERPRINT"],
     "database_snapshot": os.environ["DATABASE_SNAPSHOT"],
     "pg_tools_image": os.environ["TOOLS_IMAGE"],
 }
@@ -133,14 +178,14 @@ PY
     expected_sha=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["dump_sha256"])' "$snapshot/manifest.json")
     actual_sha=$(sha256sum "$snapshot/brain.dump" | awk '{print $1}')
     [ "$expected_sha" = "$actual_sha" ] || { echo "dump hash mismatch" >&2; exit 1; }
-    expected_fingerprint=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["source_fingerprint"])' "$snapshot/manifest.json")
+    expected_fingerprint=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["database_fingerprint"])' "$snapshot/manifest.json")
     started=$(date -u +%s)
     started_ms=$(date -u +%s%3N)
-    python3 "$LIBPQ_ENV" write --url-env RECALL_RESTORE_DATABASE_URL \
+    python3 "$LIBPQ_ENV" write --url-env RECALL_RESTORE_DATABASE_URL --profile "$DATABASE_PROFILE" \
       --output "$snapshot/libpq.env"
     docker run --rm --network host --env-file "$snapshot/libpq.env" \
       -v "$snapshot:/backup:ro" "$TOOLS_IMAGE" \
-      pg_restore --clean --if-exists --no-owner /backup/brain.dump
+      sh -c 'exec pg_restore --dbname="$PGDATABASE" --clean --if-exists --no-owner /backup/brain.dump'
     actual_fingerprint=$(fingerprint RECALL_RESTORE_DATABASE_URL)
     completed=$(date -u +%s)
     completed_ms=$(date -u +%s%3N)

--- a/recall/server/scripts/backup_restore.sh
+++ b/recall/server/scripts/backup_restore.sh
@@ -18,74 +18,95 @@ usage() {
 fingerprint() {
   local url_env=$1
   local snapshot=${2:-}
-  local snapshot_sql=''
+  local snapshot_sql='' rows
   if [ -n "$snapshot" ]; then
     snapshot_sql="SET TRANSACTION SNAPSHOT '$snapshot';"
   fi
+  rows=$(
     python3 "$LIBPQ_ENV" exec --url-env "$url_env" --profile "$DATABASE_PROFILE" -- \
     psql -XAtq -v ON_ERROR_STOP=1 <<SQL
 BEGIN ISOLATION LEVEL REPEATABLE READ READ ONLY;
 $snapshot_sql
-WITH fingerprints(name,row_count,digest) AS (
-  SELECT 'schema_migrations',count(*),
-    COALESCE(md5(string_agg(md5(row_to_json(value)::text),'' ORDER BY version)),md5(''))
-    FROM schema_migrations value
-  UNION ALL SELECT 'source_events',count(*),
-    COALESCE(md5(string_agg(md5(row_to_json(value)::text),'' ORDER BY id)),md5(''))
-    FROM source_events value
-  UNION ALL SELECT 'brain_tenants',count(*),
-    COALESCE(md5(string_agg(md5(row_to_json(value)::text),'' ORDER BY tenant_id)),md5(''))
-    FROM brain_tenants value
-  UNION ALL SELECT 'brain_principals',count(*),
-    COALESCE(md5(string_agg(md5(row_to_json(value)::text),'' ORDER BY tenant_id,principal_id)),md5(''))
-    FROM brain_principals value
-  UNION ALL SELECT 'canonical_sources',count(*),
-    COALESCE(md5(string_agg(md5(row_to_json(value)::text),'' ORDER BY tenant_id,source_id)),md5(''))
-    FROM canonical_sources value
-  UNION ALL SELECT 'raw_artifacts',count(*),
-    COALESCE(md5(string_agg(md5(row_to_json(value)::text),'' ORDER BY tenant_id,source_id,artifact_id)),md5(''))
-    FROM raw_artifacts value
-  UNION ALL SELECT 'canonical_ingest_jobs',count(*),
-    COALESCE(md5(string_agg(md5(row_to_json(value)::text),'' ORDER BY tenant_id,source_id,job_id)),md5(''))
-    FROM canonical_ingest_jobs value
-  UNION ALL SELECT 'canonical_events',count(*),
-    COALESCE(md5(string_agg(md5(row_to_json(value)::text),'' ORDER BY tenant_id,source_id,event_id)),md5(''))
-    FROM canonical_events value
-  UNION ALL SELECT 'canonical_documents',count(*),
-    COALESCE(md5(string_agg(md5(row_to_json(value)::text),'' ORDER BY tenant_id,source_id,document_id)),md5(''))
-    FROM canonical_documents value
-  UNION ALL SELECT 'canonical_chunks',count(*),
-    COALESCE(md5(string_agg(md5(row_to_json(value)::text),'' ORDER BY tenant_id,source_id,chunk_id)),md5(''))
-    FROM canonical_chunks value
-  UNION ALL SELECT 'receipt_redirects',count(*),
-    COALESCE(md5(string_agg(md5(row_to_json(value)::text),'' ORDER BY tenant_id,old_receipt)),md5(''))
-    FROM receipt_redirects value
-  UNION ALL SELECT 'forget_tombstones',count(*),
-    COALESCE(md5(string_agg(md5(row_to_json(value)::text),'' ORDER BY tenant_id,source_id,target_identity_sha256)),md5(''))
-    FROM forget_tombstones value
-  UNION ALL SELECT 'canonical_audit_events',count(*),
-    COALESCE(md5(string_agg(md5(row_to_json(value)::text),'' ORDER BY tenant_id,source_id,audit_id)),md5(''))
-    FROM canonical_audit_events value
+SELECT format(
+  \$query\$SELECT %L || chr(9) || count(*) || chr(9) ||
+    COALESCE(md5(string_agg(md5(row_to_json(value)::text),'' ORDER BY %s)),md5(''))
+    FROM %I value;\$query\$,
+  name, order_by, name
 )
-SELECT COALESCE(sum(row_count),0) || ':' ||
-       md5(string_agg(name || ':' || row_count || ':' || digest,'|' ORDER BY name))
-FROM fingerprints;
+FROM (VALUES
+  ('schema_migrations','version'),
+  ('source_events','id'),
+  ('brain_tenants','tenant_id'),
+  ('brain_principals','tenant_id,principal_id'),
+  ('canonical_sources','tenant_id,source_id'),
+  ('raw_artifacts','tenant_id,source_id,artifact_id'),
+  ('canonical_ingest_jobs','tenant_id,source_id,job_id'),
+  ('canonical_events','tenant_id,source_id,event_id'),
+  ('canonical_documents','tenant_id,source_id,document_id'),
+  ('canonical_chunks','tenant_id,source_id,chunk_id'),
+  ('receipt_redirects','tenant_id,old_receipt'),
+  ('forget_tombstones','tenant_id,source_id,target_identity_sha256'),
+  ('canonical_audit_events','tenant_id,source_id,audit_id')
+) AS approved(name,order_by)
+WHERE to_regclass('public.' || name) IS NOT NULL
+ORDER BY name
+\gexec
 COMMIT;
 SQL
+  )
+  FINGERPRINT_ROWS="$rows" python3 - <<'PY'
+import hashlib
+import os
+import re
+
+approved = {
+    "schema_migrations", "source_events", "brain_tenants", "brain_principals",
+    "canonical_sources", "raw_artifacts", "canonical_ingest_jobs",
+    "canonical_events", "canonical_documents", "canonical_chunks",
+    "receipt_redirects", "forget_tombstones", "canonical_audit_events",
+}
+rows = []
+for line in os.environ["FINGERPRINT_ROWS"].splitlines():
+    fields = line.split("\t")
+    if (
+        len(fields) != 3 or fields[0] not in approved or not fields[1].isdigit()
+        or re.fullmatch(r"[0-9a-f]{32}", fields[2]) is None
+    ):
+        raise SystemExit("database fingerprint failed")
+    rows.append((fields[0], int(fields[1]), fields[2]))
+if not rows or len({row[0] for row in rows}) != len(rows):
+    raise SystemExit("database fingerprint failed")
+rendered = "|".join(f"{name}:{count}:{digest}" for name, count, digest in sorted(rows))
+print(f"{sum(row[1] for row in rows)}:{hashlib.md5(rendered.encode()).hexdigest()}")
+PY
 }
 
 snapshot_newest_epoch() {
-  local url_env=$1 snapshot=$2
-  python3 "$LIBPQ_ENV" exec --url-env "$url_env" --profile "$DATABASE_PROFILE" -- \
+  local url_env=$1 snapshot=$2 epochs
+  epochs=$(
+    python3 "$LIBPQ_ENV" exec --url-env "$url_env" --profile "$DATABASE_PROFILE" -- \
     psql -XAtq -v ON_ERROR_STOP=1 <<SQL
 BEGIN ISOLATION LEVEL REPEATABLE READ READ ONLY;
 SET TRANSACTION SNAPSHOT '$snapshot';
-SELECT GREATEST(
-  COALESCE((SELECT extract(epoch FROM max(created_at))::bigint FROM source_events),0),
-  COALESCE((SELECT extract(epoch FROM max(created_at))::bigint FROM canonical_events),0)
-);
+SELECT format(
+  'SELECT COALESCE(extract(epoch FROM max(created_at))::bigint,0) FROM %I;',
+  name
+)
+FROM (VALUES ('source_events'),('canonical_events')) AS approved(name)
+WHERE to_regclass('public.' || name) IS NOT NULL
+ORDER BY name
+\gexec
 COMMIT;
 SQL
+  )
+  NEWEST_EPOCH_ROWS="$epochs" python3 - <<'PY'
+import os
+
+rows = os.environ["NEWEST_EPOCH_ROWS"].splitlines()
+if not rows or any(not row.isdigit() for row in rows):
+    raise SystemExit("database event watermark failed")
+print(max(map(int, rows)))
+PY
 }
 
 case "$MODE" in

--- a/recall/server/scripts/libpq_env.py
+++ b/recall/server/scripts/libpq_env.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import ipaddress
 import os
 import stat
 from pathlib import Path
@@ -26,7 +27,18 @@ class ConnectionPolicyError(ValueError):
     pass
 
 
-def libpq_environment(url: str) -> dict[str, str]:
+def _loopback(hostname: str) -> bool:
+    if hostname == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(hostname).is_loopback
+    except ValueError:
+        return False
+
+
+def libpq_environment(url: str, *, profile: str = "production") -> dict[str, str]:
+    if profile not in {"production", "local-fixture"}:
+        raise ConnectionPolicyError("database profile invalid")
     if not url or any(character in url for character in "\x00\r\n"):
         raise ConnectionPolicyError("database URL unavailable")
     parsed = urlsplit(url)
@@ -50,8 +62,12 @@ def libpq_environment(url: str) -> dict[str, str]:
     if len({key for key, _value in pairs}) != len(pairs):
         raise ConnectionPolicyError("database query duplicated")
     query = dict(pairs)
-    if query.pop("sslmode", None) != "verify-full":
-        raise ConnectionPolicyError("database TLS policy invalid")
+    sslmode = query.pop("sslmode", None)
+    if profile == "production":
+        if sslmode != "verify-full":
+            raise ConnectionPolicyError("database TLS policy invalid")
+    elif not _loopback(parsed.hostname) or sslmode != "disable":
+        raise ConnectionPolicyError("database fixture policy invalid")
     unknown = set(query) - set(ALLOWED_QUERY)
     if unknown:
         raise ConnectionPolicyError("database query unsupported")
@@ -61,7 +77,7 @@ def libpq_environment(url: str) -> dict[str, str]:
         "PGDATABASE": database,
         "PGUSER": username,
         "PGPASSWORD": password,
-        "PGSSLMODE": "verify-full",
+        "PGSSLMODE": sslmode,
         **{ALLOWED_QUERY[key]: value for key, value in query.items()},
     }
     if any(
@@ -100,12 +116,21 @@ def main() -> None:
     operations = parser.add_subparsers(dest="operation", required=True)
     execute = operations.add_parser("exec")
     execute.add_argument("--url-env", required=True)
+    execute.add_argument(
+        "--profile", choices=("production", "local-fixture"), default="production",
+    )
     execute.add_argument("command", nargs=argparse.REMAINDER)
     write = operations.add_parser("write")
     write.add_argument("--url-env", required=True)
+    write.add_argument(
+        "--profile", choices=("production", "local-fixture"), default="production",
+    )
     write.add_argument("--output", type=Path, required=True)
     args = parser.parse_args()
-    values = libpq_environment(os.environ.get(args.url_env, ""))
+    values = libpq_environment(
+        os.environ.get(args.url_env, ""),
+        profile=args.profile,
+    )
     if args.operation == "write":
         write_environment(args.output, values)
         return

--- a/recall/server/tests/e2e_v2_isolation.py
+++ b/recall/server/tests/e2e_v2_isolation.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sys
+import tempfile
+import uuid
+from pathlib import Path
+
+SERVER = Path(__file__).resolve().parents[1]
+ROOT = SERVER.parent
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(SERVER))
+
+from recall_server.archive import ArchiveRequest, FilesystemArchiveStore
+from recall_server.canonical import (
+    CanonicalArchiveGateway,
+    CanonicalLifecycleError,
+    CanonicalPlane,
+)
+from recall_server.db import BrainStore
+from recall_server.projectors import canonical_json
+
+
+def event(
+    *,
+    source_id: str,
+    native_id: str,
+    principal_id: str,
+    artifact: dict,
+    text: str,
+) -> dict:
+    content = {"text": text}
+    return {
+        "schema_version": 1,
+        "source_id": source_id,
+        "native_id": native_id,
+        "native_parent_id": native_id,
+        "kind": "connector_record",
+        "occurred_at": "2026-07-19T13:00:00Z",
+        "observed_at": "2026-07-19T13:00:00Z",
+        "principal_id": principal_id,
+        "visibility": "private",
+        "content_type": "application/json",
+        "content": content,
+        "provenance": {
+            "connector_id": "synthetic.isolation",
+            "connector_schema_version": 1,
+            "artifact_ref": artifact,
+        },
+        "content_sha256": hashlib.sha256(canonical_json(content)).hexdigest(),
+    }
+
+
+def main() -> None:
+    dsn = os.environ["RECALL_DATABASE_URL"]
+    store = BrainStore(dsn)
+    store.migrate()
+    nonce = uuid.uuid4().hex
+    source_id = f"source:isolation:{nonce}"
+    native_id = "native:same-across-tenants"
+    tenants = [f"tenant:isolation:{nonce}:{suffix}" for suffix in ("a", "b")]
+    principals = [f"principal:isolation:{nonce}:{suffix}" for suffix in ("a", "b")]
+
+    with tempfile.TemporaryDirectory() as temporary:
+        archive = FilesystemArchiveStore(
+            Path(temporary) / "archive",
+            namespace_key=b"i" * 32,
+        )
+        plane = CanonicalPlane(store, archive)
+        artifacts = []
+        ingests = []
+        for index, (tenant_id, principal_id) in enumerate(
+            zip(tenants, principals, strict=True)
+        ):
+            gateway = CanonicalArchiveGateway(
+                store,
+                archive,
+                tenant_id=tenant_id,
+                principal_id=principal_id,
+            )
+            raw = json.dumps({
+                "tenant_index": index,
+                "raw_canary": f"private-isolation-canary-{index}",
+            }, sort_keys=True).encode()
+            artifact = gateway.put_raw(
+                tenant_id=tenant_id,
+                source_id=source_id,
+                native_id=native_id,
+                payload=raw,
+                media_type="application/json",
+                created_at="2026-07-19T13:00:00Z",
+            )
+            artifacts.append(artifact)
+            ingests.append(plane.ingest_document(
+                tenant_id=tenant_id,
+                principal_id=principal_id,
+                connector_id="synthetic.isolation",
+                artifact_ref=artifact,
+                envelope=event(
+                    source_id=source_id,
+                    native_id=native_id,
+                    principal_id=principal_id,
+                    artifact=artifact,
+                    text=f"safe tenant evidence {index}",
+                ),
+                text_redacted=f"safe tenant evidence {index}",
+            ))
+
+        try:
+            plane.ingest_document(
+                tenant_id=tenants[0],
+                principal_id=principals[0],
+                connector_id="synthetic.isolation",
+                artifact_ref=artifacts[1],
+                envelope=event(
+                    source_id=source_id,
+                    native_id="native:forged",
+                    principal_id=principals[0],
+                    artifact=artifacts[1],
+                    text="forged",
+                ),
+                text_redacted="forged",
+            )
+        except CanonicalLifecycleError as error:
+            if error.error_code != "canonical_lineage_invalid":
+                raise
+        else:
+            raise RuntimeError("cross-tenant artifact lineage was accepted")
+
+        forget = {
+            "contract": "recall.forget-request.v1",
+            "schema_version": 1,
+            "tenant_id": tenants[0],
+            "principal_id": principals[0],
+            "source_id": source_id,
+            "target_receipt": ingests[0]["receipt"],
+            "mode": "explicit_forget",
+            "reason": "owner_requested",
+            "requested_at": "2026-07-19T13:05:00Z",
+            "idempotency_key": "isolation-forget-" + nonce,
+        }
+        unauthorized = {**forget, "principal_id": principals[1]}
+        try:
+            plane.forget(unauthorized)
+        except CanonicalLifecycleError as error:
+            if error.error_code != "forget_authority_forbidden":
+                raise
+        else:
+            raise RuntimeError("cross-principal forget was accepted")
+        deleted = plane.forget(forget)
+        if deleted["raw_deleted"] != 1:
+            raise RuntimeError("tenant-scoped forget did not delete one raw object")
+
+        with store.connect() as connection:
+            counts = connection.execute(
+                """SELECT tenant_id,
+                          count(*) FILTER (WHERE deleted_at IS NULL) AS live_chunks
+                   FROM canonical_chunks
+                   WHERE tenant_id=ANY(%s) AND source_id=%s
+                   GROUP BY tenant_id ORDER BY tenant_id""",
+                (tenants, source_id),
+            ).fetchall()
+            tombstones = connection.execute(
+                """SELECT tenant_id,count(*) AS count
+                   FROM forget_tombstones
+                   WHERE tenant_id=ANY(%s) AND source_id=%s
+                   GROUP BY tenant_id ORDER BY tenant_id""",
+                (tenants, source_id),
+            ).fetchall()
+        if [(row["tenant_id"], row["live_chunks"]) for row in counts] != [
+            (tenants[1], 1),
+        ]:
+            raise RuntimeError("tenant-scoped projection isolation failed")
+        if [(row["tenant_id"], row["count"]) for row in tombstones] != [
+            (tenants[0], 1),
+        ]:
+            raise RuntimeError("tenant-scoped forget proof escaped")
+        remaining = archive.put(ArchiveRequest(
+            tenant_id=tenants[1],
+            source_id=source_id,
+            native_id=native_id,
+            media_type="application/json",
+            payload=json.dumps({
+                "tenant_index": 1,
+                "raw_canary": "private-isolation-canary-1",
+            }, sort_keys=True).encode(),
+        ))
+        archive.read(
+            remaining,
+            tenant_id=tenants[1],
+            source_id=source_id,
+        )
+        if (archive.root / artifacts[0]["object_key"] / "data").exists():
+            raise RuntimeError("forgotten tenant raw object survived")
+    store.close()
+    print(json.dumps({
+        "status": "pass",
+        "tenants": 2,
+        "same_source_and_native": True,
+        "cross_tenant_lineage_rejections": 1,
+        "cross_principal_forget_rejections": 1,
+        "tenant_b_live_chunks": 1,
+        "tenant_b_raw_objects": 1,
+        "tenant_a_tombstones": 1,
+    }, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/recall/tests/test_archive_snapshot.py
+++ b/recall/tests/test_archive_snapshot.py
@@ -60,6 +60,12 @@ class ArchiveSnapshotTest(unittest.TestCase):
                     source_id="source:snapshot",
                 ),
             )
+        for directory in (
+            self.archive.root / "objects",
+            *list((self.archive.root / "objects").glob("*")),
+            *list((self.archive.root / "objects").glob("*/*")),
+        ):
+            self.assertEqual(directory.stat().st_mode & 0o777, 0o700)
         self.assertEqual(backup.stat().st_mode & 0o777, 0o700)
         self.assertEqual(restored.stat().st_mode & 0o777, 0o700)
         rendered = json.dumps(result)

--- a/recall/tests/test_archive_snapshot.py
+++ b/recall/tests/test_archive_snapshot.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from server.recall_server.archive import ArchiveRequest, FilesystemArchiveStore
+from server.recall_server.archive_snapshot import (
+    ArchiveSnapshotError,
+    backup_filesystem_archive,
+    restore_filesystem_archive,
+    verify_filesystem_archive,
+)
+
+
+class ArchiveSnapshotTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        self.archive = FilesystemArchiveStore(
+            self.root / "archive",
+            namespace_key=b"a" * 32,
+        )
+        self.references = []
+        for index in range(3):
+            self.references.append(self.archive.put(ArchiveRequest(
+                tenant_id="tenant:snapshot",
+                source_id="source:snapshot",
+                native_id=f"native:{index}",
+                media_type="application/json",
+                payload=json.dumps({"index": index, "text": "private"}).encode(),
+            )))
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def test_backup_restore_is_independent_exact_private_and_content_free(self) -> None:
+        backup = self.root / "backup"
+        before = verify_filesystem_archive(self.archive.root)
+        published = backup_filesystem_archive(self.archive.root, backup)
+        restored = self.root / "restored"
+        result = restore_filesystem_archive(backup, restored)
+        after = verify_filesystem_archive(restored)
+
+        self.assertEqual(before, after)
+        self.assertEqual(published["archive_fingerprint"], before["archive_fingerprint"])
+        self.assertEqual(result["archive_fingerprint"], before["archive_fingerprint"])
+        self.assertEqual(result["status"], "pass")
+        restored_store = FilesystemArchiveStore(
+            restored,
+            namespace_key=b"a" * 32,
+        )
+        for reference in self.references:
+            self.assertIn(
+                b'"text": "private"',
+                restored_store.read(
+                    reference,
+                    tenant_id="tenant:snapshot",
+                    source_id="source:snapshot",
+                ),
+            )
+        self.assertEqual(backup.stat().st_mode & 0o777, 0o700)
+        self.assertEqual(restored.stat().st_mode & 0o777, 0o700)
+        rendered = json.dumps(result)
+        self.assertNotIn("private", rendered)
+        self.assertNotIn(str(self.root), rendered)
+
+    def test_tamper_symlink_and_nonempty_restore_fail_closed(self) -> None:
+        backup = self.root / "backup"
+        backup_filesystem_archive(self.archive.root, backup)
+        data = next((backup / "objects").glob("*/*/data"))
+        data.write_bytes(b"tampered")
+        with self.assertRaisesRegex(ArchiveSnapshotError, "integrity"):
+            restore_filesystem_archive(backup, self.root / "restore-tampered")
+
+        object_dir = next((self.archive.root / "objects").glob("*/*"))
+        (object_dir / "data").unlink()
+        (object_dir / "data").symlink_to(self.root / "outside")
+        with self.assertRaisesRegex(ArchiveSnapshotError, "unsafe"):
+            verify_filesystem_archive(self.archive.root)
+
+        occupied = self.root / "occupied"
+        occupied.mkdir(mode=0o700)
+        (occupied / "marker").write_text("do not replace")
+        with self.assertRaisesRegex(ArchiveSnapshotError, "empty"):
+            restore_filesystem_archive(backup, occupied)

--- a/recall/tests/test_backup_restore.py
+++ b/recall/tests/test_backup_restore.py
@@ -30,10 +30,12 @@ class BackupPublicationTest(unittest.TestCase):
             "forget_tombstones",
             "canonical_audit_events",
         ):
-            self.assertIn(f"FROM {table}", rendered)
+            self.assertIn(f"('{table}',", rendered)
         self.assertIn('"database_fingerprint"', rendered)
         self.assertNotIn('"source_fingerprint"', rendered)
         self.assertIn('pg_restore --dbname="$PGDATABASE"', rendered)
+        self.assertIn("to_regclass('public.' || name) IS NOT NULL", rendered)
+        self.assertIn("database fingerprint failed", rendered)
 
     def test_deployment_timer_is_non_overlapping_and_makes_no_false_rpo_claim(self) -> None:
         timer = (ROOT / "server/deploy/recall-brain-backup.timer").read_text()
@@ -88,7 +90,7 @@ case "$input" in
     read ignored < "$fifo"
     ;;
   *'SET TRANSACTION SNAPSHOT'*'max(created_at)'*) echo 0;;
-  *'SET TRANSACTION SNAPSHOT'*) echo '1:synthetic-fingerprint';;
+  *'SET TRANSACTION SNAPSHOT'*) printf 'schema_migrations\t1\td41d8cd98f00b204e9800998ecf8427e\n';;
   *) exit 4;;
 esac
 """
@@ -140,10 +142,13 @@ esac
             backup = root / "latest"
             backup.mkdir()
             original = b"stable-root-owned-dump"
+            digest = hashlib.md5(
+                b"schema_migrations:1:d41d8cd98f00b204e9800998ecf8427e"
+            ).hexdigest()
             (backup / "brain.dump").write_bytes(original)
             (backup / "manifest.json").write_text(json.dumps({
                 "dump_sha256": hashlib.sha256(original).hexdigest(),
-                "database_fingerprint": "1:synthetic-fingerprint",
+                "database_fingerprint": f"1:{digest}",
             }))
             control = root / "control"
             control.mkdir()
@@ -172,7 +177,10 @@ test "$(cat "$mount/brain.dump")" = 'stable-root-owned-dump'
             )
             docker.chmod(0o755)
             psql = binaries / "psql"
-            psql.write_text("#!/bin/sh\necho '1:synthetic-fingerprint'\n")
+            psql.write_text(
+                "#!/bin/sh\n"
+                "printf 'schema_migrations\\t1\\td41d8cd98f00b204e9800998ecf8427e\\n'\n"
+            )
             psql.chmod(0o755)
             forbidden_link = binaries / "ln"
             forbidden_link.write_text("#!/bin/sh\necho 'hardlink forbidden' >&2\nexit 1\n")

--- a/recall/tests/test_backup_restore.py
+++ b/recall/tests/test_backup_restore.py
@@ -15,6 +15,26 @@ SCRIPT = ROOT / "server/scripts/backup_restore.sh"
 
 
 class BackupPublicationTest(unittest.TestCase):
+    def test_database_fingerprint_covers_v2_truth_projections_and_forget_fence(self) -> None:
+        rendered = SCRIPT.read_text()
+        for table in (
+            "brain_tenants",
+            "brain_principals",
+            "canonical_sources",
+            "raw_artifacts",
+            "canonical_ingest_jobs",
+            "canonical_events",
+            "canonical_documents",
+            "canonical_chunks",
+            "receipt_redirects",
+            "forget_tombstones",
+            "canonical_audit_events",
+        ):
+            self.assertIn(f"FROM {table}", rendered)
+        self.assertIn('"database_fingerprint"', rendered)
+        self.assertNotIn('"source_fingerprint"', rendered)
+        self.assertIn('pg_restore --dbname="$PGDATABASE"', rendered)
+
     def test_deployment_timer_is_non_overlapping_and_makes_no_false_rpo_claim(self) -> None:
         timer = (ROOT / "server/deploy/recall-brain-backup.timer").read_text()
         service = (ROOT / "server/deploy/recall-brain-backup.service").read_text()
@@ -99,7 +119,7 @@ esac
                 manifest = json.loads((backup / "manifest.json").read_text())
                 self.assertTrue(manifest["dump_sha256"])
                 self.assertEqual(manifest["database_snapshot"], "00000001-00000001-1")
-                self.assertIn('"schema_version": 1', stdout)
+                self.assertIn('"schema_version": 2', stdout)
                 self.assertEqual(backup.stat().st_mode & 0o777, 0o700)
                 self.assertEqual((backup / "brain.dump").stat().st_mode & 0o777, 0o600)
                 self.assertEqual((backup / "manifest.json").stat().st_mode & 0o777, 0o600)
@@ -123,7 +143,7 @@ esac
             (backup / "brain.dump").write_bytes(original)
             (backup / "manifest.json").write_text(json.dumps({
                 "dump_sha256": hashlib.sha256(original).hexdigest(),
-                "source_fingerprint": "1:synthetic-fingerprint",
+                "database_fingerprint": "1:synthetic-fingerprint",
             }))
             control = root / "control"
             control.mkdir()

--- a/recall/tests/test_backup_restore.py
+++ b/recall/tests/test_backup_restore.py
@@ -143,7 +143,8 @@ esac
             backup.mkdir()
             original = b"stable-root-owned-dump"
             digest = hashlib.md5(
-                b"schema_migrations:1:d41d8cd98f00b204e9800998ecf8427e"
+                b"schema_migrations:1:d41d8cd98f00b204e9800998ecf8427e",
+                usedforsecurity=False,
             ).hexdigest()
             (backup / "brain.dump").write_bytes(original)
             (backup / "manifest.json").write_text(json.dumps({

--- a/recall/tests/test_libpq_env.py
+++ b/recall/tests/test_libpq_env.py
@@ -78,6 +78,22 @@ class LibpqEnvironmentTest(unittest.TestCase):
                 with self.assertRaises(MODULE.ConnectionPolicyError):
                     MODULE.libpq_environment(url)
 
+    def test_local_fixture_is_explicit_disabled_tls_and_loopback_only(self) -> None:
+        values = MODULE.libpq_environment(
+            "postgresql://user:password@127.0.0.1:55439/recall?sslmode=disable",
+            profile="local-fixture",
+        )
+        self.assertEqual(values["PGSSLMODE"], "disable")
+        with self.assertRaises(MODULE.ConnectionPolicyError):
+            MODULE.libpq_environment(
+                "postgresql://user:password@db.invalid/recall?sslmode=disable",
+                profile="local-fixture",
+            )
+        with self.assertRaises(MODULE.ConnectionPolicyError):
+            MODULE.libpq_environment(
+                "postgresql://user:password@127.0.0.1/recall?sslmode=disable",
+            )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- fingerprint and blank-restore every v2 canonical truth, projection, redirect, and forget fence
- add streaming owner-only filesystem archive snapshot and independent restore verification
- prove same-identity tenant isolation and cross-principal/cross-artifact rejection
- add explicit loopback-only backup fixture profile while retaining verified TLS by default

## Verification
- 556 Python tests and 3 Node tests pass
- 28 E2Es pass on a fresh PostgreSQL database
- real blank-database restore matches the exact v2 fingerprint
- archive restore reopens every exact raw object and rejects tamper/symlink/nonempty targets
- immutable nonroot core container passes