### PR TITLE
feat(recall): use managed MCP from the skill

### DIFF
--- a/recall/README.md
+++ b/recall/README.md
@@ -46,7 +46,8 @@ The transcripts remain the source of truth. The SQLite index is disposable and
 fully rebuildable.
 
 When a private Recall Brain service is available, set `RECALL_URL` to use the same read commands
-over the tailnet. `RECALL_MODE=shadow` compares central receipts while returning local behavior;
+remotely. An explicit `/mcp` suffix selects the scoped MCP tools; a URL without it preserves the
+legacy REST transport. `RECALL_MODE=shadow` compares central receipts while returning local behavior;
 `RECALL_MODE=local` is an instant rollback that does not rewrite either store. Remote failures do
 not silently fall back to stale local results.
 

--- a/recall/server/recall_server/db.py
+++ b/recall/server/recall_server/db.py
@@ -1375,6 +1375,19 @@ class BrainStore:
         try:
             with self.connect() as conn:
                 routed_source_ids = self._resolve_routed_source_ids(conn, filters)
+                exact_question_rows = run_leg(
+                    "exact-question",
+                    lambda: self._exact_question_leg(
+                        conn,
+                        query,
+                        filters,
+                        authorized_source=authorized_source,
+                        routed_source_ids=routed_source_ids,
+                        deadline_at=deadline_at,
+                    ),
+                )
+                exact_question_count = len(exact_question_rows)
+                merge(exact_question_rows)
                 if identifiers:
                     merge(run_leg("entity", lambda: self._entity_leg(
                         conn, identifiers, filters, authorized_source=authorized_source,
@@ -1392,12 +1405,6 @@ class BrainStore:
                             break
                 else:
                     phrase_spec = phrase_query_spec(preferred_phrase_probes(engine.phrase_queries(query)))
-                    exact_question_rows = run_leg("exact-question", lambda: self._exact_question_leg(
-                        conn, query, filters, authorized_source=authorized_source,
-                        routed_source_ids=routed_source_ids, deadline_at=deadline_at,
-                    ))
-                    exact_question_count = len(exact_question_rows)
-                    merge(exact_question_rows)
                     # Dense retrieval is the primary non-exact natural-language
                     # leg. Run it before broad phrase scans and optional rewrites.
                     # Those rescues run lazily only when dense evidence cannot

--- a/recall/server/recall_server/ranking.py
+++ b/recall/server/recall_server/ranking.py
@@ -8,7 +8,7 @@ DEFAULT_SEARCH_DEADLINE_MS = 300
 def retrieval_leg_order(identifiers: list[str]) -> tuple[str, ...]:
     """Exact identifiers get the deadline before any potentially broad phrase."""
     return (
-        ("entity", "identifier") if identifiers
+        ("exact-question", "entity", "identifier") if identifiers
         else ("exact-question", "semantic", "phrase", "entity", "partial", "all")
     )
 

--- a/recall/skills/recall/SKILL.md
+++ b/recall/skills/recall/SKILL.md
@@ -20,9 +20,16 @@ Setting `RECALL_URL` selects the tailnet central service for read commands (`sea
 `related`, and `doctor`) and enables deliberate writes (`put` and `delete`). The same flags and output shapes remain valid, and every displayed remote
 hit includes its resolvable receipt on the `WHY` line.
 
+Use an explicit `/mcp` suffix for a public or managed MCP endpoint, for example
+`RECALL_URL=https://recall.example.com/mcp`. The skill then calls the scoped
+`recall_search`, `recall_show`, `recall_related`, `recall_capture`, and
+`recall_forget` tools directly; `doctor` uses MCP ping. `session-export` has no
+MCP tool and fails closed. A URL without `/mcp` preserves the legacy REST
+transport.
+
 For a persistent per-device read profile, use a mode-0600 regular file at
 `~/.config/recall-brain/client.json` with the exact shape
-`{"schema_version":1,"url":"https://brain.example.ts.net:9443",`
+`{"schema_version":1,"url":"https://brain.example.com/mcp",`
 `"token_file":"/absolute/private/read-token.json"}`. The referenced token file
 must also be a non-symlink mode-0600 regular file. Environment variables override
 the profile field by field; `RECALL_MODE=local` remains the instant rollback.
@@ -67,8 +74,10 @@ python3 scripts/recall.py delete 'recall://memory:mac:host/memory-…?rev=1'
 
 `put` returns the canonical receipt. Preserve it when reporting the write;
 `delete` requires that receipt and emits a tombstone under the same source and
-native ID. Writes require remote mode and fail closed if `RECALL_URL`, the
-source-scoped credential, or the exact source ID is unavailable. Never infer a
+native ID. REST writes require the exact source ID. MCP writes are instead
+bound to the source and origin of the scoped host credential, so the client
+does not transmit either authority. All writes require remote mode and fail
+closed if the endpoint or scoped credential is unavailable. Never infer a
 shared visibility choice: default to `private`, and use `shared` only when the
 user deliberately selects it. Secret-shaped lines are redacted before ingest.
 

--- a/recall/skills/recall/scripts/recall.py
+++ b/recall/skills/recall/scripts/recall.py
@@ -73,6 +73,8 @@ REMOTE_WRITE_COMMANDS = frozenset({"put", "delete"})
 CLIENT_CONFIG_FIELDS = {"schema_version", "url", "token_file"}
 MAX_CLIENT_CONFIG_BYTES = 16_384
 MAX_TOKEN_FILE_BYTES = 16_384
+MAX_REMOTE_RESPONSE_BYTES = 1024 * 1024
+MCP_PROTOCOL_VERSION = "2025-11-25"
 
 
 class RemoteRecallError(RuntimeError):
@@ -102,7 +104,7 @@ def _validated_remote_base(value: str) -> str:
         or parsed.password is not None
         or parsed.query
         or parsed.fragment
-        or parsed.path not in {"", "/"}
+        or parsed.path not in {"", "/", "/mcp"}
         or (port is not None and not 1 <= port <= 65535)
     ):
         raise RemoteRecallError("remote URL is invalid")
@@ -177,7 +179,7 @@ def load_client_config() -> dict | None:
     if (
         not isinstance(url, str) or not ((parsed.scheme == "https" and parsed.hostname) or loopback)
         or parsed.username or parsed.password or parsed.query or parsed.fragment
-        or parsed.path not in {"", "/"} or (port is not None and not 1 <= port <= 65535)
+        or parsed.path not in {"", "/", "/mcp"} or (port is not None and not 1 <= port <= 65535)
     ):
         raise RemoteRecallError("client config URL is invalid")
     token_file = value["token_file"]
@@ -212,6 +214,121 @@ def remote_headers() -> dict[str, str]:
     return headers
 
 
+def _read_remote_object(response) -> dict:
+    raw = response.read(MAX_REMOTE_RESPONSE_BYTES + 1)
+    if len(raw) > MAX_REMOTE_RESPONSE_BYTES:
+        raise RemoteRecallError("server response is too large")
+    rendered = json.loads(raw)
+    if not isinstance(rendered, dict):
+        raise RemoteRecallError("server returned a non-object response")
+    return rendered
+
+
+def _mcp_call(base: str, method: str, path: str, body: dict | None) -> dict:
+    if path == "/v1/session-export":
+        raise RemoteRecallError("session export is not available over MCP")
+    tool = {
+        "/v1/search": "recall_search",
+        "/v1/show": "recall_show",
+        "/v1/related": "recall_related",
+    }.get(path)
+    arguments = body or {}
+    if path == "/v1/doctor":
+        if method != "GET":
+            raise RemoteRecallError("unsupported MCP operation")
+        message = {"jsonrpc": "2.0", "id": 1, "method": "ping", "params": {}}
+    elif path == "/v1/ingest/batches":
+        events = arguments.get("events")
+        if method != "POST" or not isinstance(events, list) or len(events) != 1:
+            raise RemoteRecallError("unsupported MCP ingest request")
+        event = events[0]
+        if not isinstance(event, dict):
+            raise RemoteRecallError("unsupported MCP ingest request")
+        if event.get("kind") == "memory":
+            content = event.get("content")
+            text = content.get("text") if isinstance(content, dict) else None
+            provenance = event.get("provenance")
+            uri = provenance.get("uri") if isinstance(provenance, dict) else None
+            if not isinstance(text, str) or not text.strip() or len(text) > 32_000:
+                raise RemoteRecallError("MCP memory body is invalid")
+            title = next((line.strip() for line in text.splitlines() if line.strip()), text.strip())
+            tool = "recall_capture"
+            arguments = {
+                "schema_version": 1,
+                "title": title[:500],
+                "body": text,
+                "occurred_at": event.get("occurred_at"),
+                "provenance": {"uri": uri},
+            }
+        elif event.get("kind") == "tombstone":
+            content = event.get("content")
+            receipt = content.get("deleted_receipt") if isinstance(content, dict) else None
+            tool = "recall_forget"
+            arguments = {"receipt": receipt}
+        else:
+            raise RemoteRecallError("unsupported MCP ingest event")
+        message = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {"name": tool, "arguments": arguments},
+        }
+    elif tool is not None and method == "POST":
+        message = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {"name": tool, "arguments": arguments},
+        }
+    else:
+        raise RemoteRecallError("unsupported MCP operation")
+
+    headers = remote_headers()
+    headers["Accept"] = "application/json, text/event-stream"
+    headers["MCP-Protocol-Version"] = MCP_PROTOCOL_VERSION
+    request = urllib.request.Request(
+        base,
+        data=json.dumps(message, sort_keys=True).encode(),
+        method="POST",
+        headers=headers,
+    )
+    try:
+        with _open_remote(
+            request,
+            timeout=float(os.environ.get("RECALL_TIMEOUT", "15")),
+        ) as response:
+            rendered = _read_remote_object(response)
+    except urllib.error.HTTPError as exc:
+        exc.read(MAX_REMOTE_RESPONSE_BYTES + 1)
+        raise RemoteRecallError(f"HTTP {exc.code}: MCP request failed") from exc
+    except (OSError, urllib.error.URLError, json.JSONDecodeError, ValueError) as exc:
+        raise RemoteRecallError(type(exc).__name__) from exc
+
+    error = rendered.get("error")
+    if isinstance(error, dict):
+        code = error.get("code")
+        raise RemoteRecallError(f"MCP {code}: tool call failed")
+    if rendered.get("id") != message["id"] or not isinstance(rendered.get("result"), dict):
+        raise RemoteRecallError("MCP response is invalid")
+    result = rendered["result"]
+    if message["method"] == "ping":
+        return {"status": "ok", "transport": "mcp"}
+    structured = result.get("structuredContent")
+    if result.get("isError") is True or not isinstance(structured, dict):
+        raise RemoteRecallError("MCP tool result is invalid")
+    if path == "/v1/ingest/batches":
+        receipt = structured.get("receipt")
+        if not isinstance(receipt, str) or not receipt:
+            raise RemoteRecallError("MCP write result has no receipt")
+        return {
+            "status": structured.get("status"),
+            "inserted": 0 if structured.get("duplicate") else 1,
+            "duplicate_events": 1 if structured.get("duplicate") else 0,
+            "receipts": [receipt],
+        }
+    return structured
+
+
 def remote_request(method: str, path: str, body: dict | None = None,
                    idempotency_key: str | None = None) -> dict:
     config = load_client_config()
@@ -220,6 +337,8 @@ def remote_request(method: str, path: str, body: dict | None = None,
     ))
     if not base:
         raise RemoteRecallError("RECALL_URL is required for remote mode")
