### PR TITLE
perf(recall): index turn projection cursor

### DIFF
--- a/recall/server/deploy/README.md
+++ b/recall/server/deploy/README.md
@@ -61,7 +61,7 @@ infrastructure. The example is synthetic; a live manifest belongs in a private m
 location and contains references, never credential values.
 
 The production database gate requires a standard PostgreSQL URL with
-`sslmode=verify-full` and an explicit trust root, schema migrations 1 through 21,
+`sslmode=verify-full` and an explicit trust root, schema migrations 1 through 22,
 pgvector 0.8.0 or newer, and a runtime role without superuser, database/role creation,
 replication, or RLS-bypass privilege:
 

--- a/recall/server/recall_server/__init__.py
+++ b/recall/server/recall_server/__init__.py
@@ -1,4 +1,4 @@
 """Recall central BrainStore service."""
 
-SCHEMA_VERSION = 21
+SCHEMA_VERSION = 22
 PROJECTOR_VERSION = 3

--- a/recall/server/schema/022_turn_anchor_cursor_index.sql
+++ b/recall/server/schema/022_turn_anchor_cursor_index.sql
@@ -1,0 +1,9 @@
+BEGIN;
+
+CREATE INDEX IF NOT EXISTS items_live_user_session_id_idx
+    ON items(source_id, session_native_id, id)
+    WHERE deleted_at IS NULL AND role='user' AND btrim(text_redacted)<>'';
+
+INSERT INTO schema_migrations(version) VALUES (22) ON CONFLICT DO NOTHING;
+
+COMMIT;

--- a/recall/tests/central_brain/test_brainstore_unit.py
+++ b/recall/tests/central_brain/test_brainstore_unit.py
@@ -76,6 +76,19 @@ class SchemaMigrationContractTest(unittest.TestCase):
                 rf"schema_migrations\(version\) VALUES \({version}\)",
             )
 
+    def test_turn_backfill_anchor_cursor_has_a_session_id_index(self) -> None:
+        migration = SERVER / "schema" / "022_turn_anchor_cursor_index.sql"
+        rendered = " ".join(migration.read_text().split()).casefold()
+        self.assertIn(
+            "on items(source_id, session_native_id, id)",
+            rendered,
+        )
+        self.assertIn(
+            "where deleted_at is null and role='user' "
+            "and btrim(text_redacted)<>''",
+            rendered,
+        )
+
     def test_v2_canonical_plane_is_tenant_keyed_and_deletion_explicit(self) -> None:
         migration = SERVER / "schema" / "019_v2_canonical_plane.sql"
         rendered = " ".join(migration.read_text().split()).casefold()


### PR DESCRIPTION
Adds the partial session/id index required by dirty turn-projection cursor scans, advances schema to 22, and locks the contract with a migration test. Production index was applied concurrently and validated before enabling workers.\n\nValidation:\n- `npm test` in `recall/`\n- schema migration contract includes the new cursor index\n- `git diff --check`\n- gitleaks on the exact commit: zero findings