### PR TITLE
docs(recall): preserve read-only migration grants

### DIFF
--- a/recall/server/deploy/README.md
+++ b/recall/server/deploy/README.md
@@ -163,10 +163,16 @@ GRANT SELECT, INSERT, UPDATE, DELETE
   ON ALL TABLES IN SCHEMA public TO recall_runtime;
 GRANT USAGE, SELECT
   ON ALL SEQUENCES IN SCHEMA public TO recall_runtime;
+REVOKE ALL PRIVILEGES
+  ON TABLE public.schema_migrations FROM recall_runtime;
+GRANT SELECT
+  ON TABLE public.schema_migrations TO recall_runtime;
 ```
 
-Apply only the grants the enabled runtime operations need. Reassign objects to the
-durable owner before deleting a temporary migration role.
+The final two statements are mandatory after the broad table refresh: the runtime
+capability gate requires migration history to remain read-only. Apply only the grants
+the enabled runtime operations need. Reassign objects to the durable owner before
+deleting a temporary migration role.
 
 After reviewing the zero-network preview and mode-0600 approval document, run
 the exact approved apply under 1Password injection:

--- a/recall/tests/central_brain/test_brainstore_unit.py
+++ b/recall/tests/central_brain/test_brainstore_unit.py
@@ -296,6 +296,14 @@ class SchemaMigrationContractTest(unittest.TestCase):
         self.assertIn("refresh runtime grants after every migration", guide)
         self.assertIn("on all tables in schema public", guide)
         self.assertIn("on all sequences in schema public", guide)
+        self.assertIn(
+            "revoke all privileges on table public.schema_migrations",
+            guide,
+        )
+        self.assertIn(
+            "grant select on table public.schema_migrations",
+            guide,
+        )
 
 
 class EmbeddingBackfillWatermarkTest(unittest.TestCase):


### PR DESCRIPTION
## Summary
- revoke broad table grants from `schema_migrations` after each runtime grant refresh
- restore SELECT-only access required by the production capability gate
- lock the deployment contract in the BrainStore unit suite

## Verification
- 75 BrainStore unit tests pass
- staged secret/private-path scan clean
- live production capability check reports least-privilege runtime ready