+    if urllib.parse.urlsplit(base).path == "/mcp":
+        return _mcp_call(base, method, path, body)
     data = None if body is None else json.dumps(body, sort_keys=True).encode()
     headers = remote_headers()
     if idempotency_key:
@@ -227,10 +346,7 @@ def remote_request(method: str, path: str, body: dict | None = None,
     request = urllib.request.Request(base + path, data=data, method=method, headers=headers)
     try:
         with _open_remote(request, timeout=float(os.environ.get("RECALL_TIMEOUT", "15"))) as response:
-            rendered = json.loads(response.read())
-            if not isinstance(rendered, dict):
-                raise RemoteRecallError("server returned a non-object response")
-            return rendered
+            return _read_remote_object(response)
     except urllib.error.HTTPError as exc:
         try:
             detail = json.loads(exc.read()).get("error", "HTTP error")
@@ -243,7 +359,14 @@ def remote_request(method: str, path: str, body: dict | None = None,
 
 def remote_execute(args) -> tuple[str, dict]:
     if args.command in REMOTE_WRITE_COMMANDS:
+        config = load_client_config()
+        configured_base = _validated_remote_base(os.environ.get("RECALL_URL") or (
+            config["url"] if config is not None else ""
+        ))
+        is_mcp = urllib.parse.urlsplit(configured_base).path == "/mcp"
         source_id = args.source_id or os.environ.get("RECALL_WRITE_SOURCE_ID", "")
+        if is_mcp and not source_id:
+            source_id = "mcp:host-bound"
         if not re.fullmatch(r"[A-Za-z0-9_.:@-]{3,160}", source_id):
             raise RemoteRecallError("--source-id or RECALL_WRITE_SOURCE_ID is required")
         principal_id = args.principal_id or os.environ.get("RECALL_PRINCIPAL_ID", "owner")
@@ -271,7 +394,7 @@ def remote_execute(args) -> tuple[str, dict]:
                     raise ValueError
             except (ValueError, TypeError) as exc:
                 raise RemoteRecallError("invalid receipt") from exc
-            if receipt_source != source_id:
+            if not is_mcp and receipt_source != source_id:
                 raise RemoteRecallError("receipt source does not match write source")
             kind = "tombstone"
             content = {"target_native_id": native_id, "deleted_receipt": event_part}

--- a/recall/tests/central_brain/test_brainstore_unit.py
+++ b/recall/tests/central_brain/test_brainstore_unit.py
@@ -810,6 +810,17 @@ class SemanticRetrievalContractTest(unittest.TestCase):
             result_limit=5,
         ))
 
