### PR TITLE
fix(recall): omit null optional MCP arguments

### DIFF
--- a/recall/skills/recall/scripts/recall.py
+++ b/recall/skills/recall/scripts/recall.py
@@ -274,6 +274,9 @@ def _mcp_call(base: str, method: str, path: str, body: dict | None) -> dict:
             "params": {"name": tool, "arguments": arguments},
         }
     elif tool is not None and method == "POST":
+        arguments = {
+            key: value for key, value in arguments.items() if value is not None
+        }
         message = {
             "jsonrpc": "2.0",
             "id": 1,

--- a/recall/tests/test_engine.py
+++ b/recall/tests/test_engine.py
@@ -1021,9 +1021,26 @@ class RemoteTransportTest(unittest.TestCase):
 
             target = "recall://claude:linux/mcp-session:1?rev=1#item=0"
             self.assertIn("remote MCP prompt", self.call("show", target, "--prompts")[1])
+            self.assertEqual(
+                McpRemoteHandler.requests[-1]["body"]["params"]["arguments"],
+                {"target": target, "prompts": True, "tail": 0},
+            )
             self.assertIn(
                 "overlap=2",
                 self.call("related", "--cwd", "/work/grep123/project", "--branch", "feature/mcp")[1],
+            )
+            self.assertIn(
+                "overlap=2",
+                self.call("related", "--cwd", "/work/grep123/project")[1],
+            )
+            self.assertEqual(
+                McpRemoteHandler.requests[-1]["body"]["params"]["arguments"],
+                {
+                    "cwd": "/work/grep123/project",
+                    "limit": 10,
+                    "mains_only": False,
+                    "fast": False,
+                },
             )
             self.assertIn("OK remote", self.call("doctor")[1])
             self.assertEqual(McpRemoteHandler.requests[-1]["body"]["method"], "ping")


### PR DESCRIPTION
Fixes the installed Recall skill’s managed MCP show/related path: optional CLI fields with no value are now omitted instead of serialized as JSON null, matching the tools’ closed schemas.\n\nDiscovered by live installed-skill search → show E2E against Render.\n\nValidation:\n- TDD asserts show omits around and related omits branch when unset\n- targeted MCP transport test: pass\n- full npm test + ruff: pass\n- gitleaks staged scan: pass