### PR TITLE
fix(recall): bound search evidence snippets

### DIFF
--- a/recall/server/recall_server/db.py
+++ b/recall/server/recall_server/db.py
@@ -29,6 +29,8 @@ from .projectors import KIND_RE, SOURCE_ID_RE, advisory_lock_key, canonical_json
 from .ranking import DEFAULT_SEARCH_DEADLINE_MS, evidence_rank_components, should_run_partial
 from .semantic import SemanticRuntime
 
+MAX_SEARCH_RESULT_TEXT_CHARS = 4096
+
 
 class IdempotencyConflict(Exception):
     pass
@@ -36,6 +38,11 @@ class IdempotencyConflict(Exception):
 
 class SearchDeadlineExceeded(Exception):
     pass
+
+
+def bounded_search_text(value: str) -> tuple[str, bool]:
+    """Return an agent-sized search snippet; show resolves the full receipt."""
+    return value[:MAX_SEARCH_RESULT_TEXT_CHARS], len(value) > MAX_SEARCH_RESULT_TEXT_CHARS
 
 
 def semantic_candidate_limit(result_limit: int) -> int:
@@ -1631,13 +1638,15 @@ class BrainStore:
             metadata = row["metadata"] or {}
             path = row["path"] or metadata.get("original_path") or f"recall://{row['source_id']}/{row['session_native_id']}"
             cwd = metadata.get("cwd")
+            text, text_truncated = bounded_search_text(row["text_redacted"])
             results.append({
                 "source_id": row["source_id"], "native_id": row["event_native_id"],
                 "session_native_id": row["session_native_id"], "path": path,
                 "occurred_at": row["occurred_at"], "observed_at": row["observed_at"],
                 "cwd": cwd, "slot": metadata.get("slot") or (re.search(r"grep\d+", cwd or "").group(0) if re.search(r"grep\d+", cwd or "") else None),
                 "branch": metadata.get("branch"), "harness": metadata.get("harness"),
-                "surface": row["surface"], "text": row["text_redacted"],
+                "surface": row["surface"], "text": text,
+                "text_truncated": text_truncated,
                 "receipt": row["receipt"], "matched_terms": row["matched_terms"],
                 "legs": sorted(row["legs"]), "tier": row["evidence"]["class_priority"],
                 "evidence": row["evidence"],

--- a/recall/tests/central_brain/test_brainstore_unit.py
+++ b/recall/tests/central_brain/test_brainstore_unit.py
@@ -32,6 +32,7 @@ from recall_server.app import Handler, serve, serve_unix, validate_http_profile
 from recall_server.capture import build_capture_event
 from recall_server.db import (
     BrainStore,
+    bounded_search_text,
     enough_session_anchors,
     optional_rescue_deadline,
     related_candidate_limit,
@@ -753,6 +754,18 @@ class RelatedRetrievalContractTest(unittest.TestCase):
 
 
 class SemanticRetrievalContractTest(unittest.TestCase):
+    def test_search_results_bound_large_evidence_and_keep_show_receipt(self) -> None:
+        exact, exact_truncated = bounded_search_text("x" * 4096)
+        oversized, oversized_truncated = bounded_search_text("🙂" * 4097)
+
+        self.assertEqual(exact, "x" * 4096)
+        self.assertFalse(exact_truncated)
+        self.assertEqual(oversized, "🙂" * 4096)
+        self.assertTrue(oversized_truncated)
+        implementation = inspect.getsource(BrainStore.search)
+        self.assertIn("bounded_search_text", implementation)
+        self.assertIn('"text_truncated"', implementation)
+
     @mock.patch("recall_server.db.ConnectionPool")
     def test_brainstore_reuses_a_bounded_connection_pool(self, pool_type) -> None:
         pool = pool_type.return_value


### PR DESCRIPTION
## Summary
- bound each search result snippet to 4096 characters and expose `text_truncated`
- preserve the exact receipt so agents can resolve full context through `recall_show`
- prevent valid large evidence from exceeding the public MCP response cap

## Verification
- formerly failing managed case shrinks from 534121 to 52912 JSON bytes with 10 valid results
- 562 Python tests and 3 Node tests pass
- Recall CI lint profile and high-severity Bandit scan pass

Private owner questions, transcripts, credentials, and evaluation evidence remain outside Git.