### PR TITLE
feat(recall): parallelize dirty turn projection safely

### DIFF
--- a/recall/server/recall_server/db.py
+++ b/recall/server/recall_server/db.py
@@ -721,6 +721,7 @@ class BrainStore:
         batch_size: int = 128,
         max_batches: int | None = None,
         source_id: str | None = None,
+        dirty_only: bool = False,
     ) -> dict[str, Any]:
         """Embed user request plus its complete assistant response as one retrieval unit."""
         if self.semantic_runtime is None:
@@ -729,18 +730,25 @@ class BrainStore:
             raise ValueError("invalid turn embedding backfill bounds")
         if source_id is not None and not SOURCE_ID_RE.fullmatch(source_id):
             raise ValueError("invalid embedding source")
+        if not isinstance(dirty_only, bool):
+            raise ValueError("invalid dirty-only mode")
         fingerprint = turn_runtime_fingerprint(self.semantic_runtime.fingerprint)
         processed = batches = 0
         with self.connect() as conn:
             lock_name = "recall:turn-embeddings"
+            lock_function = (
+                "pg_try_advisory_lock_shared"
+                if dirty_only
+                else "pg_try_advisory_lock"
+            )
             locked = conn.execute(
-                "SELECT pg_try_advisory_lock(hashtextextended(%s,0)) AS value",
+                f"SELECT {lock_function}(hashtextextended(%s,0)) AS value",
                 (lock_name,),
             ).fetchone()["value"]
             if not locked:
                 return {"status": "busy", "processed": 0, "batches": 0}
             try:
-                use_watermark = source_id is None
+                use_watermark = source_id is None and not dirty_only
                 watermark = 0
                 if use_watermark:
                     conn.execute(
@@ -771,6 +779,8 @@ class BrainStore:
                            FOR UPDATE SKIP LOCKED""",
                         (source_id, source_id),
                     ).fetchone()
+                    if dirty is None and dirty_only:
+                        break
                     scan_source_id = (
                         dirty["source_id"] if dirty is not None else source_id
                     )
@@ -1005,8 +1015,13 @@ class BrainStore:
                     processed += len(rows)
                     batches += 1
             finally:
+                unlock_function = (
+                    "pg_advisory_unlock_shared"
+                    if dirty_only
+                    else "pg_advisory_unlock"
+                )
                 conn.execute(
-                    "SELECT pg_advisory_unlock(hashtextextended(%s,0))",
+                    f"SELECT {unlock_function}(hashtextextended(%s,0))",
                     (lock_name,),
                 )
         return {

--- a/recall/server/tests/e2e_semantic_l2.py
+++ b/recall/server/tests/e2e_semantic_l2.py
@@ -326,6 +326,8 @@ def main() -> None:
         authorized_source="source-k",
     )
     assert late_result["results"][0]["native_id"] == "late-answer"
+    with store.connect() as connection:
+        connection.execute("DELETE FROM turn_embedding_dirty_sessions")
     store.ingest("turn-watermark-low", [
         envelope(
             "source-l", "watermark-low-question", "Low turn question.",
@@ -354,8 +356,22 @@ def main() -> None:
             occurred_at="2026-07-16T04:01:00Z",
         ),
     ])
-    dirty_first = store.embed_pending_turns(batch_size=100, max_batches=1)
+    dirty_first = store.embed_pending_turns(
+        batch_size=100, max_batches=1, dirty_only=True,
+    )
     assert dirty_first["processed"] == 1
+    dirty_replay = store.embed_pending_turns(
+        batch_size=100, dirty_only=True,
+    )
+    assert dirty_replay["processed"] == 0
+    with store.connect() as connection:
+        projected_before_global_scan = connection.execute(
+            """SELECT count(*) AS value
+               FROM turn_embeddings embedding
+               JOIN items item ON item.id=embedding.anchor_item_id
+               WHERE item.source_id IN ('source-l','source-m')"""
+        ).fetchone()["value"]
+    assert projected_before_global_scan == 1
     global_turn_backfill = store.embed_pending_turns(batch_size=100)
     global_turn_replay = store.embed_pending_turns(batch_size=100)
     assert global_turn_backfill["processed"] >= 1
@@ -368,6 +384,48 @@ def main() -> None:
                WHERE item.source_id IN ('source-l','source-m')"""
         ).fetchone()["value"]
     assert projected_watermark_turns == 2
+    store.ingest("parallel-dirty-turns", [
+        envelope(
+            "source-n", "parallel-dirty-n-question", "Parallel dirty N question.",
+            "session-parallel-dirty-n", occurred_at="2026-07-16T05:00:00Z",
+        ),
+        envelope(
+            "source-n", "parallel-dirty-n-answer", "Parallel dirty N answer.",
+            "session-parallel-dirty-n", role="assistant",
+            occurred_at="2026-07-16T05:01:00Z",
+        ),
+        envelope(
+            "source-o", "parallel-dirty-o-question", "Parallel dirty O question.",
+            "session-parallel-dirty-o", occurred_at="2026-07-16T06:00:00Z",
+        ),
+        envelope(
+            "source-o", "parallel-dirty-o-answer", "Parallel dirty O answer.",
+            "session-parallel-dirty-o", role="assistant",
+            occurred_at="2026-07-16T06:01:00Z",
+        ),
+    ])
+    dirty_barrier = threading.Barrier(2)
+    dirty_parallel_stores = [
+        BrainStore(
+            os.environ["RECALL_DATABASE_URL"],
+            semantic_runtime=CoordinatedSemanticRuntime(dirty_barrier),
+        )
+        for _ in range(2)
+    ]
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+        dirty_parallel_results = [
+            future.result()
+            for future in [
+                executor.submit(
+                    dirty_parallel_stores[index].embed_pending_turns,
+                    batch_size=100,
+                    max_batches=1,
+                    dirty_only=True,
+                )
+                for index in range(2)
+            ]
+        ]
+    assert [result["processed"] for result in dirty_parallel_results] == [1, 1]
     exact_question = "What exact orchard premise decision did we make?"
     store.ingest("exact-question-i", [
         envelope(
@@ -521,6 +579,9 @@ def main() -> None:
         "sensitive_queries_sent_to_planner": 0,
         "parallel_source_backfills": sum(
             result["processed"] for result in parallel_results
+        ),
+        "parallel_dirty_turn_backfills": sum(
+            result["processed"] for result in dirty_parallel_results
         ),
         "parallel_same_source_backfills": sum(
             result["processed"] for result in same_source_results


### PR DESCRIPTION
Adds an explicit dirty-only turn projection mode for large managed bootstrap and repair. Dirty-only workers use shared advisory coordination plus per-session FOR UPDATE SKIP LOCKED claims, so independent workers can drain sessions concurrently while ordinary global scans retain an exclusive lock. Dirty-only mode never reads or advances the global watermark.\n\nTDD/E2E validation:\n- dirty-only processing cannot fall through into global scan\n- dirty late sessions do not advance global watermark\n- two coordinated PostgreSQL workers both reach embedding concurrently and persist distinct turns\n- clean PostgreSQL semantic L2 E2E: pass\n- full npm test + ruff: pass\n- gitleaks staged scan: pass