### PR TITLE
perf(recall): bound turn response index scan

### DIFF
--- a/recall/server/recall_server/db.py
+++ b/recall/server/recall_server/db.py
@@ -830,11 +830,16 @@ class BrainStore:
                             AND btrim(candidate.text_redacted)<>''
                             AND (candidate.occurred_at,candidate.id)>
                                 (anchor.occurred_at,anchor.id)
-                            AND (
-                              next_user.id IS NULL
-                              OR (candidate.occurred_at,candidate.id)<
-                                 (next_user.occurred_at,next_user.id)
-                            )
+                            AND (candidate.occurred_at,candidate.id)<
+                                (
+                                  COALESCE(
+                                    next_user.occurred_at,
+                                    'infinity'::timestamptz
+                                  ),
+                                  COALESCE(
+                                    next_user.id,9223372036854775807
+                                  )
+                                )
                           HAVING count(*)>0
                         ) response ON true
                         LEFT JOIN turn_embeddings embedding

--- a/recall/tests/central_brain/test_brainstore_unit.py
+++ b/recall/tests/central_brain/test_brainstore_unit.py
@@ -768,6 +768,23 @@ class RelatedRetrievalContractTest(unittest.TestCase):
 
 
 class SemanticRetrievalContractTest(unittest.TestCase):
+    def test_turn_projection_uses_one_indexable_response_range(self) -> None:
+        implementation = inspect.getsource(BrainStore.embed_pending_turns)
+        response_range = implementation.split(
+            "FROM items candidate", 1,
+        )[1].split("HAVING count(*)>0", 1)[0]
+        response_range = " ".join(response_range.split())
+
+        self.assertNotIn("next_user.id IS NULL", response_range)
+        self.assertIn(
+            "COALESCE( next_user.occurred_at, 'infinity'::timestamptz )",
+            response_range,
+        )
+        self.assertIn(
+            "COALESCE( next_user.id,9223372036854775807 )",
+            response_range,
+        )
+
     def test_turn_projection_preserves_question_head_and_final_answer_tail(self) -> None:
         rendered = turn_embedding_text(
             "Why did we choose the managed database?",


### PR DESCRIPTION
Makes the assistant response window one indexable tuple range instead of an OR-filtered scan. On the largest real production session, one result improved from 1,030 ms / 766,571 filtered rows to a 512-turn batch in 19.1 ms / 2 filtered rows.\n\nTDD and validation:\n- new source contract rejects the unbounded OR form\n- full `npm test` in `recall/` passes\n- exact commit gitleaks scan: zero findings\n- no private corpus or live evidence committed