### PR TITLE
fix(recall): retire superseded item projections

### DIFF
--- a/recall/server/deploy/README.md
+++ b/recall/server/deploy/README.md
@@ -61,7 +61,7 @@ infrastructure. The example is synthetic; a live manifest belongs in a private m
 location and contains references, never credential values.
 
 The production database gate requires a standard PostgreSQL URL with
-`sslmode=verify-full` and an explicit trust root, schema migrations 1 through 25,
+`sslmode=verify-full` and an explicit trust root, schema migrations 1 through 26,
 pgvector 0.8.0 or newer, and a runtime role without superuser, database/role creation,
 replication, or RLS-bypass privilege:
 

--- a/recall/server/recall_server/__init__.py
+++ b/recall/server/recall_server/__init__.py
@@ -1,4 +1,4 @@
 """Recall central BrainStore service."""
 
-SCHEMA_VERSION = 25
+SCHEMA_VERSION = 26
 PROJECTOR_VERSION = 3

--- a/recall/server/recall_server/db.py
+++ b/recall/server/recall_server/db.py
@@ -1249,6 +1249,17 @@ class BrainStore:
             )
             return
         items, metadata = project(envelope, revision)
+        # A source/native identity is one logical record whose immutable
+        # source_events rows retain its history. Only the latest revision may
+        # remain in the live search projection.
+        conn.execute(
+            """UPDATE items
+               SET deleted_at=now()
+               WHERE source_id=%s
+                 AND event_native_id=%s
+                 AND deleted_at IS NULL""",
+            (envelope["source_id"], envelope["native_id"]),
+        )
         if not items and set(metadata) <= {"projector_version", "harness"}:
             return
         conn.execute(

--- a/recall/server/schema/026_retire_superseded_items.sql
+++ b/recall/server/schema/026_retire_superseded_items.sql
@@ -1,0 +1,18 @@
+BEGIN;
+
+UPDATE items item
+SET deleted_at = now()
+FROM source_events event
+WHERE event.id = item.event_id
+  AND item.deleted_at IS NULL
+  AND EXISTS (
+    SELECT 1
+    FROM source_events newer
+    WHERE newer.source_id = event.source_id
+      AND newer.native_id = event.native_id
+      AND newer.revision > event.revision
+  );
+
+INSERT INTO schema_migrations(version) VALUES (26) ON CONFLICT DO NOTHING;
+
+COMMIT;

--- a/recall/server/tests/e2e_brainstore.py
+++ b/recall/server/tests/e2e_brainstore.py
@@ -94,7 +94,11 @@ def main() -> None:
     with tempfile.TemporaryDirectory(prefix="recall-c1-e2e-") as tmp:
         log_path = Path(tmp) / "server.log"
         log = log_path.open("w")
-        env = os.environ | {"PYTHONPATH": str(SERVER), "RECALL_DATABASE_URL": dsn, "RECALL_PORT": str(port)}
+        env = os.environ | {
+            "PYTHONPATH": os.pathsep.join((str(RECALL), str(SERVER))),
+            "RECALL_DATABASE_URL": dsn,
+            "RECALL_PORT": str(port),
+        }
         process = subprocess.Popen([sys.executable, "-m", "recall_server.app"], env=env, stdout=log, stderr=log)
         try:
             for _ in range(50):
@@ -392,6 +396,39 @@ def main() -> None:
             assert status == 409 and "different request" in conflict["error"]
             status, revision_ack = request(base, "POST", "/v1/ingest/batches", {"events": [changed]}, "batch-revision")
             assert status == 201 and revision_ack["receipts"][0].endswith("?rev=2")
+            with store.connect() as conn:
+                revision_projection = conn.execute(
+                    """SELECT item.text_redacted,item.deleted_at,event.revision
+                       FROM items item
+                       JOIN source_events event ON event.id=item.event_id
+                       WHERE item.source_id='codex:linux'
+                         AND item.event_native_id='session-1:turn-1'
+                       ORDER BY event.revision"""
+                ).fetchall()
+            assert len(revision_projection) == 2, revision_projection
+            assert revision_projection[0]["deleted_at"] is not None, revision_projection
+            assert revision_projection[1]["deleted_at"] is None, revision_projection
+            assert revision_projection[1]["text_redacted"] == "quartz decision revised"
+            with store.connect() as conn:
+                conn.execute(
+                    """UPDATE items item SET deleted_at=NULL
+                       FROM source_events event
+                       WHERE event.id=item.event_id
+                         AND event.source_id='codex:linux'
+                         AND event.native_id='session-1:turn-1'
+                         AND event.revision=1"""
+                )
+                conn.execute("DELETE FROM schema_migrations WHERE version=26")
+            store.migrate()
+            with store.connect() as conn:
+                live_revision_projection = conn.execute(
+                    """SELECT count(*) AS n
+                       FROM items
+                       WHERE source_id='codex:linux'
+                         AND event_native_id='session-1:turn-1'
+                         AND deleted_at IS NULL"""
+                ).fetchone()["n"]
+            assert live_revision_projection == 1, live_revision_projection
 
             # Same native ID in different sources remains two independently resolvable records.
             collision_a = make_envelope("shared-native:1", {"text": "alpha evidence"}, source="source:alpha", parent="shared")
@@ -668,6 +705,7 @@ def main() -> None:
                     "source_events": conn.execute("SELECT count(*) AS n FROM source_events").fetchone()["n"],
                     "live_items": conn.execute("SELECT count(*) AS n FROM items WHERE deleted_at IS NULL").fetchone()["n"],
                     "revisions_for_session_1_turn_1": conn.execute("SELECT count(*) AS n FROM source_events WHERE source_id='codex:linux' AND native_id='session-1:turn-1'").fetchone()["n"],
+                    "superseded_revision_live_items": 0,
                     "race_duplicates": 0,
                     "same_key_race_single_commit": True,
                     "watermark_advanced_once_per_batch": True,


### PR DESCRIPTION
## Summary
- retire the prior live item projection whenever a newer source-event revision is projected
- add migration 26 to clean historical superseded projections without deleting raw source events
- cover both live revision ingestion and upgrade cleanup in the BrainStore E2E

## Verification
- fresh PostgreSQL BrainStore E2E passes
- 75 BrainStore unit tests pass
- 24 retrieval-eval and collector tests pass
- staged secret/private-path scan clean