### PR TITLE
feat(recall): dedupe repeated turn prompts

### DIFF
--- a/recall/server/deploy/README.md
+++ b/recall/server/deploy/README.md
@@ -61,7 +61,7 @@ infrastructure. The example is synthetic; a live manifest belongs in a private m
 location and contains references, never credential values.
 
 The production database gate requires a standard PostgreSQL URL with
-`sslmode=verify-full` and an explicit trust root, schema migrations 1 through 22,
+`sslmode=verify-full` and an explicit trust root, schema migrations 1 through 23,
 pgvector 0.8.0 or newer, and a runtime role without superuser, database/role creation,
 replication, or RLS-bypass privilege:
 

--- a/recall/server/recall_server/__init__.py
+++ b/recall/server/recall_server/__init__.py
@@ -1,4 +1,4 @@
 """Recall central BrainStore service."""
 
-SCHEMA_VERSION = 22
+SCHEMA_VERSION = 23
 PROJECTOR_VERSION = 3

--- a/recall/server/recall_server/db.py
+++ b/recall/server/recall_server/db.py
@@ -796,11 +796,36 @@ class BrainStore:
                     )
                     rows = conn.execute(
                         """
+                        WITH latest_anchors AS MATERIALIZED (
+                          SELECT max(candidate_anchor.id) AS anchor_item_id
+                          FROM items candidate_anchor
+                          WHERE candidate_anchor.deleted_at IS NULL
+                            AND candidate_anchor.role='user'
+                            AND btrim(candidate_anchor.text_redacted)<>''
+                            AND (
+                              %s::text IS NULL
+                              OR candidate_anchor.source_id=%s
+                            )
+                            AND (
+                              %s::text IS NULL
+                              OR candidate_anchor.session_native_id=%s
+                            )
+                            AND (
+                              %s::bigint IS NULL
+                              OR candidate_anchor.id>%s
+                            )
+                          GROUP BY candidate_anchor.source_id,
+                                   candidate_anchor.session_native_id,
+                                   candidate_anchor.text_redacted
+                          ORDER BY max(candidate_anchor.id)
+                        )
                         SELECT anchor.id AS anchor_item_id,anchor.source_id,
                                anchor.session_native_id,anchor.text_redacted AS user_text,
                                response.response_item_id,response.item_ids,
                                response.assistant_texts
-                        FROM items anchor
+                        FROM latest_anchors latest_anchor
+                        JOIN items anchor
+                          ON anchor.id=latest_anchor.anchor_item_id
                         LEFT JOIN LATERAL (
                           SELECT boundary.occurred_at,boundary.id
                           FROM items boundary
@@ -844,16 +869,7 @@ class BrainStore:
                         ) response ON true
                         LEFT JOIN turn_embeddings embedding
                           ON embedding.anchor_item_id=anchor.id
-                        WHERE anchor.deleted_at IS NULL
-                          AND anchor.role='user'
-                          AND btrim(anchor.text_redacted)<>''
-                          AND (%s::text IS NULL OR anchor.source_id=%s)
-                          AND (
-                            %s::text IS NULL
-                            OR anchor.session_native_id=%s
-                          )
-                          AND (%s::bigint IS NULL OR anchor.id>%s)
-                          AND (
+                        WHERE (
                             %s::boolean
                             OR (
                               embedding.anchor_item_id IS NULL
@@ -935,6 +951,25 @@ class BrainStore:
                     vectors = self.semantic_runtime.embed_documents(documents)
                     with conn.transaction():
                         with conn.cursor() as cursor:
+                            cursor.executemany(
+                                """DELETE FROM turn_embeddings older_embedding
+                                   USING items older_anchor
+                                   WHERE older_embedding.anchor_item_id=
+                                         older_anchor.id
+                                     AND older_embedding.source_id=%s
+                                     AND older_embedding.session_native_id=%s
+                                     AND older_embedding.anchor_item_id<>%s
+                                     AND older_anchor.text_redacted=%s""",
+                                [
+                                    (
+                                        row["source_id"],
+                                        row["session_native_id"],
+                                        row["anchor_item_id"],
+                                        row["user_text"],
+                                    )
+                                    for row in rows
+                                ],
+                            )
                             cursor.executemany(
                                 """INSERT INTO turn_embeddings(
                                      anchor_item_id,response_item_id,source_id,

--- a/recall/server/schema/023_turn_prompt_dedupe_index.sql
+++ b/recall/server/schema/023_turn_prompt_dedupe_index.sql
@@ -1,0 +1,8 @@
+BEGIN;
+
+CREATE INDEX IF NOT EXISTS turn_embeddings_source_session_anchor_idx
+    ON turn_embeddings(source_id, session_native_id, anchor_item_id);
+
+INSERT INTO schema_migrations(version) VALUES (23) ON CONFLICT DO NOTHING;
+
+COMMIT;

--- a/recall/server/tests/e2e_semantic_l2.py
+++ b/recall/server/tests/e2e_semantic_l2.py
@@ -326,6 +326,48 @@ def main() -> None:
         authorized_source="source-k",
     )
     assert late_result["results"][0]["native_id"] == "late-answer"
+    repeated_prompt = "What is the current deployment status?"
+    store.ingest("repeated-turn-old-p", [
+        envelope(
+            "source-p", "repeated-question-old", repeated_prompt,
+            "session-repeated-p", occurred_at="2026-07-16T02:10:00Z",
+        ),
+        envelope(
+            "source-p", "repeated-answer-old", "The old deployment status.",
+            "session-repeated-p", role="assistant",
+            occurred_at="2026-07-16T02:11:00Z",
+        ),
+    ])
+    assert store.embed_pending_turns(
+        batch_size=10, source_id="source-p",
+    )["processed"] == 1
+    store.ingest("repeated-turn-latest-p", [
+        envelope(
+            "source-p", "repeated-question-latest", repeated_prompt,
+            "session-repeated-p", occurred_at="2026-07-16T02:12:00Z",
+        ),
+        envelope(
+            "source-p", "repeated-answer-latest", "The latest deployment status.",
+            "session-repeated-p", role="assistant",
+            occurred_at="2026-07-16T02:13:00Z",
+        ),
+    ])
+    repeated_turn = store.embed_pending_turns(
+        batch_size=10, source_id="source-p",
+    )
+    assert repeated_turn["processed"] == 1
+    with store.connect() as connection:
+        repeated_projection = connection.execute(
+            """SELECT count(*) AS value,
+                      max(response.event_native_id) AS response_native_id
+               FROM turn_embeddings embedding
+               JOIN items anchor ON anchor.id=embedding.anchor_item_id
+               JOIN items response ON response.id=embedding.response_item_id
+               WHERE anchor.source_id='source-p'
+                 AND anchor.session_native_id='session-repeated-p'"""
+        ).fetchone()
+    assert repeated_projection["value"] == 1
+    assert repeated_projection["response_native_id"] == "repeated-answer-latest"
     with store.connect() as connection:
         connection.execute("DELETE FROM turn_embedding_dirty_sessions")
     store.ingest("turn-watermark-low", [

--- a/recall/tests/central_brain/test_brainstore_unit.py
+++ b/recall/tests/central_brain/test_brainstore_unit.py
@@ -89,6 +89,14 @@ class SchemaMigrationContractTest(unittest.TestCase):
             rendered,
         )
 
+    def test_turn_dedupe_has_a_session_scoped_cleanup_index(self) -> None:
+        migration = SERVER / "schema" / "023_turn_prompt_dedupe_index.sql"
+        rendered = " ".join(migration.read_text().split()).casefold()
+        self.assertIn(
+            "on turn_embeddings(source_id, session_native_id, anchor_item_id)",
+            rendered,
+        )
+
     def test_v2_canonical_plane_is_tenant_keyed_and_deletion_explicit(self) -> None:
         migration = SERVER / "schema" / "019_v2_canonical_plane.sql"
         rendered = " ".join(migration.read_text().split()).casefold()
@@ -768,6 +776,29 @@ class RelatedRetrievalContractTest(unittest.TestCase):
 
 
 class SemanticRetrievalContractTest(unittest.TestCase):
+    def test_turn_projection_keeps_only_the_latest_exact_prompt_per_session(
+        self,
+    ) -> None:
+        implementation = inspect.getsource(BrainStore.embed_pending_turns)
+        latest_anchors = implementation.split(
+            "WITH latest_anchors AS MATERIALIZED", 1,
+        )[1].split("SELECT anchor.id AS anchor_item_id", 1)[0]
+        latest_anchors = " ".join(latest_anchors.split())
+
+        self.assertIn("max(candidate_anchor.id) AS anchor_item_id", latest_anchors)
+        self.assertIn(
+            "GROUP BY candidate_anchor.source_id, "
+            "candidate_anchor.session_native_id, "
+            "candidate_anchor.text_redacted",
+            latest_anchors,
+        )
+        self.assertIn("ORDER BY max(candidate_anchor.id)", latest_anchors)
+        self.assertIn(
+            "DELETE FROM turn_embeddings older_embedding",
+            implementation,
+        )
+        self.assertIn("older_anchor.text_redacted=%s", implementation)
+
     def test_turn_projection_uses_one_indexable_response_range(self) -> None:
         implementation = inspect.getsource(BrainStore.embed_pending_turns)
         response_range = implementation.split(


### PR DESCRIPTION
Keeps raw redacted items intact while projecting only the latest exact prompt/response per session. Incremental reprojection deletes obsolete duplicate turn embeddings, backed by a session-scoped cleanup index (schema 23).\n\nReal workload motivation (aggregate only): one 1.37 GB Claude transcript had 766,878 user items but only 27 distinct user texts. The projection candidate set drops from hundreds of thousands to tens without deleting history.\n\nValidation:\n- full `npm test` in `recall/`\n- fresh PostgreSQL E2E proves old projection is replaced by the latest answer\n- production schema-23 index applied concurrently and valid\n- exact commit gitleaks scan: zero findings\n- no transcripts/private corpus/live evidence committed