### PR TITLE
perf(recall): adapt managed embedding batches safely

### DIFF
--- a/recall/server/recall_server/semantic.py
+++ b/recall/server/recall_server/semantic.py
@@ -130,8 +130,14 @@ class SemanticRuntime:
             and not (embedding_key_file or embedding_key_env)
         ):
             raise ValueError("remote managed embedding endpoint requires a key source")
-        if not 1 <= embedding_batch_size <= 128:
-            raise ValueError("embedding batch size must be between 1 and 128")
+        maximum_embedding_batch_size = (
+            128 if embedding_protocol == "tei" else 512
+        )
+        if not 1 <= embedding_batch_size <= maximum_embedding_batch_size:
+            raise ValueError(
+                "embedding batch size must be between 1 and "
+                f"{maximum_embedding_batch_size}"
+            )
         if not 1 <= planner_samples <= 3:
             raise ValueError("planner samples must be between 1 and 3")
         planner_values = (

--- a/recall/server/recall_server/semantic.py
+++ b/recall/server/recall_server/semantic.py
@@ -8,6 +8,7 @@ import re
 import stat
 import threading
 import time
+import urllib.error
 import urllib.request
 from collections import OrderedDict
 from concurrent.futures import ThreadPoolExecutor
@@ -443,31 +444,62 @@ class SemanticRuntime:
                 headers = {}
                 if self.embedding_key_file or self.embedding_key_env:
                     headers["Authorization"] = "Bearer " + self._read_embedding_key()
-                payload: dict[str, object] = {
-                    "model": self.model,
-                    "input": batch,
-                }
-                if self.embedding_protocol == "voyage":
-                    payload.update(
-                        {
-                            "input_type": input_type,
-                            "output_dimension": self.dimensions,
-                            "output_dtype": "float",
-                            "truncation": True,
-                        }
+                result.extend(
+                    self._embed_managed_batch(
+                        batch,
+                        input_type=input_type,
+                        headers=headers,
                     )
-                else:
-                    payload.update(
-                        {
-                            "encoding_format": "float",
-                            "dimensions": self.dimensions,
-                        }
-                    )
-                response = self._post(
-                    self._managed_embedding_endpoint, payload, headers
                 )
-                result.extend(self._openai_vectors(response, len(batch)))
             return result
+
+    def _embed_managed_batch(
+        self,
+        batch: list[str],
+        *,
+        input_type: str,
+        headers: dict[str, str],
+    ) -> list[list[float]]:
+        payload: dict[str, object] = {
+            "model": self.model,
+            "input": batch,
+        }
+        if self.embedding_protocol == "voyage":
+            payload.update(
+                {
+                    "input_type": input_type,
+                    "output_dimension": self.dimensions,
+                    "output_dtype": "float",
+                    "truncation": True,
+                }
+            )
+        else:
+            payload.update(
+                {
+                    "encoding_format": "float",
+                    "dimensions": self.dimensions,
+                }
+            )
+        try:
+            response = self._post(
+                self._managed_embedding_endpoint, payload, headers
+            )
+        except urllib.error.HTTPError as error:
+            splittable = error.code == 413 or 500 <= error.code <= 504
+            if not splittable or len(batch) == 1:
+                raise
+            error.close()
+            midpoint = len(batch) // 2
+            return self._embed_managed_batch(
+                batch[:midpoint],
+                input_type=input_type,
+                headers=headers,
+            ) + self._embed_managed_batch(
+                batch[midpoint:],
+                input_type=input_type,
+                headers=headers,
+            )
+        return self._openai_vectors(response, len(batch))
 
     def embed_documents(self, texts: list[str]) -> list[list[float]]:
         return self._embed(texts, input_type="document")

--- a/recall/tests/central_brain/test_semantic_runtime.py
+++ b/recall/tests/central_brain/test_semantic_runtime.py
@@ -197,6 +197,30 @@ class SemanticRuntimeContractTest(unittest.TestCase):
         self.assertEqual(runtime.embedding_batch_size, 64)
         self.assertEqual(runtime.query_prefix, "")
 
+    def test_managed_embedding_batch_supports_bounded_bulk_backfill(self) -> None:
+        runtime = SemanticRuntime(
+            embedding_protocol="voyage",
+            embedding_url="https://api.voyage.example",
+            embedding_approved_url="https://api.voyage.example",
+            embedding_key_env="VOYAGE_API_KEY",
+            model="voyage-synthetic",
+            revision="voyage-synthetic-v1",
+            dimensions=512,
+            embedding_batch_size=512,
+        )
+        self.assertEqual(runtime.embedding_batch_size, 512)
+        with self.assertRaisesRegex(ValueError, "between 1 and 512"):
+            SemanticRuntime(
+                embedding_protocol="voyage",
+                embedding_url="https://api.voyage.example",
+                embedding_approved_url="https://api.voyage.example",
+                embedding_key_env="VOYAGE_API_KEY",
+                model="voyage-synthetic",
+                revision="voyage-synthetic-v1",
+                dimensions=512,
+                embedding_batch_size=513,
+            )
+
     def test_managed_key_may_come_from_a_named_secret_environment_variable(
         self,
     ) -> None:

--- a/recall/tests/central_brain/test_semantic_runtime.py
+++ b/recall/tests/central_brain/test_semantic_runtime.py
@@ -6,6 +6,7 @@ import tempfile
 import threading
 import time
 import unittest
+import urllib.error
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from unittest import mock
@@ -220,6 +221,46 @@ class SemanticRuntimeContractTest(unittest.TestCase):
                 dimensions=512,
                 embedding_batch_size=513,
             )
+
+    def test_managed_embedding_batch_splits_bounded_upstream_failures(self) -> None:
+        runtime = SemanticRuntime(
+            embedding_protocol="voyage",
+            embedding_url="https://api.voyage.example",
+            embedding_approved_url="https://api.voyage.example",
+            embedding_key_env="VOYAGE_API_KEY",
+            model="voyage-synthetic",
+            revision="voyage-synthetic-v1",
+            dimensions=512,
+            embedding_batch_size=512,
+        )
+        batch_sizes: list[int] = []
+
+        def limited_upstream(url, payload, headers):
+            batch_sizes.append(len(payload["input"]))
+            if len(payload["input"]) > 128:
+                raise urllib.error.HTTPError(url, 500, "synthetic", {}, None)
+            return {
+                "data": [
+                    {"index": index, "embedding": [float(index)] * 512}
+                    for index in range(len(payload["input"]))
+                ]
+            }
+
+        with (
+            mock.patch.dict(
+                os.environ,
+                {"VOYAGE_API_KEY": "short-lived-synthetic-embedding-key"},
+                clear=True,
+            ),
+            mock.patch.object(runtime, "_post", side_effect=limited_upstream),
+        ):
+            vectors = runtime.embed_documents(
+                [f"synthetic-document-{index}" for index in range(300)]
+            )
+        self.assertEqual(len(vectors), 300)
+        self.assertEqual(batch_sizes, [300, 150, 75, 75, 150, 75, 75])
+        self.assertEqual(vectors[0][0], 0.0)
+        self.assertEqual(vectors[75][0], 0.0)
 
     def test_managed_key_may_come_from_a_named_secret_environment_variable(
         self,


### PR DESCRIPTION
Allows managed embedding protocols to attempt up to 512 documents per request while the local TEI sidecar remains capped at 128. Bounded 413 and 500–504 failures split recursively, preserve ordering, and still fail closed at a single document. This reduces large-corpus backfill round trips without letting failed writes advance projection cursors.\n\nTDD/live validation:\n- 512 accepted; 513 rejected\n- synthetic upstream rejects batches >128: 300 documents recover as deterministic 300→150→75 splits\n- staging LiteLLM/Voyage synthetic 512 batch: HTTP 200, 512 vectors, 3.29 MB in 2.04s\n- live private backfill exposed a long-document 500; transaction preserved the cursor and adaptive worker resumed\n- semantic runtime: 21/21 pass\n- full npm test + ruff: pass\n- gitleaks staged scan: pass