### PR TITLE
fix(recall): requeue historical duplicate turns

### DIFF
--- a/recall/server/deploy/README.md
+++ b/recall/server/deploy/README.md
@@ -61,7 +61,7 @@ infrastructure. The example is synthetic; a live manifest belongs in a private m
 location and contains references, never credential values.
 
 The production database gate requires a standard PostgreSQL URL with
-`sslmode=verify-full` and an explicit trust root, schema migrations 1 through 23,
+`sslmode=verify-full` and an explicit trust root, schema migrations 1 through 24,
 pgvector 0.8.0 or newer, and a runtime role without superuser, database/role creation,
 replication, or RLS-bypass privilege:
 

--- a/recall/server/recall_server/__init__.py
+++ b/recall/server/recall_server/__init__.py
@@ -1,4 +1,4 @@
 """Recall central BrainStore service."""
 
-SCHEMA_VERSION = 23
+SCHEMA_VERSION = 24
 PROJECTOR_VERSION = 3

--- a/recall/server/schema/024_requeue_turn_prompt_duplicates.sql
+++ b/recall/server/schema/024_requeue_turn_prompt_duplicates.sql
@@ -1,0 +1,21 @@
+BEGIN;
+
+INSERT INTO turn_embedding_dirty_sessions(
+    source_id,session_native_id,last_anchor_item_id,updated_at
+)
+SELECT
+    embedding.source_id,
+    embedding.session_native_id,
+    0,
+    now()
+FROM turn_embeddings embedding
+JOIN items anchor ON anchor.id=embedding.anchor_item_id
+GROUP BY embedding.source_id,embedding.session_native_id
+HAVING count(*)>count(DISTINCT anchor.text_redacted)
+ON CONFLICT(source_id,session_native_id) DO UPDATE SET
+    last_anchor_item_id=0,
+    updated_at=excluded.updated_at;
+
+INSERT INTO schema_migrations(version) VALUES (24) ON CONFLICT DO NOTHING;
+
+COMMIT;

--- a/recall/tests/central_brain/test_brainstore_unit.py
+++ b/recall/tests/central_brain/test_brainstore_unit.py
@@ -97,6 +97,26 @@ class SchemaMigrationContractTest(unittest.TestCase):
             rendered,
         )
 
+    def test_turn_dedupe_upgrade_requeues_historical_duplicate_sessions(
+        self,
+    ) -> None:
+        migration = SERVER / "schema" / "024_requeue_turn_prompt_duplicates.sql"
+        rendered = " ".join(migration.read_text().split()).casefold()
+        self.assertIn("insert into turn_embedding_dirty_sessions(", rendered)
+        self.assertIn(
+            "source_id,session_native_id,last_anchor_item_id,updated_at",
+            rendered,
+        )
+        self.assertIn(
+            "having count(*)>count(distinct anchor.text_redacted)",
+            rendered,
+        )
+        self.assertIn(
+            "on conflict(source_id,session_native_id) do update set "
+            "last_anchor_item_id=0",
+            rendered,
+        )
+
     def test_v2_canonical_plane_is_tenant_keyed_and_deletion_explicit(self) -> None:
         migration = SERVER / "schema" / "019_v2_canonical_plane.sql"
         rendered = " ".join(migration.read_text().split()).casefold()


### PR DESCRIPTION
Adds idempotent schema migration 24 so existing installations enqueue only sessions that already contain duplicate exact-prompt turn embeddings. The schema-23 projector then replaces them with the latest turn while preserving raw items.\n\nValidation:\n- full `npm test` in `recall/`\n- migration contract verifies affected-session detection and cursor reset\n- production equivalent queued 224 affected sessions successfully\n- exact commit gitleaks scan: zero findings\n- no private content or live evidence committed