+    def test_exact_question_precedes_identifier_routing_for_answer_promotion(self) -> None:
+        implementation = inspect.getsource(BrainStore.search)
+        self.assertLess(
+            implementation.index("exact_question_rows = run_leg("),
+            implementation.index("if identifiers:"),
+        )
+        self.assertEqual(
+            retrieval_leg_order(["ticket-123"]),
+            ("exact-question", "entity", "identifier"),
+        )
+
     def test_similarity_threshold_is_applied_after_bounded_hnsw_retrieval(self) -> None:
         runtime = mock.Mock(
             model="voyage-4",
@@ -1107,7 +1118,10 @@ class EnvelopeContractTest(unittest.TestCase):
         )
 
     def test_identifier_plan_runs_exact_legs_before_any_phrase(self) -> None:
-        self.assertEqual(retrieval_leg_order(["api-prod-6fcdc84dd4-mmjpj"]), ("entity", "identifier"))
+        self.assertEqual(
+            retrieval_leg_order(["api-prod-6fcdc84dd4-mmjpj"]),
+            ("exact-question", "entity", "identifier"),
+        )
         self.assertEqual(
             retrieval_leg_order([]),
             ("exact-question", "semantic", "phrase", "entity", "partial", "all"),

--- a/recall/tests/test_engine.py
+++ b/recall/tests/test_engine.py
@@ -818,6 +818,110 @@ class RedirectOnlyHandler(BaseHTTPRequestHandler):
         self.end_headers()
 
 
+class McpRemoteHandler(BaseHTTPRequestHandler):
+    requests: list[dict] = []
+    target_path = "/source/mcp-session.jsonl"
+    fail_tool = False
+
+    def log_message(self, *_args):
+        pass
+
+    def send_json(self, status: int, body: dict) -> None:
+        rendered = json.dumps(body).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(rendered)))
+        self.end_headers()
+        self.wfile.write(rendered)
+
+    def do_POST(self):
+        body = json.loads(self.rfile.read(int(self.headers.get("Content-Length", "0"))))
+        type(self).requests.append({
+            "method": "POST",
+            "path": self.path,
+            "body": body,
+            "authorization": self.headers.get("Authorization"),
+            "accept": self.headers.get("Accept"),
+            "protocol": self.headers.get("MCP-Protocol-Version"),
+            "idempotency_key": self.headers.get("Idempotency-Key"),
+        })
+        if self.path != "/mcp":
+            self.send_json(404, {"error": "not found"})
+            return
+        if type(self).fail_tool:
+            self.send_json(200, {
+                "jsonrpc": "2.0", "id": body.get("id"),
+                "error": {"code": -32603, "message": "synthetic tool failure"},
+            })
+            return
+        if body["method"] == "ping":
+            value = {}
+        else:
+            self.assert_tool_call(body)
+            name = body["params"]["name"]
+            arguments = body["params"]["arguments"]
+            if name == "recall_search":
+                value = {"results": [{
+                    "path": type(self).target_path,
+                    "occurred_at": "2026-01-01T00:00:00Z",
+                    "cwd": "/work/grep123/project",
+                    "slot": "grep123",
+                    "branch": "feature/mcp",
+                    "surface": "tool_output",
+                    "text": "remote MCP exact deadbeef evidence",
+                    "matched_terms": ["deadbeef"],
+                    "legs": ["exact"],
+                    "receipt": "recall://claude:linux/mcp-session:1?rev=1#item=0",
+                }], "diagnostics": {"deadline_ms": 300, "elapsed_ms": 11.0}}
+            elif name == "recall_show":
+                value = {"chunks": [{
+                    "occurred_at": "2026-01-01T00:00:00Z",
+                    "surface": "user",
+                    "text": "remote MCP prompt",
+                    "receipt": arguments["target"],
+                }]}
+            elif name == "recall_related":
+                value = {"results": [{
+                    "path": type(self).target_path,
+                    "overlap": 2,
+                    "cwd": arguments.get("cwd"),
+                    "branch": arguments.get("branch"),
+                    "receipt": "recall://claude:linux/mcp-session:1?rev=1#item=0",
+                }]}
+            elif name == "recall_capture":
+                value = {
+                    "status": "committed",
+                    "receipt": "recall://memory:mcp/capture-1?rev=1",
+                    "duplicate": False,
+                }
+            elif name == "recall_forget":
+                value = {
+                    "status": "forgotten",
+                    "receipt": arguments["receipt"].split("#", 1)[0],
+                }
+            else:
+                raise AssertionError(name)
+        self.send_json(200, {
+            "jsonrpc": "2.0", "id": body["id"],
+            "result": (
+                value if body["method"] == "ping" else {
+                    "content": [{"type": "text", "text": json.dumps(value)}],
+                    "structuredContent": value,
+                    "isError": False,
+                }
+            ),
+        })
+
+    @staticmethod
+    def assert_tool_call(body):
+        if (
+            body.get("jsonrpc") != "2.0"
+            or body.get("method") != "tools/call"
+            or set(body.get("params", {})) != {"name", "arguments"}
+        ):
+            raise AssertionError(body)
+
+
 class RemoteTransportTest(unittest.TestCase):
     def setUp(self):
         self.tmp = tempfile.TemporaryDirectory()
