### PR TITLE
fix(recall): scrub standalone provider credentials

### DIFF
--- a/.github/workflows/recall-image.yml
+++ b/.github/workflows/recall-image.yml
@@ -12,6 +12,7 @@ on:
       - "recall/.dockerignore"
       - "recall/server/**"
       - "recall/contracts/**"
+      - "recall/privacy/**"
       - "recall/skills/recall/scripts/recall.py"
       - ".github/workflows/recall-image.yml"
   workflow_dispatch:

--- a/recall/client/README.md
+++ b/recall/client/README.md
@@ -134,7 +134,7 @@ search and its prior receipt no longer resolves.
 
 ## Pre-ingest privacy policy
 
-Privacy policy version `recall-privacy-v1` runs on parsed content before a
+Privacy policy version `recall-privacy-v2` runs on parsed content before a
 collector writes version hashes or outbox rows and before export or memory code
 makes an HTTP request:
 

--- a/recall/client/README.md
+++ b/recall/client/README.md
@@ -152,9 +152,10 @@ the approved router:
 printf '%s' "$VALUE" | recall-brain privacy-preview --privacy-mode scrub
 ```
 
-The local structural policy covers credential assignments and structured email,
-phone, postal, government, financial, and medical identifiers. Contextual names
-and meaning require the optional agentic judge. It accepts only an HTTPS staging
+The local structural policy covers credential assignments, standalone common
+provider credential shapes, and structured email, phone, postal, government,
+financial, and medical identifiers. Contextual names and meaning require the
+optional agentic judge. It accepts only an HTTPS staging
 LiteLLM URL, a model alias, and a mode-0600 file containing a short-lived scoped
 virtual key as `{"virtual_key":"...","scope":"recall-privacy-judge",`
 `"expires_at":"...Z"}`; provider-direct URLs, wrong scopes, and expired files are

--- a/recall/privacy/policy.py
+++ b/recall/privacy/policy.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from .transport import open_no_redirect
 
 
-POLICY_VERSION = "recall-privacy-v1"
+POLICY_VERSION = "recall-privacy-v2"
 REDACTION = "[REDACTED:{category}]"
 ALLOWED_JUDGE_CATEGORIES = {
     "contextual_name",
@@ -27,6 +27,21 @@ ALLOWED_JUDGE_CATEGORIES = {
 }
 SENSITIVE_KEY = re.compile(
     r"(?:litellm.*master.*key|api[_-]?key|password|secret|authorization|bearer|access[_-]?token|refresh[_-]?token|private[_-]?key)$",
+    re.I,
+)
+PROVIDER_CREDENTIAL = re.compile(
+    r"(?<![A-Za-z0-9_])(?:"
+    r"sk-(?:proj|svcacct|admin)-[A-Za-z0-9_-]{40,}|"
+    r"sk-(?!ant-|or-v1-)[A-Za-z0-9_-]{32,}|"
+    r"sk-ant-(?:api03|admin01)-[A-Za-z0-9_-]{80,}AA|"
+    r"sk-or-v1-[A-Za-z0-9_-]{20,}|gsk_[A-Za-z0-9]{20,}|"
+    r"xai-[A-Za-z0-9_-]{20,}|pplx-[A-Za-z0-9_-]{20,}|csk-[A-Za-z0-9_-]{20,}|"
+    r"xox[baprs]-[A-Za-z0-9-]{20,}|"
+    r"(?:gh[pousr]|github_pat)_[A-Za-z0-9_]{20,}|ops_[A-Za-z0-9_-]{20,}|"
+    r"A[KS]IA[A-Z0-9]{16}|AIza[A-Za-z0-9_-]{35}|"
+    r"(?:sk|rk)_(?:live|test)_[A-Za-z0-9]{20,}|hf_[A-Za-z0-9]{20,}|"
+    r"pcsk_[A-Za-z0-9_-]{20,}|lsv2_[A-Za-z0-9_-]{20,}"
+    r")(?![A-Za-z0-9_-])",
     re.I,
 )
 APPROVED_JUDGE_BASE_URL_ENV = "RECALL_PRIVACY_JUDGE_ALLOWED_BASE_URL"
@@ -116,6 +131,7 @@ def _structural_spans(text: str) -> list[dict[str, Any]]:
 
     add(r"\b(?:api[_-]?key|password|secret|access[_-]?token|refresh[_-]?token)\s*[=:]\s*[^\s,;]+", "credential", flags=re.I)
     add(r"\bBearer\s+[^\s,;]+", "credential", flags=re.I)
+    add(PROVIDER_CREDENTIAL.pattern, "credential", flags=PROVIDER_CREDENTIAL.flags)
     add(r"(?<![\w.+-])([A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,})(?![\w.-])", "email", flags=re.I, group=1)
     add(r"(?<![\w.])((?:\+1\s+|\(\d{3}\)\s*)\d{3}[- ]\d{4}|\+1\s+\d{3}[- ]\d{3}[- ]\d{4})(?![\w.-])", "phone", group=1)
     add(r"(?<![\w.])(\d{3}-\d{3}-\d{4})(?![\w.-])", "phone", group=1)

--- a/recall/server/tests/e2e_grep_ai.py
+++ b/recall/server/tests/e2e_grep_ai.py
@@ -29,6 +29,7 @@ SOURCE = "grep-ai:synthetic:postgres"
 OTHER_SOURCE = "grep-ai:synthetic:other"
 KEY = "parcha-synthetic-" + "b" * 32
 CANARY = "grep-ai-private-canary-77"
+PROVIDER_CANARY = "sk-proj-" + "A" * 48
 RAW_CANARY = "grep-ai-raw-response-canary-98"
 CORPUS = ROOT / "recall/tests/grep_ai_v2/corpus.jsonl"
 
@@ -37,6 +38,8 @@ def fixtures() -> tuple[dict, dict]:
     rows = {row["case"]: row for row in map(json.loads, CORPUS.read_text().splitlines())}
     safe, private = rows["complete"], rows["sensitive-complete"]
     details = {**safe["details"], **private["details"]}
+    private_detail = details[private["list"]["items"][0]["job_id"]]
+    private_detail["report"]["markdown"] += " standalone " + PROVIDER_CANARY
     next(iter(details.values()))["context"] = {"ignored": RAW_CANARY}
     page = {
         "items": [safe["list"]["items"][0], private["list"]["items"][0]],
@@ -164,6 +167,7 @@ def main() -> None:
             requests_after_commit = state.requests
             assert requests_after_commit == 3
             assert CANARY.encode() not in spool.read_bytes()
+            assert PROVIDER_CANARY.encode() not in spool.read_bytes()
             assert RAW_CANARY.encode() not in spool.read_bytes()
             runner.close()
 
@@ -177,6 +181,7 @@ def main() -> None:
             safe_results = store.search("Safe report citation", authorized_source=SOURCE)["results"]
             assert len(safe_results) == 1
             assert store.search(CANARY, authorized_source=SOURCE)["results"] == []
+            assert store.search(PROVIDER_CANARY, authorized_source=SOURCE)["results"] == []
             safe_native_id = safe_results[0]["native_id"]
             recovered.close()
             record = ConnectorRecord(

--- a/recall/tests/privacy_eval_v1/manifest.json
+++ b/recall/tests/privacy_eval_v1/manifest.json
@@ -5,7 +5,7 @@
     "total": 12
   },
   "corpus_sha256": "bc67b12e40fb7a91c86696922cb07a334b270f968641180fbeb08928366506b1",
-  "policy_version": "recall-privacy-v1",
+  "policy_version": "recall-privacy-v2",
   "thresholds": {
     "benign_retention_percent": 100,
     "safe_text_mutation_percent": 0,

--- a/recall/tests/test_privacy_policy.py
+++ b/recall/tests/test_privacy_policy.py
@@ -10,7 +10,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest import mock
 
-from privacy.policy import AgenticJudge, PrivacyPolicy
+from privacy.policy import AgenticJudge, POLICY_VERSION, PrivacyPolicy
 
 
 CORPUS = Path(__file__).with_name("privacy_eval_v1") / "corpus.jsonl"
@@ -27,6 +27,7 @@ class FrozenPrivacyEvalTest(unittest.TestCase):
         manifest = json.loads(MANIFEST.read_text())
         rows = corpus()
         self.assertEqual(hashlib.sha256(CORPUS.read_bytes()).hexdigest(), manifest["corpus_sha256"])
+        self.assertEqual(manifest["policy_version"], POLICY_VERSION)
         self.assertEqual(manifest["counts"], {
             "benign": sum(not row["sensitive"] for row in rows),
             "sensitive": sum(row["sensitive"] for row in rows),
@@ -73,6 +74,40 @@ class FrozenPrivacyEvalTest(unittest.TestCase):
         decision = PrivacyPolicy(mode="off").apply(value)
         self.assertEqual(decision.action, "keep")
         self.assertIs(decision.value, value)
+
+    def test_provider_credential_shapes_are_scrubbed_without_assignment_context(self) -> None:
+        credentials = (
+            "sk-proj-" + "A" * 48,
+            "sk-ant-api03-" + "A" * 90 + "AA",
+            "sk-or-v1-" + "R" * 40,
+            "gsk_" + "Q" * 40,
+            "xai-" + "X" * 40,
+            "pplx-" + "P" * 40,
+            "csk-" + "C" * 40,
+            "github_pat_" + "J" * 60,
+            "xoxb-" + "S" * 40,
+            "ops_" + "W" * 40,
+            "AKIA" + "Z" * 16,
+            "AIza" + "G" * 35,
+            "sk_live_" + "T" * 32,
+            "hf_" + "F" * 40,
+            "pcsk_" + "N" * 40,
+            "lsv2_" + "L" * 40,
+        )
+        for credential in credentials:
+            with self.subTest(prefix=credential[:10]):
+                decision = PrivacyPolicy(mode="scrub").apply(
+                    {"text": f"safe prefix {credential} safe suffix"}
+                )
+                self.assertEqual(decision.action, "scrub")
+                self.assertEqual(decision.categories, {"credential": 1})
+                self.assertNotIn(credential, json.dumps(decision.value))
+        self.assertEqual(
+            PrivacyPolicy(mode="scrub").apply(
+                {"text": "sketch-projection is ordinary prose"}
+            ).action,
+            "keep",
+        )
 
     def test_agent_failure_obeys_fail_closed_drop_without_echoing_input(self) -> None:
         canary = "contextual-canary-must-not-escape"


### PR DESCRIPTION
## What
- recognize standalone provider credential shapes in the shared pre-ingest privacy policy
- bump the policy receipt to recall-privacy-v2
- freeze provider-shape and Grep connector search/spool canaries

## Verification
- 574 Python tests and 3 launcher tests pass
- fresh-PostgreSQL Grep connector E2E passes with zero canary search hits and zero raw spool bytes
- no transcripts, live cascade evidence, private paths, or real credentials are included