### PR TITLE
feat(recall): context-aware conversational turn retrieval

### DIFF
--- a/recall/evals/private_holdout.py
+++ b/recall/evals/private_holdout.py
@@ -148,6 +148,7 @@ def validate_private_holdout(path: Path, *, minimum_cases: int = 50) -> dict[str
         if case["match_method"] not in {
             "exact-indexed-evidence",
             "exact-session-export-evidence",
+            "synthetic-paraphrase-from-indexed-evidence",
             "owner-reviewed",
             "owner-reviewed-no-answer",
         }:

--- a/recall/server/deploy/README.md
+++ b/recall/server/deploy/README.md
@@ -61,7 +61,7 @@ infrastructure. The example is synthetic; a live manifest belongs in a private m
 location and contains references, never credential values.
 
 The production database gate requires a standard PostgreSQL URL with
-`sslmode=verify-full` and an explicit trust root, schema migrations 1 through 20,
+`sslmode=verify-full` and an explicit trust root, schema migrations 1 through 21,
 pgvector 0.8.0 or newer, and a runtime role without superuser, database/role creation,
 replication, or RLS-bypass privilege:
 
@@ -289,6 +289,15 @@ head-and-tail projection so a giant tool result cannot stall a complete backfill
 verifies the exact model commit and float32 dtype against TEI `/info` before sending text. Search
 ignores stale fingerprints, dimensions, projector versions, and content hashes.
 
+Schema 021 adds a second, rebuildable semantic projection for conversational sources. It embeds a
+user request together with every assistant message before the next user turn, preserving the
+request at the head and the final response at the tail. Search still returns the final canonical
+assistant item and its normal `recall://` receipt; the combined turn is only a retrieval vector.
+Every contributing item is linked so a soft deletion excludes the vector immediately, and search
+also verifies that the cited response is still the current final response for the turn. This
+closes the common failure where a short answer is meaningless without its preceding question
+without creating uncited synthetic memory.
+
 Production backfill uses an identical second sidecar on `127.0.0.1:8090`. Keeping historical CPU
 inference separate prevents convergence work from rejecting live query embeddings. Neither port is
 served through Tailscale, and both runtimes enforce the same pinned single-input contract. The worker
@@ -312,6 +321,8 @@ items, or receipts:
 ```bash
 RECALL_DATABASE_URL=... RECALL_EMBEDDING_URL=http://127.0.0.1:8089 \
   python -m recall_server.cli backfill-embeddings --batch-size 128
+RECALL_DATABASE_URL=... RECALL_EMBEDDING_URL=http://127.0.0.1:8089 \
+  python -m recall_server.cli backfill-turn-embeddings --batch-size 128
 ```
 
 On a large existing brain, converge high-value sources first without changing global correctness:
@@ -319,6 +330,7 @@ On a large existing brain, converge high-value sources first without changing gl
 ```bash
 python -m recall_server.cli backfill-embeddings --source-id SOURCE_ID --batch-size 128
 python -m recall_server.cli backfill-embeddings --source-id SOURCE_ID --surface user --batch-size 128
+python -m recall_server.cli backfill-turn-embeddings --source-id SOURCE_ID --batch-size 128
 ```
 
 The optional source and surface selectors change scheduling only. Metrics and search compatibility remain global, and an

--- a/recall/server/deploy/recall-embedding-backfill.service
+++ b/recall/server/deploy/recall-embedding-backfill.service
@@ -9,6 +9,7 @@ TimeoutStartSec=infinity
 WorkingDirectory=%h/services/recall-brain/recall/server
 EnvironmentFile=%h/.config/recall-brain/service.env
 ExecStart=/usr/bin/env RECALL_EMBEDDING_URL=http://127.0.0.1:8090 RECALL_SEMANTIC_TIMEOUT_SECONDS=120 %h/.config/recall-brain/venv/bin/python -m recall_server.cli backfill-embeddings --batch-size 128 --max-batches 4
+ExecStart=/usr/bin/env RECALL_EMBEDDING_URL=http://127.0.0.1:8090 RECALL_SEMANTIC_TIMEOUT_SECONDS=120 %h/.config/recall-brain/venv/bin/python -m recall_server.cli backfill-turn-embeddings --batch-size 128 --max-batches 4
 UMask=0077
 NoNewPrivileges=true
 PrivateTmp=true

--- a/recall/server/recall_server/__init__.py
+++ b/recall/server/recall_server/__init__.py
@@ -1,4 +1,4 @@
 """Recall central BrainStore service."""
 
-SCHEMA_VERSION = 20
+SCHEMA_VERSION = 21
 PROJECTOR_VERSION = 3

--- a/recall/server/recall_server/capabilities.py
+++ b/recall/server/recall_server/capabilities.py
@@ -20,6 +20,9 @@ WITH expected_tables(name) AS (
         ('audit_events'), ('projection_watermarks'), ('collector_credentials'),
         ('entities'), ('projection_backfills'), ('source_profiles'),
         ('session_export_cursors'), ('source_aliases'), ('item_embeddings'),
+        ('embedding_projection_watermarks'), ('turn_embeddings'),
+        ('turn_embedding_items'), ('turn_embedding_projection_watermarks'),
+        ('turn_embedding_dirty_sessions'),
         ('brain_tenants'), ('brain_principals'), ('canonical_sources'),
         ('raw_artifacts'), ('canonical_events'), ('canonical_documents'),
         ('canonical_chunks'), ('canonical_ingest_jobs'), ('receipt_redirects'),
@@ -48,13 +51,13 @@ SELECT
     role.rolbypassrls AS bypass_rls,
     pg_catalog.has_database_privilege(current_database(), 'CONNECT') AS can_connect,
     pg_catalog.has_schema_privilege(current_user, 'public', 'USAGE') AS can_use_schema,
-    (SELECT count(*) = 29 AND COALESCE(bool_and(
+    (SELECT count(*) = 34 AND COALESCE(bool_and(
         pg_catalog.to_regclass(pg_catalog.format('public.%I', name)) IS NOT NULL
         AND pg_catalog.has_table_privilege(
             current_user, pg_catalog.to_regclass(pg_catalog.format('public.%I', name)), 'SELECT'
         )
     ), false) FROM expected_tables) AS can_read_runtime_tables,
-    (SELECT count(*) = 28 AND COALESCE(bool_and(
+    (SELECT count(*) = 33 AND COALESCE(bool_and(
         pg_catalog.to_regclass(pg_catalog.format('public.%I', name)) IS NOT NULL
         AND pg_catalog.has_table_privilege(
             current_user, pg_catalog.to_regclass(pg_catalog.format('public.%I', name)),

--- a/recall/server/recall_server/cli.py
+++ b/recall/server/recall_server/cli.py
@@ -74,6 +74,10 @@ def main() -> None:
     backfill_embeddings.add_argument("--max-batches", type=int)
     backfill_embeddings.add_argument("--source-id")
     backfill_embeddings.add_argument("--surface")
+    backfill_turn_embeddings = sub.add_parser("backfill-turn-embeddings")
+    backfill_turn_embeddings.add_argument("--batch-size", type=int, default=128)
+    backfill_turn_embeddings.add_argument("--max-batches", type=int)
+    backfill_turn_embeddings.add_argument("--source-id")
     sub.add_parser("export")
     conformance = sub.add_parser("mcp-conformance")
     conformance.add_argument("--config", type=Path, required=True)
@@ -265,6 +269,17 @@ def main() -> None:
                     args.max_batches,
                     args.source_id,
                     args.surface,
+                ),
+                sort_keys=True,
+            )
+        )
+    elif args.command == "backfill-turn-embeddings":
+        print(
+            json.dumps(
+                store.embed_pending_turns(
+                    args.batch_size,
+                    args.max_batches,
+                    args.source_id,
                 ),
                 sort_keys=True,
             )

--- a/recall/server/recall_server/db.py
+++ b/recall/server/recall_server/db.py
@@ -30,6 +30,10 @@ from .ranking import DEFAULT_SEARCH_DEADLINE_MS, evidence_rank_components, shoul
 from .semantic import SemanticRuntime
 
 MAX_SEARCH_RESULT_TEXT_CHARS = 4096
+TURN_USER_MARKER = "User request:\n"
+TURN_ASSISTANT_MARKER = "\nAssistant response:\n"
+TURN_CONTINUATION_MARKER = "\n\nAssistant continuation:\n"
+TURN_EMBEDDING_CONTRACT = "recall.turn-embedding.v1:question-complete-response"
 
 
 class IdempotencyConflict(Exception):
@@ -43,6 +47,25 @@ class SearchDeadlineExceeded(Exception):
 def bounded_search_text(value: str) -> tuple[str, bool]:
     """Return an agent-sized search snippet; show resolves the full receipt."""
     return value[:MAX_SEARCH_RESULT_TEXT_CHARS], len(value) > MAX_SEARCH_RESULT_TEXT_CHARS
+
+
+def turn_embedding_text(user_text: str, assistant_texts: Iterable[str]) -> str:
+    """Represent a conversational turn with the question and its complete response."""
+    responses = list(assistant_texts)
+    if not user_text.strip() or not responses or any(not value.strip() for value in responses):
+        raise ValueError("turn embedding requires non-empty user and assistant text")
+    return (
+        TURN_USER_MARKER
+        + user_text
+        + TURN_ASSISTANT_MARKER
+        + TURN_CONTINUATION_MARKER.join(responses)
+    )
+
+
+def turn_runtime_fingerprint(semantic_fingerprint: str) -> str:
+    return hashlib.sha256(
+        f"{TURN_EMBEDDING_CONTRACT}\0{semantic_fingerprint}".encode()
+    ).hexdigest()
 
 
 def semantic_candidate_limit(result_limit: int) -> int:
@@ -693,6 +716,306 @@ class BrainStore:
             "surface_scoped": surface is not None,
         }
 
+    def embed_pending_turns(
+        self,
+        batch_size: int = 128,
+        max_batches: int | None = None,
+        source_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Embed user request plus its complete assistant response as one retrieval unit."""
+        if self.semantic_runtime is None:
+            raise ValueError("semantic runtime is not configured")
+        if not 1 <= batch_size <= 1000 or (max_batches is not None and max_batches < 1):
+            raise ValueError("invalid turn embedding backfill bounds")
+        if source_id is not None and not SOURCE_ID_RE.fullmatch(source_id):
+            raise ValueError("invalid embedding source")
+        fingerprint = turn_runtime_fingerprint(self.semantic_runtime.fingerprint)
+        processed = batches = 0
+        with self.connect() as conn:
+            lock_name = "recall:turn-embeddings"
+            locked = conn.execute(
+                "SELECT pg_try_advisory_lock(hashtextextended(%s,0)) AS value",
+                (lock_name,),
+            ).fetchone()["value"]
+            if not locked:
+                return {"status": "busy", "processed": 0, "batches": 0}
+            try:
+                use_watermark = source_id is None
+                watermark = 0
+                if use_watermark:
+                    conn.execute(
+                        """INSERT INTO turn_embedding_projection_watermarks(
+                             runtime_fingerprint,model,dimensions,last_anchor_item_id
+                           ) VALUES (%s,%s,%s,0)
+                           ON CONFLICT(runtime_fingerprint) DO NOTHING""",
+                        (
+                            fingerprint,
+                            self.semantic_runtime.model,
+                            self.semantic_runtime.dimensions,
+                        ),
+                    )
+                    watermark = conn.execute(
+                        """SELECT last_anchor_item_id
+                           FROM turn_embedding_projection_watermarks
+                           WHERE runtime_fingerprint=%s
+                           FOR UPDATE""",
+                        (fingerprint,),
+                    ).fetchone()["last_anchor_item_id"]
+                while max_batches is None or batches < max_batches:
+                    dirty = conn.execute(
+                        """SELECT source_id,session_native_id,last_anchor_item_id
+                           FROM turn_embedding_dirty_sessions
+                           WHERE (%s::text IS NULL OR source_id=%s)
+                           ORDER BY updated_at,source_id,session_native_id
+                           LIMIT 1
+                           FOR UPDATE SKIP LOCKED""",
+                        (source_id, source_id),
+                    ).fetchone()
+                    scan_source_id = (
+                        dirty["source_id"] if dirty is not None else source_id
+                    )
+                    scan_session_native_id = (
+                        dirty["session_native_id"]
+                        if dirty is not None
+                        else None
+                    )
+                    scan_after = (
+                        dirty["last_anchor_item_id"]
+                        if dirty is not None
+                        else (watermark if use_watermark else None)
+                    )
+                    rows = conn.execute(
+                        """
+                        SELECT anchor.id AS anchor_item_id,anchor.source_id,
+                               anchor.session_native_id,anchor.text_redacted AS user_text,
+                               response.response_item_id,response.item_ids,
+                               response.assistant_texts
+                        FROM items anchor
+                        LEFT JOIN LATERAL (
+                          SELECT boundary.occurred_at,boundary.id
+                          FROM items boundary
+                          WHERE boundary.source_id=anchor.source_id
+                            AND boundary.session_native_id=anchor.session_native_id
+                            AND boundary.deleted_at IS NULL
+                            AND boundary.role='user'
+                            AND (boundary.occurred_at,boundary.id)>
+                                (anchor.occurred_at,anchor.id)
+                          ORDER BY boundary.occurred_at,boundary.id
+                          LIMIT 1
+                        ) next_user ON true
+                        JOIN LATERAL (
+                          SELECT
+                            (array_agg(candidate.id ORDER BY
+                               candidate.occurred_at DESC,candidate.id DESC))[1]
+                              AS response_item_id,
+                            array_agg(candidate.id ORDER BY
+                               candidate.occurred_at,candidate.id) AS item_ids,
+                            array_agg(candidate.text_redacted ORDER BY
+                               candidate.occurred_at,candidate.id) AS assistant_texts
+                          FROM items candidate
+                          WHERE candidate.source_id=anchor.source_id
+                            AND candidate.session_native_id=anchor.session_native_id
+                            AND candidate.deleted_at IS NULL
+                            AND candidate.role='assistant'
+                            AND btrim(candidate.text_redacted)<>''
+                            AND (candidate.occurred_at,candidate.id)>
+                                (anchor.occurred_at,anchor.id)
+                            AND (
+                              next_user.id IS NULL
+                              OR (candidate.occurred_at,candidate.id)<
+                                 (next_user.occurred_at,next_user.id)
+                            )
+                          HAVING count(*)>0
+                        ) response ON true
+                        LEFT JOIN turn_embeddings embedding
+                          ON embedding.anchor_item_id=anchor.id
+                        WHERE anchor.deleted_at IS NULL
+                          AND anchor.role='user'
+                          AND btrim(anchor.text_redacted)<>''
+                          AND (%s::text IS NULL OR anchor.source_id=%s)
+                          AND (
+                            %s::text IS NULL
+                            OR anchor.session_native_id=%s
+                          )
+                          AND (%s::bigint IS NULL OR anchor.id>%s)
+                          AND (
+                            %s::boolean
+                            OR (
+                              embedding.anchor_item_id IS NULL
+                              OR embedding.response_item_id<>
+                                 response.response_item_id
+                              OR embedding.model<>%s
+                              OR embedding.runtime_fingerprint<>%s
+                              OR embedding.dimensions<>%s
+                              OR cardinality(response.item_ids)+1<>(
+                                SELECT count(*)
+                                FROM turn_embedding_items linked
+                                WHERE linked.anchor_item_id=anchor.id
+                              )
+                              OR EXISTS (
+                                SELECT 1
+                                FROM turn_embedding_items linked
+                                JOIN items linked_item
+                                  ON linked_item.id=linked.item_id
+                                WHERE linked.anchor_item_id=anchor.id
+                                  AND linked_item.deleted_at IS NOT NULL
+                              )
+                            )
+                          )
+                        ORDER BY anchor.id
+                        LIMIT %s
+                        FOR UPDATE OF anchor SKIP LOCKED
+                        """,
+                        (
+                            scan_source_id,
+                            scan_source_id,
+                            scan_session_native_id,
+                            scan_session_native_id,
+                            scan_after,
+                            scan_after,
+                            dirty is not None,
+                            self.semantic_runtime.model,
+                            fingerprint,
+                            self.semantic_runtime.dimensions,
+                            batch_size,
+                        ),
+                    ).fetchall()
+                    if not rows:
+                        if dirty is not None:
+                            conn.execute(
+                                """DELETE FROM turn_embedding_dirty_sessions
+                                   WHERE source_id=%s
+                                     AND session_native_id=%s""",
+                                (
+                                    dirty["source_id"],
+                                    dirty["session_native_id"],
+                                ),
+                            )
+                            conn.commit()
+                            continue
+                        if use_watermark:
+                            watermark = conn.execute(
+                                """SELECT COALESCE(max(id),%s) AS value
+                                   FROM items
+                                   WHERE id>%s AND deleted_at IS NULL
+                                     AND role='user' AND btrim(text_redacted)<>''""",
+                                (watermark, watermark),
+                            ).fetchone()["value"]
+                            conn.execute(
+                                """UPDATE turn_embedding_projection_watermarks
+                                   SET last_anchor_item_id=GREATEST(
+                                         last_anchor_item_id,%s
+                                       ),
+                                       updated_at=now()
+                                   WHERE runtime_fingerprint=%s""",
+                                (watermark, fingerprint),
+                            )
+                        break
+                    documents = [
+                        turn_embedding_text(
+                            row["user_text"], row["assistant_texts"],
+                        )
+                        for row in rows
+                    ]
+                    vectors = self.semantic_runtime.embed_documents(documents)
+                    with conn.transaction():
+                        with conn.cursor() as cursor:
+                            cursor.executemany(
+                                """INSERT INTO turn_embeddings(
+                                     anchor_item_id,response_item_id,source_id,
+                                     session_native_id,model,dimensions,
+                                     content_sha256,runtime_fingerprint,embedding
+                                   ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s::halfvec)
+                                   ON CONFLICT(anchor_item_id) DO UPDATE SET
+                                     response_item_id=excluded.response_item_id,
+                                     source_id=excluded.source_id,
+                                     session_native_id=excluded.session_native_id,
+                                     model=excluded.model,
+                                     dimensions=excluded.dimensions,
+                                     content_sha256=excluded.content_sha256,
+                                     runtime_fingerprint=excluded.runtime_fingerprint,
+                                     embedding=excluded.embedding,
+                                     embedded_at=now()""",
+                                [
+                                    (
+                                        row["anchor_item_id"],
+                                        row["response_item_id"],
+                                        row["source_id"],
+                                        row["session_native_id"],
+                                        self.semantic_runtime.model,
+                                        self.semantic_runtime.dimensions,
+                                        hashlib.sha256(document.encode()).hexdigest(),
+                                        fingerprint,
+                                        json.dumps(vector, separators=(",", ":")),
+                                    )
+                                    for row, document, vector in zip(
+                                        rows, documents, vectors, strict=True
+                                    )
+                                ],
+                            )
+                            cursor.executemany(
+                                """DELETE FROM turn_embedding_items
+                                   WHERE anchor_item_id=%s""",
+                                [(row["anchor_item_id"],) for row in rows],
+                            )
+                            cursor.executemany(
+                                """INSERT INTO turn_embedding_items(
+                                     anchor_item_id,item_id
+                                   ) VALUES (%s,%s)""",
+                                [
+                                    (row["anchor_item_id"], item_id)
+                                    for row in rows
+                                    for item_id in (
+                                        row["anchor_item_id"],
+                                        *row["item_ids"],
+                                    )
+                                ],
+                            )
+                            if use_watermark:
+                                watermark = max(
+                                    row["anchor_item_id"] for row in rows
+                                )
+                                cursor.execute(
+                                    """UPDATE turn_embedding_projection_watermarks
+                                       SET last_anchor_item_id=GREATEST(
+                                             last_anchor_item_id,%s
+                                           ),
+                                           updated_at=now()
+                                       WHERE runtime_fingerprint=%s""",
+                                    (watermark, fingerprint),
+                                )
+                            if dirty is not None:
+                                cursor.execute(
+                                    """UPDATE turn_embedding_dirty_sessions
+                                       SET last_anchor_item_id=GREATEST(
+                                             last_anchor_item_id,%s
+                                           ),
+                                           updated_at=updated_at
+                                       WHERE source_id=%s
+                                         AND session_native_id=%s""",
+                                    (
+                                        max(
+                                            row["anchor_item_id"]
+                                            for row in rows
+                                        ),
+                                        dirty["source_id"],
+                                        dirty["session_native_id"],
+                                    ),
+                                )
+                    processed += len(rows)
+                    batches += 1
+            finally:
+                conn.execute(
+                    "SELECT pg_advisory_unlock(hashtextextended(%s,0))",
+                    (lock_name,),
+                )
+        return {
+            "status": "complete",
+            "processed": processed,
+            "batches": batches,
+            "source_scoped": source_id is not None,
+        }
+
     def record_dead_letter(self, error_code: str, summary: str) -> None:
         """Record rejection metadata only; never persist the rejected payload."""
         with self.connect() as conn:
@@ -1178,6 +1501,121 @@ class BrainStore:
             if float(row["lexical_rank"]) >= minimum_similarity
         ]
 
+    def _turn_semantic_leg(
+        self,
+        conn,
+        vector: list[float],
+        filters: dict,
+        *,
+        authorized_source: str | list[str] | tuple[str, ...] | None = None,
+        limit: int = 100,
+        routed_source_ids: list[str] | None = None,
+        deadline_at: float | None = None,
+        minimum_similarity: float = 0.35,
+    ) -> list[dict]:
+        """Retrieve a final answer using an embedding of its complete conversational turn."""
+        if self.semantic_runtime is None:
+            return []
+        where, params = self._read_filters(
+            filters, authorized_source, routed_source_ids,
+        )
+        encoded = json.dumps(vector, separators=(",", ":"))
+        fingerprint = turn_runtime_fingerprint(self.semantic_runtime.fingerprint)
+        conn.execute("SELECT set_config('hnsw.iterative_scan','strict_order',true)")
+        rows = self._execute_bounded(
+            conn,
+            f"""
+            WITH nearest AS MATERIALIZED (
+              SELECT embedding.anchor_item_id,embedding.response_item_id,
+                     embedding.embedding <=> %s::halfvec AS distance
+              FROM turn_embeddings embedding
+              JOIN items i ON i.id=embedding.response_item_id
+              JOIN sessions s
+                ON s.source_id=i.source_id
+               AND s.native_id=i.session_native_id
+              WHERE embedding.model=%s
+                AND embedding.runtime_fingerprint=%s
+                AND embedding.dimensions=%s
+                AND {where}
+              ORDER BY embedding.embedding <=> %s::halfvec,
+                       embedding.anchor_item_id DESC
+              LIMIT %s
+            )
+            SELECT i.id,i.source_id,i.session_native_id,i.event_native_id,
+                   i.occurred_at,i.surface,i.text_redacted,i.receipt,
+                   i.projector_version,s.started_at,s.ended_at,s.metadata,
+                   se.envelope #>> '{{provenance,original_path}}' AS path,
+                   se.observed_at,
+                   coalesce(sp.family,'unclassified') AS source_family,
+                   coalesce(sp.quality,'unrated') AS source_quality,
+                   coalesce(sp.freshness_half_life_days,180)
+                     AS freshness_half_life_days,
+                   (sp.source_id IS NOT NULL) AS source_profiled,
+                   (1-nearest.distance)::real AS lexical_rank
+            FROM nearest
+            JOIN items anchor ON anchor.id=nearest.anchor_item_id
+            JOIN items i ON i.id=nearest.response_item_id
+            JOIN sessions s
+              ON s.source_id=i.source_id
+             AND s.native_id=i.session_native_id
+            JOIN source_events se ON se.id=i.event_id
+            LEFT JOIN source_profiles sp ON sp.source_id=i.source_id
+            LEFT JOIN LATERAL (
+              SELECT boundary.occurred_at,boundary.id
+              FROM items boundary
+              WHERE boundary.source_id=anchor.source_id
+                AND boundary.session_native_id=anchor.session_native_id
+                AND boundary.deleted_at IS NULL
+                AND boundary.role='user'
+                AND (boundary.occurred_at,boundary.id)>
+                    (anchor.occurred_at,anchor.id)
+              ORDER BY boundary.occurred_at,boundary.id
+              LIMIT 1
+            ) next_user ON true
+            JOIN LATERAL (
+              SELECT candidate.id
+              FROM items candidate
+              WHERE candidate.source_id=anchor.source_id
+                AND candidate.session_native_id=anchor.session_native_id
+                AND candidate.deleted_at IS NULL
+                AND candidate.role='assistant'
+                AND (candidate.occurred_at,candidate.id)>
+                    (anchor.occurred_at,anchor.id)
+                AND (
+                  next_user.id IS NULL
+                  OR (candidate.occurred_at,candidate.id)<
+                     (next_user.occurred_at,next_user.id)
+                )
+              ORDER BY candidate.occurred_at DESC,candidate.id DESC
+              LIMIT 1
+            ) current_response ON current_response.id=nearest.response_item_id
+            WHERE anchor.deleted_at IS NULL
+              AND NOT EXISTS (
+                SELECT 1
+                FROM turn_embedding_items linked
+                JOIN items linked_item ON linked_item.id=linked.item_id
+                WHERE linked.anchor_item_id=nearest.anchor_item_id
+                  AND linked_item.deleted_at IS NOT NULL
+              )
+            ORDER BY nearest.distance,nearest.anchor_item_id DESC
+            """,
+            [
+                encoded,
+                self.semantic_runtime.model,
+                fingerprint,
+                self.semantic_runtime.dimensions,
+                *params,
+                encoded,
+                limit,
+            ],
+            deadline_at,
+        ).fetchall()
+        return [
+            {**dict(row), "leg": "turn-semantic", "tier": 2}
+            for row in rows
+            if float(row["lexical_rank"]) >= minimum_similarity
+        ]
+
     def _answer_leg(self, conn, anchors: list[dict], filters: dict, *,
                     deadline_at: float | None = None) -> list[dict]:
         """Promote the final assistant item in a matched user's conversational turn."""
@@ -1347,7 +1785,12 @@ class BrainStore:
             for position, row in enumerate(rows, 1):
                 contribution = 1.0 / (60 + position)
                 leg = row.pop("leg")
-                observable_legs = {leg, "answer"} if leg == "exact-answer" else {leg}
+                if leg == "exact-answer":
+                    observable_legs = {leg, "answer"}
+                elif leg == "turn-semantic":
+                    observable_legs = {leg, "semantic", "answer"}
+                else:
+                    observable_legs = {leg}
                 existing = candidates.get(row["id"])
                 if existing is None:
                     row["legs"] = observable_legs
@@ -1430,6 +1873,22 @@ class BrainStore:
                     # Those rescues run lazily only when dense evidence cannot
                     # fill the requested session anchors.
                     for vector_index, semantic_vector in enumerate(semantic_vectors):
+                        turn_rows = run_leg(
+                            f"turn-semantic-{vector_index}",
+                            lambda semantic_vector=semantic_vector:
+                                self._turn_semantic_leg(
+                                    conn,
+                                    semantic_vector,
+                                    filters,
+                                    authorized_source=authorized_source,
+                                    routed_source_ids=routed_source_ids,
+                                    deadline_at=deadline_at,
+                                    limit=semantic_candidate_limit(limit),
+                                    minimum_similarity=
+                                        self.semantic_minimum_similarity,
+                                ),
+                        )
+                        merge(turn_rows)
                         semantic_rows = run_leg(f"semantic-{vector_index}", lambda semantic_vector=semantic_vector: self._semantic_leg(
                             conn, semantic_vector, filters, authorized_source=authorized_source,
                             routed_source_ids=routed_source_ids, deadline_at=deadline_at,
@@ -1437,8 +1896,11 @@ class BrainStore:
                             minimum_similarity=self.semantic_minimum_similarity,
                         ))
                         if vector_index == 0:
-                            for semantic_row in semantic_rows:
-                                anchor = (semantic_row["source_id"], semantic_row["session_native_id"])
+                            for semantic_row in [*turn_rows, *semantic_rows]:
+                                anchor = (
+                                    semantic_row["source_id"],
+                                    semantic_row["session_native_id"],
+                                )
                                 if anchor not in dense_anchor_keys:
                                     dense_anchor_keys.append(anchor)
                                 if len(dense_anchor_keys) >= max(1, limit - 1):
@@ -2073,8 +2535,11 @@ class BrainStore:
                 before = conn.execute("SELECT count(*) AS n FROM items WHERE deleted_at IS NULL").fetchone()["n"]
                 entities_before = conn.execute("SELECT count(*) AS n FROM entities").fetchone()["n"]
                 conn.execute(
-                    "TRUNCATE item_embeddings,entities,chunks,items,sessions,"
-                    "projection_watermarks RESTART IDENTITY"
+                    "TRUNCATE turn_embedding_items,turn_embeddings,"
+                    "turn_embedding_projection_watermarks,"
+                    "turn_embedding_dirty_sessions,item_embeddings,"
+                    "embedding_projection_watermarks,entities,chunks,items,"
+                    "sessions,projection_watermarks RESTART IDENTITY"
                 )
                 rows = conn.execute("SELECT id,envelope,revision FROM source_events ORDER BY id").fetchall()
                 self._project_batch(

--- a/recall/server/schema/021_turn_semantic_retrieval.sql
+++ b/recall/server/schema/021_turn_semantic_retrieval.sql
@@ -1,0 +1,93 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS turn_embeddings (
+    anchor_item_id bigint PRIMARY KEY REFERENCES items(id) ON DELETE CASCADE,
+    response_item_id bigint NOT NULL REFERENCES items(id) ON DELETE CASCADE,
+    source_id text NOT NULL,
+    session_native_id text NOT NULL,
+    model text NOT NULL,
+    dimensions smallint NOT NULL CHECK (dimensions = 512),
+    content_sha256 char(64) NOT NULL,
+    runtime_fingerprint char(64) NOT NULL,
+    embedding halfvec(512) NOT NULL,
+    embedded_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS turn_embedding_items (
+    anchor_item_id bigint NOT NULL
+        REFERENCES turn_embeddings(anchor_item_id) ON DELETE CASCADE,
+    item_id bigint NOT NULL REFERENCES items(id) ON DELETE CASCADE,
+    PRIMARY KEY(anchor_item_id, item_id)
+);
+
+CREATE TABLE IF NOT EXISTS turn_embedding_projection_watermarks (
+    runtime_fingerprint char(64) PRIMARY KEY,
+    model text NOT NULL,
+    dimensions smallint NOT NULL CHECK (dimensions = 512),
+    last_anchor_item_id bigint NOT NULL DEFAULT 0
+        CHECK (last_anchor_item_id >= 0),
+    updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS turn_embedding_dirty_sessions (
+    source_id text NOT NULL,
+    session_native_id text NOT NULL,
+    last_anchor_item_id bigint NOT NULL DEFAULT 0
+        CHECK (last_anchor_item_id >= 0),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY(source_id, session_native_id)
+);
+
+CREATE OR REPLACE FUNCTION mark_turn_embedding_session_dirty()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+    dirty_source_id text;
+    dirty_session_native_id text;
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        dirty_source_id := OLD.source_id;
+        dirty_session_native_id := OLD.session_native_id;
+    ELSE
+        dirty_source_id := NEW.source_id;
+        dirty_session_native_id := NEW.session_native_id;
+    END IF;
+    INSERT INTO public.turn_embedding_dirty_sessions(
+        source_id,session_native_id,last_anchor_item_id,updated_at
+    ) VALUES (dirty_source_id,dirty_session_native_id,0,now())
+    ON CONFLICT(source_id,session_native_id) DO UPDATE SET
+        last_anchor_item_id=0,
+        updated_at=excluded.updated_at;
+    IF TG_OP = 'DELETE' THEN
+        RETURN OLD;
+    END IF;
+    RETURN NEW;
+END
+$$;
+
+DROP TRIGGER IF EXISTS items_mark_turn_embedding_session_dirty ON items;
+CREATE TRIGGER items_mark_turn_embedding_session_dirty
+AFTER INSERT OR DELETE OR UPDATE OF deleted_at ON items
+FOR EACH ROW EXECUTE FUNCTION mark_turn_embedding_session_dirty();
+
+CREATE INDEX IF NOT EXISTS turn_embeddings_source_anchor_idx
+    ON turn_embeddings(source_id, anchor_item_id);
+
+CREATE INDEX IF NOT EXISTS turn_embeddings_runtime_anchor_idx
+    ON turn_embeddings(runtime_fingerprint, anchor_item_id);
+
+CREATE INDEX IF NOT EXISTS turn_embeddings_hnsw_idx
+    ON turn_embeddings USING hnsw (embedding halfvec_cosine_ops)
+    WITH (m = 16, ef_construction = 64);
+
+CREATE INDEX IF NOT EXISTS turn_embedding_items_item_idx
+    ON turn_embedding_items(item_id, anchor_item_id);
+
+CREATE INDEX IF NOT EXISTS turn_embedding_dirty_sessions_updated_idx
+    ON turn_embedding_dirty_sessions(updated_at, source_id, session_native_id);
+
+INSERT INTO schema_migrations(version) VALUES (21) ON CONFLICT DO NOTHING;
+
+COMMIT;

--- a/recall/server/tests/e2e_semantic_l2.py
+++ b/recall/server/tests/e2e_semantic_l2.py
@@ -38,7 +38,15 @@ class FakeSemanticRuntime:
     def vector(text: str) -> list[float]:
         value = text.casefold()
         vector = [0.0] * 512
-        if "orchard premise" in value:
+        if (
+            "paired semantic clue" in value
+            or (
+                "context anchor alpha" in value
+                and "final evidence beta" in value
+            )
+        ):
+            vector[3] = 1.0
+        elif "orchard premise" in value:
             vector[2] = 1.0
         else:
             vector[0 if ("trip and cooldown" in value or "circuit breaker" in value) else 1] = 1.0
@@ -247,6 +255,81 @@ def main() -> None:
         authorized_source="source-h",
     )
     assert bounded_answer["results"][0]["native_id"] == "progress", bounded_answer
+    store.ingest("turn-semantic-j", [
+        envelope(
+            "source-j", "turn-question", "Context anchor alpha.", "session-turn",
+            occurred_at="2026-07-16T01:00:00Z",
+        ),
+        envelope(
+            "source-j", "turn-answer", "Final evidence beta.", "session-turn",
+            role="assistant", occurred_at="2026-07-16T01:01:00Z",
+        ),
+        envelope(
+            "source-j", "turn-boundary", "What came after that?", "session-turn",
+            occurred_at="2026-07-16T01:02:00Z",
+        ),
+    ])
+    assert store.embed_pending(batch_size=10, source_id="source-j")["processed"] == 3
+    turn_backfill = store.embed_pending_turns(batch_size=10, source_id="source-j")
+    turn_replay = store.embed_pending_turns(batch_size=10, source_id="source-j")
+    assert turn_backfill["processed"] == 1
+    assert turn_replay["processed"] == 0
+    paired = store.search(
+        "recover the paired semantic clue", {}, 5,
+        authorized_source="source-j",
+    )
+    assert paired["results"][0]["native_id"] == "turn-answer", paired
+    assert {"turn-semantic", "semantic", "answer"} <= set(
+        paired["results"][0]["legs"]
+    )
+    scoped_elsewhere = store.search(
+        "recover the paired semantic clue", {}, 5,
+        authorized_source="source-a",
+    )
+    assert all(
+        row["source_id"] == "source-a" for row in scoped_elsewhere["results"]
+    )
+    assert all(
+        row["native_id"] != "turn-answer"
+        for row in scoped_elsewhere["results"]
+    )
+    with store.connect() as connection:
+        connection.execute(
+            """UPDATE items SET deleted_at=now()
+               WHERE source_id='source-j' AND event_native_id='turn-answer'"""
+        )
+    deleted_turn = store.search(
+        "recover the paired semantic clue", {}, 5,
+        authorized_source="source-j",
+    )
+    assert all(
+        row["native_id"] != "turn-answer" for row in deleted_turn["results"]
+    )
+    store.ingest("turn-late-user-k", [
+        envelope(
+            "source-k", "late-question", "Context anchor alpha.", "session-late",
+            occurred_at="2026-07-16T02:00:00Z",
+        ),
+    ])
+    empty_turn = store.embed_pending_turns(batch_size=10, source_id="source-k")
+    assert empty_turn["processed"] == 0
+    store.ingest("turn-late-answer-k", [
+        envelope(
+            "source-k", "late-answer", "Final evidence beta.", "session-late",
+            role="assistant", occurred_at="2026-07-16T02:01:00Z",
+        ),
+    ])
+    late_turn = store.embed_pending_turns(batch_size=10, source_id="source-k")
+    assert late_turn["processed"] == 1
+    late_result = store.search(
+        "recover the paired semantic clue", {}, 5,
+        authorized_source="source-k",
+    )
+    assert late_result["results"][0]["native_id"] == "late-answer"
+    global_turn_backfill = store.embed_pending_turns(batch_size=100)
+    global_turn_replay = store.embed_pending_turns(batch_size=100)
+    assert global_turn_backfill["processed"] >= 1
+    assert global_turn_replay["processed"] == 0
     exact_question = "What exact orchard premise decision did we make?"
     store.ingest("exact-question-i", [
         envelope(
@@ -386,6 +469,13 @@ def main() -> None:
     print(json.dumps({
         "status": "pass", "semantic_hit": 1, "answer_adjacency_hit": 1,
         "answer_turn_index_used": 1,
+        "turn_semantic_hit": 1,
+        "turn_embedding_backfill": turn_backfill["processed"],
+        "turn_embedding_replay": turn_replay["processed"],
+        "global_turn_embedding_backfill": global_turn_backfill["processed"],
+        "global_turn_embedding_replay": global_turn_replay["processed"],
+        "turn_deleted_hits": 0,
+        "late_assistant_turn_backfill": late_turn["processed"],
         "unauthorized_hits": 0,
         "first_backfill": first["processed"] + remaining["processed"],
         "idempotent_replay": second["processed"], "source_scoped_replay": 0,

--- a/recall/tests/central_brain/test_brainstore_unit.py
+++ b/recall/tests/central_brain/test_brainstore_unit.py
@@ -38,6 +38,7 @@ from recall_server.db import (
     related_candidate_limit,
     semantic_candidate_limit,
     should_run_optional_rescue,
+    turn_embedding_text,
 )
 from recall_server.federation import SOURCE_FAMILIES, SourceProfile
 from recall_server.projectors import advisory_lock_key, canonical_json, effective_session_id, partial_lexical_probes, phrase_query_spec, preferred_phrase_probe, preferred_phrase_probes, project, redact_text, validate_envelope
@@ -754,6 +755,26 @@ class RelatedRetrievalContractTest(unittest.TestCase):
 
 
 class SemanticRetrievalContractTest(unittest.TestCase):
+    def test_turn_projection_preserves_question_head_and_final_answer_tail(self) -> None:
+        rendered = turn_embedding_text(
+            "Why did we choose the managed database?",
+            ["First progress update.", "The final decision and reason."],
+        )
+
+        self.assertTrue(rendered.startswith(
+            "User request:\nWhy did we choose the managed database?"
+        ))
+        self.assertTrue(rendered.endswith("The final decision and reason."))
+        self.assertIn("\n\nAssistant continuation:\n", rendered)
+
+    def test_turn_candidate_limit_is_applied_after_authorization_filters(self) -> None:
+        implementation = inspect.getsource(BrainStore._turn_semantic_leg)
+        nearest = implementation.split("WITH nearest AS MATERIALIZED", 1)[1]
+        nearest = nearest.split("LIMIT %s", 1)[0]
+
+        self.assertIn("JOIN items i ON i.id=embedding.response_item_id", nearest)
+        self.assertIn("AND {where}", nearest)
+
     def test_search_results_bound_large_evidence_and_keep_show_receipt(self) -> None:
         exact, exact_truncated = bounded_search_text("x" * 4096)
         oversized, oversized_truncated = bounded_search_text("🙂" * 4097)

--- a/recall/tests/test_private_holdout.py
+++ b/recall/tests/test_private_holdout.py
@@ -55,6 +55,29 @@ class PrivateOwnerHoldoutTest(unittest.TestCase):
             self.assertNotIn("query", json.dumps(receipt))
             self.assertNotIn("task-001", json.dumps(receipt))
 
+    def test_validates_synthetic_paraphrases_without_owner_review_claim(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            directory = private_dir(root, "private")
+            holdout = directory / "holdout.jsonl"
+            rows = [{
+                "id": f"semantic-{index:03d}",
+                "stratum": "owner-semantic",
+                "query": f"What decision did the indexed evidence describe for topic {index:03d}?",
+                "answers": [f"recall://synthetic:source/task-{index:03d}"],
+                "match_method": "synthetic-paraphrase-from-indexed-evidence",
+            } for index in range(50)]
+            private_write(
+                holdout,
+                "".join(json.dumps(row, sort_keys=True) + "\n" for row in rows),
+            )
+
+            receipt = validate_private_holdout(holdout)
+
+            self.assertEqual(receipt["case_count"], 50)
+            self.assertEqual(receipt["positive_cases"], 50)
+            self.assertEqual(receipt["strata_count"], 1)
+
     def test_rejects_private_boundary_schema_and_qrel_failures(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)


### PR DESCRIPTION
## Summary
- add deletion-aware conversational-turn embeddings while preserving canonical item receipts
- continuously repair late assistant turns and keep source authorization in the SQL retrieval leg
- distinguish synthetic semantic paraphrase evals from owner-reviewed holdouts

## Verification
- 563 Python + 3 Node tests
- 28/28 fresh PostgreSQL E2Es
- private 50-case canary: turn representation Recall@5 1.00 vs item-only 0.06 against 950 distractors
- Ruff fatal checks, high-severity Bandit, dependency audit, staged gitleaks

Private queries, transcripts, credentials, and Cascade evidence are intentionally excluded.