@@ -886,6 +990,134 @@ class RemoteTransportTest(unittest.TestCase):
             "source_alias": "cowork",
         })
         self.assertEqual(request["body"]["limit"], 7)
+
+    def test_explicit_mcp_url_uses_tools_call_for_read_surface(self):
+        mcp = ThreadingHTTPServer(("127.0.0.1", 0), McpRemoteHandler)
+        thread = threading.Thread(target=mcp.serve_forever, daemon=True)
+        thread.start()
+        McpRemoteHandler.requests = []
+        os.environ["RECALL_URL"] = f"http://127.0.0.1:{mcp.server_port}/mcp"
+        try:
+            code, output, error = self.call(
+                "search", "deadbeef", "--limit", "5",
+                "--source-family", "coding_history",
+            )
+            self.assertEqual((code, error), (0, ""))
+            self.assertIn(McpRemoteHandler.target_path, output)
+            request = McpRemoteHandler.requests[-1]
+            self.assertEqual(request["path"], "/mcp")
+            self.assertEqual(request["protocol"], "2025-11-25")
+            self.assertEqual(request["accept"], "application/json, text/event-stream")
+            self.assertIsNone(request["idempotency_key"])
+            self.assertEqual(request["body"]["method"], "tools/call")
+            self.assertEqual(request["body"]["params"], {
+                "name": "recall_search",
+                "arguments": {
+                    "query": "deadbeef",
+                    "filters": {"source_family": "coding_history"},
+                    "limit": 5,
+                },
+            })
+
+            target = "recall://claude:linux/mcp-session:1?rev=1#item=0"
+            self.assertIn("remote MCP prompt", self.call("show", target, "--prompts")[1])
+            self.assertIn(
+                "overlap=2",
+                self.call("related", "--cwd", "/work/grep123/project", "--branch", "feature/mcp")[1],
+            )
+            self.assertIn("OK remote", self.call("doctor")[1])
+            self.assertEqual(McpRemoteHandler.requests[-1]["body"]["method"], "ping")
+        finally:
+            mcp.shutdown()
+            mcp.server_close()
+
+    def test_explicit_mcp_url_maps_deliberate_write_and_fails_closed_for_export(self):
+        mcp = ThreadingHTTPServer(("127.0.0.1", 0), McpRemoteHandler)
+        thread = threading.Thread(target=mcp.serve_forever, daemon=True)
+        thread.start()
+        McpRemoteHandler.requests = []
+        os.environ["RECALL_URL"] = f"http://127.0.0.1:{mcp.server_port}/mcp"
+        os.environ["RECALL_WRITE_SOURCE_ID"] = "memory:mac:test"
+        self.addCleanup(os.environ.pop, "RECALL_WRITE_SOURCE_ID", None)
+        try:
+            code, output, error = self.call(
+                "put", "A deliberate MCP memory\nwith bounded body",
+                "--provenance-uri", "manual://unit-test",
+            )
+            self.assertEqual((code, error), (0, ""))
+            captured = json.loads(output)
+            self.assertEqual(captured["receipt"], "recall://memory:mcp/capture-1?rev=1")
+            request = McpRemoteHandler.requests[-1]
+            self.assertEqual(request["body"]["params"]["name"], "recall_capture")
+            self.assertEqual(request["body"]["params"]["arguments"]["title"], "A deliberate MCP memory")
+            self.assertEqual(
+                request["body"]["params"]["arguments"]["body"],
+                "A deliberate MCP memory\nwith bounded body",
+            )
+            self.assertNotIn("source_id", request["body"]["params"]["arguments"])
+
+            code, output, error = self.call(
+                "delete", captured["receipt"], "--source-id", "memory:mac:test",
+            )
+            self.assertEqual((code, error), (0, ""))
+            self.assertEqual(
+                McpRemoteHandler.requests[-1]["body"]["params"],
+                {"name": "recall_forget", "arguments": {"receipt": captured["receipt"]}},
+            )
+
+            before = len(McpRemoteHandler.requests)
+            code, output, error = self.call(
+                "session-export", "--target", McpRemoteHandler.target_path,
+            )
+            self.assertNotEqual(code, 0)
+            self.assertEqual(output, "")
+            self.assertIn("not available over MCP", error)
+            self.assertEqual(len(McpRemoteHandler.requests), before)
+        finally:
+            mcp.shutdown()
+            mcp.server_close()
+
+    def test_mcp_error_is_bounded_and_does_not_echo_request_or_token(self):
+        mcp = ThreadingHTTPServer(("127.0.0.1", 0), McpRemoteHandler)
+        thread = threading.Thread(target=mcp.serve_forever, daemon=True)
+        thread.start()
+        McpRemoteHandler.requests = []
+        McpRemoteHandler.fail_tool = True
+        token_file = self.root / "mcp-token.json"
+        token_file.write_text(json.dumps({"token": "mcp-synthetic-secret-token"}))
+        token_file.chmod(0o600)
+        os.environ["RECALL_TOKEN_FILE"] = str(token_file)
+        os.environ["RECALL_URL"] = f"http://127.0.0.1:{mcp.server_port}/mcp"
+        canary = "private-query-canary-must-not-echo"
+        try:
+            code, output, error = self.call("search", canary)
+            self.assertNotEqual(code, 0)
+            self.assertEqual(output, "")
+            self.assertIn("MCP -32603", error)
+            self.assertNotIn(canary, error)
+            self.assertNotIn("mcp-synthetic-secret-token", error)
+        finally:
+            McpRemoteHandler.fail_tool = False
+            mcp.shutdown()
+            mcp.server_close()
+
+    def test_private_client_config_accepts_explicit_mcp_endpoint(self):
+        token_file = self.root / "mcp-read-token.json"
+        token_file.write_text(json.dumps({"token": "configured-mcp-read-token"}))
+        token_file.chmod(0o600)
+        config = self.root / "mcp-client.json"
+        config.write_text(json.dumps({
+            "schema_version": 1,
+            "url": f"http://127.0.0.1:{self.server.server_port}/mcp",
+            "token_file": str(token_file),
+        }))
+        config.chmod(0o600)
+        os.environ.pop("RECALL_URL", None)
+        os.environ.pop("RECALL_TOKEN_FILE", None)
+        os.environ["RECALL_CONFIG_FILE"] = str(config)
+        loaded = engine.load_client_config()
+        self.assertEqual(loaded["url"], f"http://127.0.0.1:{self.server.server_port}/mcp")
+        self.assertEqual(loaded["token_file"], str(token_file))
 
     def test_remote_paths_show_related_and_doctor_keep_cli_surface(self):
         remote_trace = self.root / "remote-trace.jsonl"


### PR DESCRIPTION
## Summary
- add explicit `/mcp` remote transport to the Recall skill while preserving legacy REST URLs
- map scoped read, capture, forget, and health operations to stateless MCP calls
- run exact prior-question retrieval before identifier routing so its conversational answer can be promoted

## Verification
- 561 Python tests and 3 Node tests pass
- Recall CI lint profile and high-severity Bandit scan pass
- live managed MCP dogfood: doctor and five-result natural-language search pass

Private owner questions, transcripts, credentials, and evaluation evidence remain outside Git.