### PR TITLE
fix(recall): promote exact conversational answers

### DIFF
--- a/recall/server/recall_server/db.py
+++ b/recall/server/recall_server/db.py
@@ -1190,10 +1190,14 @@ class BrainStore:
             """
             WITH anchors AS (
               SELECT *
-              FROM unnest(%s::bigint[],%s::double precision[],%s::integer[])
-                   WITH ORDINALITY AS value(anchor_id,lexical_rank,anchor_tier,anchor_order)
+              FROM unnest(
+                %s::bigint[],%s::double precision[],%s::integer[],%s::boolean[]
+              ) WITH ORDINALITY AS value(
+                anchor_id,lexical_rank,anchor_tier,exact_question,anchor_order
+              )
             ), answers AS (
-              SELECT value.lexical_rank,value.anchor_tier,value.anchor_order,response.id
+              SELECT value.lexical_rank,value.anchor_tier,value.exact_question,
+                     value.anchor_order,response.id
               FROM anchors value
               JOIN items anchor ON anchor.id=value.anchor_id
               LEFT JOIN LATERAL (
@@ -1236,7 +1240,7 @@ class BrainStore:
                    coalesce(sp.freshness_half_life_days,180) AS freshness_half_life_days,
                    (sp.source_id IS NOT NULL) AS source_profiled,
                    answers.lexical_rank::real AS lexical_rank,
-                   answers.anchor_tier
+                   answers.anchor_tier,answers.exact_question
             FROM answers
             JOIN items i ON i.id=answers.id
             JOIN sessions s ON s.source_id=i.source_id AND s.native_id=i.session_native_id
@@ -1248,6 +1252,7 @@ class BrainStore:
                 [int(row["id"]) for row in bounded],
                 [float(row.get("lexical_rank", 0.0)) for row in bounded],
                 [int(row.get("tier", 1)) for row in bounded],
+                ["exact-question" in row.get("legs", ()) for row in bounded],
                 filters.get("since"), filters.get("since"),
                 filters.get("until"), filters.get("until"),
             ],
@@ -1255,9 +1260,16 @@ class BrainStore:
         ).fetchall()
         return [
             {
-                **{key: value for key, value in dict(row).items() if key != "anchor_tier"},
-                "leg": "answer",
-                "tier": max(2, int(row["anchor_tier"])),
+                **{
+                    key: value
+                    for key, value in dict(row).items()
+                    if key not in {"anchor_tier", "exact_question"}
+                },
+                "leg": "exact-answer" if row["exact_question"] else "answer",
+                "tier": max(
+                    4 if row["exact_question"] else 2,
+                    int(row["anchor_tier"]),
+                ),
             }
             for row in rows
         ]
@@ -1550,7 +1562,7 @@ class BrainStore:
                         authorized_source=authorized_source, deadline_at=deadline_at,
                         routed_source_ids=routed_source_ids,
                     )))
-                if not identifiers and candidates:
+                if candidates:
                     merge(run_leg("answer", lambda: self._answer_leg(
                         conn, list(candidates.values()), filters, deadline_at=deadline_at,
                     )))

--- a/recall/server/recall_server/db.py
+++ b/recall/server/recall_server/db.py
@@ -1340,14 +1340,15 @@ class BrainStore:
             for position, row in enumerate(rows, 1):
                 contribution = 1.0 / (60 + position)
                 leg = row.pop("leg")
+                observable_legs = {leg, "answer"} if leg == "exact-answer" else {leg}
                 existing = candidates.get(row["id"])
                 if existing is None:
-                    row["legs"] = {leg}
+                    row["legs"] = observable_legs
                     row["leg_contributions"] = {leg: contribution}
                     row["fusion_score"] = contribution
                     candidates[row["id"]] = row
                 else:
-                    existing["legs"].add(leg)
+                    existing["legs"].update(observable_legs)
                     existing["leg_contributions"][leg] = max(
                         contribution,
                         existing["leg_contributions"].get(leg, 0.0),

--- a/recall/server/recall_server/ranking.py
+++ b/recall/server/recall_server/ranking.py
@@ -25,7 +25,9 @@ def evidence_rank_components(*, legs: set[str], surface: str, lexical_rank: floa
                              corroborating_families: int = 1,
                              fusion_score: float = 0.0) -> dict:
     """Return an observable, content-free evidence vector and its ordering key."""
-    if "identifier" in legs or ("entity" in legs and has_identifier):
+    if "exact-answer" in legs:
+        evidence_class, class_priority = "exact-answer", 5
+    elif "identifier" in legs or ("entity" in legs and has_identifier):
         evidence_class, class_priority = "identifier", 4
     elif "answer" in legs:
         evidence_class, class_priority = "answer", 3
@@ -40,7 +42,7 @@ def evidence_rank_components(*, legs: set[str], surface: str, lexical_rank: floa
     else:
         evidence_class, class_priority = "broad", 0
     origin_priority = (
-        2 if evidence_class == "answer"
+        2 if evidence_class in {"answer", "exact-answer"}
         else 1 if evidence_class == "phrase" and surface == "tool_input"
         else 0
     )

--- a/recall/tests/central_brain/test_brainstore_unit.py
+++ b/recall/tests/central_brain/test_brainstore_unit.py
@@ -217,6 +217,8 @@ class SchemaMigrationContractTest(unittest.TestCase):
         self.assertIn("LEFT JOIN LATERAL", implementation)
         self.assertIn("boundary.role='user'", implementation)
         self.assertIn("candidate.role='assistant'", implementation)
+        self.assertIn("%s::boolean[]", implementation)
+        self.assertIn('"exact-answer"', implementation)
         self.assertNotIn("NOT EXISTS", implementation)
 
     def test_webhook_privacy_is_host_owned_credential_state(self) -> None:
@@ -820,6 +822,7 @@ class SemanticRetrievalContractTest(unittest.TestCase):
             retrieval_leg_order(["ticket-123"]),
             ("exact-question", "entity", "identifier"),
         )
+        self.assertNotIn("if not identifiers and candidates:", implementation)
 
     def test_similarity_threshold_is_applied_after_bounded_hnsw_retrieval(self) -> None:
         runtime = mock.Mock(
@@ -1145,6 +1148,11 @@ class EnvelopeContractTest(unittest.TestCase):
         self.assertEqual(phrase_query_spec(["504 gateway timeout"]), ("504 gateway timeout", "phraseto_tsquery"))
 
     def test_rank_components_keep_identifier_phrase_and_error_evidence_distinct(self) -> None:
+        exact_answer = evidence_rank_components(
+            legs={"exact-answer"}, surface="assistant", lexical_rank=1.0,
+            matched_count=4, informative_count=4, has_identifier=True,
+            recency_factor=0.5,
+        )
         identifier = evidence_rank_components(
             legs={"entity"}, surface="tool_output", lexical_rank=1.0,
             matched_count=1, informative_count=8, has_identifier=True,
@@ -1173,6 +1181,10 @@ class EnvelopeContractTest(unittest.TestCase):
         self.assertEqual(identifier["evidence_class"], "identifier")
         self.assertEqual(answer["evidence_class"], "answer")
         self.assertGreater(tuple(identifier["rank_key"]), tuple(answer["rank_key"]))
+        self.assertGreater(
+            tuple(exact_answer["rank_key"]),
+            tuple(identifier["rank_key"]),
+        )
         self.assertGreater(tuple(answer["rank_key"]), tuple(phrase_command["rank_key"]))
         self.assertGreater(tuple(phrase_command["rank_key"]), tuple(phrase_echo["rank_key"]))
         self.assertGreater(tuple(phrase_echo["rank_key"]), tuple(error_entity["rank_key"]))


### PR DESCRIPTION
## Summary
- promote the final assistant response when a search exactly matches its preceding user question
- preserve ordinary identifier-first ranking when no exact prior question exists
- run answer adjacency for identifier-bearing questions instead of suppressing it

## Verification
- real managed identifier-question slice: Recall@1 1.00 (20/20), previously 0.00
- 561 Python tests and 3 Node tests pass
- Recall CI lint profile and high-severity Bandit scan pass

Private owner questions, transcripts, credentials, and evaluation evidence remain outside Git.