### PR TITLE
docs(parable): isolate GPT matrix requests

### DIFF
--- a/parable/docs/LOOP_CHAIN_2026-07-20-gpt-model-effort-matrix.md
+++ b/parable/docs/LOOP_CHAIN_2026-07-20-gpt-model-effort-matrix.md
@@ -66,8 +66,10 @@ Runtime protocol:
 - The existing user-owned ChatGPT subscription OAuth record; no OpenAI API key.
 - `parable claude` from current merged `main`, using a temporary clean repository
   and a credential-free TOML per model.
-- `--safe-mode --no-session-persistence` for text cells so background title
-  generation cannot masquerade as the requested cell.
+- `--safe-mode --no-session-persistence --name <unique-cell-id>` for text
+  cells. Runtime instrumentation proved that `--no-session-persistence` alone
+  still generates a title request; an explicit `--name` suppresses it so one
+  invocation produces one attributable model request.
 - One deterministic tool-using canary per model at `medium`, separate from the
   text matrix, to preserve harness/tool coverage without multiplying tool calls
   across all fifteen effort cells.

--- a/parable/docs/evidence/g0-gpt-matrix-contract/EXIT.md
+++ b/parable/docs/evidence/g0-gpt-matrix-contract/EXIT.md
@@ -44,8 +44,10 @@ mapping, or credential handling to Parable.
 2. Five installed-CLI effort inputs plus required wire fields — ✅
    `contract.json` records `low`, `medium`, `high`, `xhigh`, `max`,
    `output_config.effort`, and `reasoning.effort`.
-3. Background/title requests cannot masquerade as cells — ✅ the chain runtime
-   protocol requires `--safe-mode --no-session-persistence` and a fresh
+3. Background/title requests cannot masquerade as cells — ✅ corrected after
+   the first G1 instrument pilot: `--no-session-persistence` alone still emitted
+   a title request, while adding a unique `--name` yielded exactly one request.
+   The chain and `contract.json` now require all three flags plus a fresh
    invocation per cell.
 4. Existing tests pass — ✅ 81/81 with an isolated temporary HOME at baseline
    `11249c32306ceb94ae5bc1875ec18cc58a31ff09`.
@@ -67,3 +69,11 @@ or reliability claim is made.
 After PR #140 is merged and verified at `main`, run all fifteen live text cells
 and three representative medium-effort tool canaries. Record every clamp,
 mapping, omission, or failure honestly.
+
+### Post-exit instrument correction (2026-07-20)
+
+The first G1 pilot falsified the original assumption that
+`--no-session-persistence` suppresses AI title generation. It does not. A
+second pilot with an explicit unique `--name` produced one attributable request
+instead of two. The contract was corrected before any pilot was admitted as a
+matrix result; neither pilot consumed a G1 evidence attempt.

--- a/parable/docs/evidence/g0-gpt-matrix-contract/contract.json
+++ b/parable/docs/evidence/g0-gpt-matrix-contract/contract.json
@@ -39,7 +39,8 @@
     "translated_evidence_field": "reasoning.effort",
     "background_request_controls": [
       "--safe-mode",
-      "--no-session-persistence"
+      "--no-session-persistence",
+      "--name <unique-cell-id>"
     ]
   },
   "source_binary_drift_hazard": {
@@ -54,6 +55,12 @@
     ],
     "source_documents_max_clamping": true,
     "resolution": "Runtime wire evidence decides every G1 cell."
+  },
+  "post_exit_instrument_correction": {
+    "observed": "--no-session-persistence still emitted a separate title request.",
+    "repair": "Add an explicit unique --name to suppress title generation.",
+    "pilot_without_name_request_logs": 2,
+    "pilot_with_name_request_logs": 1
   },
   "baseline_tests": {
     "total": 81,


### PR DESCRIPTION
## Instrument correction

The first G1 pilot falsified one G0 assumption: `--no-session-persistence` still allows Claude Code to generate a separate AI session-title request.

An explicit unique `--name` suppresses that request:

- without `--name`: two request logs (matrix request + title request)
- with `--name`: one attributable request log

This patch corrects the contract before any pilot is admitted as matrix evidence. No model/effort result is being claimed here.
