### PR TITLE
fix(recall): finalize turn prompt dedupe

### DIFF
--- a/recall/server/deploy/README.md
+++ b/recall/server/deploy/README.md
@@ -61,7 +61,7 @@ infrastructure. The example is synthetic; a live manifest belongs in a private m
 location and contains references, never credential values.
 
 The production database gate requires a standard PostgreSQL URL with
-`sslmode=verify-full` and an explicit trust root, schema migrations 1 through 24,
+`sslmode=verify-full` and an explicit trust root, schema migrations 1 through 25,
 pgvector 0.8.0 or newer, and a runtime role without superuser, database/role creation,
 replication, or RLS-bypass privilege:
 

--- a/recall/server/recall_server/__init__.py
+++ b/recall/server/recall_server/__init__.py
@@ -1,4 +1,4 @@
 """Recall central BrainStore service."""
 
-SCHEMA_VERSION = 24
+SCHEMA_VERSION = 25
 PROJECTOR_VERSION = 3

--- a/recall/server/recall_server/db.py
+++ b/recall/server/recall_server/db.py
@@ -716,6 +716,31 @@ class BrainStore:
             "surface_scoped": surface is not None,
         }
 
+    @staticmethod
+    def _dedupe_turn_embeddings_for_session(
+        connection: Any,
+        source_id: str,
+        session_native_id: str,
+    ) -> None:
+        connection.execute(
+            """WITH ranked AS (
+                 SELECT embedding.anchor_item_id,
+                        row_number() OVER (
+                          PARTITION BY anchor.text_redacted
+                          ORDER BY embedding.anchor_item_id DESC
+                        ) AS position
+                 FROM turn_embeddings embedding
+                 JOIN items anchor ON anchor.id=embedding.anchor_item_id
+                 WHERE embedding.source_id=%s
+                   AND embedding.session_native_id=%s
+               )
+               DELETE FROM turn_embeddings duplicate
+               USING ranked
+               WHERE duplicate.anchor_item_id=ranked.anchor_item_id
+                 AND ranked.position>1""",
+            (source_id, session_native_id),
+        )
+
     def embed_pending_turns(
         self,
         batch_size: int = 128,
@@ -913,6 +938,11 @@ class BrainStore:
                     ).fetchall()
                     if not rows:
                         if dirty is not None:
+                            self._dedupe_turn_embeddings_for_session(
+                                conn,
+                                dirty["source_id"],
+                                dirty["session_native_id"],
+                            )
                             conn.execute(
                                 """DELETE FROM turn_embedding_dirty_sessions
                                    WHERE source_id=%s

--- a/recall/server/schema/025_collapse_turn_prompt_duplicates.sql
+++ b/recall/server/schema/025_collapse_turn_prompt_duplicates.sql
@@ -1,0 +1,23 @@
+BEGIN;
+
+WITH ranked AS (
+    SELECT
+        embedding.anchor_item_id,
+        row_number() OVER (
+            PARTITION BY
+                embedding.source_id,
+                embedding.session_native_id,
+                anchor.text_redacted
+            ORDER BY embedding.anchor_item_id DESC
+        ) AS position
+    FROM turn_embeddings embedding
+    JOIN items anchor ON anchor.id=embedding.anchor_item_id
+)
+DELETE FROM turn_embeddings duplicate
+USING ranked
+WHERE duplicate.anchor_item_id=ranked.anchor_item_id
+  AND ranked.position>1;
+
+INSERT INTO schema_migrations(version) VALUES (25) ON CONFLICT DO NOTHING;
+
+COMMIT;

--- a/recall/tests/central_brain/test_brainstore_unit.py
+++ b/recall/tests/central_brain/test_brainstore_unit.py
@@ -117,6 +117,22 @@ class SchemaMigrationContractTest(unittest.TestCase):
             rendered,
         )
 
+    def test_turn_dedupe_upgrade_collapses_historical_projection_rows(
+        self,
+    ) -> None:
+        migration = SERVER / "schema" / "025_collapse_turn_prompt_duplicates.sql"
+        rendered = " ".join(migration.read_text().split()).casefold()
+        self.assertIn(
+            "row_number() over ( partition by embedding.source_id, "
+            "embedding.session_native_id, anchor.text_redacted "
+            "order by embedding.anchor_item_id desc )",
+            rendered,
+        )
+        self.assertIn(
+            "delete from turn_embeddings duplicate using ranked",
+            rendered,
+        )
+
     def test_v2_canonical_plane_is_tenant_keyed_and_deletion_explicit(self) -> None:
         migration = SERVER / "schema" / "019_v2_canonical_plane.sql"
         rendered = " ".join(migration.read_text().split()).casefold()
@@ -818,6 +834,13 @@ class SemanticRetrievalContractTest(unittest.TestCase):
             implementation,
         )
         self.assertIn("older_anchor.text_redacted=%s", implementation)
+        self.assertLess(
+            implementation.index("_dedupe_turn_embeddings_for_session("),
+            implementation.index(
+                "DELETE FROM turn_embedding_dirty_sessions",
+            ),
+        )
+
 
     def test_turn_projection_uses_one_indexable_response_range(self) -> None:
         implementation = inspect.getsource(BrainStore.embed_pending_turns)


### PR DESCRIPTION
Collapses historical exact-prompt duplicates set-wise (schema 25) and repeats the same cleanup whenever a dirty session reaches completion, including the newest-prompt-is-unanswered edge case. It keeps the newest answered projection and never deletes raw items.\n\nValidation:\n- full `npm test` in `recall/`\n- fresh PostgreSQL semantic E2E\n- production aggregate audit: 124,869 obsolete projection rows removed; duplicate groups now zero\n- exact commit gitleaks scan: zero findings\n- no transcripts/private corpus/live evidence committed