### PR TITLE
docs(parable): record live GPT model and effort matrix

### DIFF
--- a/parable/docs/evidence/g1-gpt-model-effort-live/EXIT.md
+++ b/parable/docs/evidence/g1-gpt-model-effort-live/EXIT.md
@@ -1,0 +1,84 @@
+# G1 — LIVE MODEL × EFFORT MATRIX · EXIT (2026-07-20)
+
+## Status: COMPLETE
+
+## The headline evidence
+
+Sol, Terra, and Luna each completed all five stock Claude Code effort
+invocations through CLIProxyAPI and ChatGPT subscription OAuth. All 15 text
+cells exited zero, returned their exact synthetic marker, produced one
+attributable model request, and carried the requested value into
+`output_config.effort`.
+
+The effort control is not end-to-end in CLIProxyAPI `v7.2.88`: all 15
+translated GPT requests used `reasoning.effort=medium`. The three requested
+`medium` cells are exact pass-through; the other twelve are mappings to
+`medium`. Each model also completed a real medium-effort Bash tool round-trip
+and produced an independently verified artifact.
+
+## What shipped
+
+| Piece | Where |
+|---|---|
+| Sanitized 15-cell and 3-canary scoreboard | `docs/evidence/g1-gpt-model-effort-live/receipt.json` |
+| Version-pinned translator diagnosis | `docs/evidence/g1-gpt-model-effort-live/mechanism.md` |
+| OSS-facing version caveat | `skills/parable/references/providers.md` |
+
+## Bound accounting (honest)
+
+- Correctly wired text attempts: 15, one per cell; all passed within the
+  two-attempt bound.
+- Correctly wired tool attempts: 3, one per model; all passed.
+- Evidence failures: 0.
+- Mechanism diagnostic: one additional Sol/low invocation with
+  `CLAUDE_CODE_ALWAYS_ENABLE_EFFORT=1`; it passed but still omitted `thinking`
+  and translated to `medium`.
+- Review rounds: 1. Receipt invariants, JSON parsing, content/credential scan,
+  `git diff --check`, 81 tests, and GitHub mergeability had no findings. PR
+  #142 reported no configured checks or reviewer.
+- Instrument correction: the first tool result parser expected one proxy log,
+  but a successful tool round-trip correctly creates two model requests (tool
+  selection and post-tool continuation). The two logs per canary were grouped
+  by the bounded invocation window and parsed through the same safe-field
+  filter. No rerun or evidence attempt was consumed.
+
+ZEN check: the result is a declarative scoreboard and a source-pinned
+diagnosis. Parable gains no provider-specific effort shim, credential path, or
+regex routing rule. The proposed repair remains at the general protocol
+translation boundary where it belongs.
+
+## Acceptance criteria → evidence
+
+1. All 15 cells have requested, inbound, and upstream effort plus a successful
+   synthetic hash — ✅ `receipt.json` contains 15 non-null cells; every exit
+   code is zero, every deterministic check is true, and every stream completed.
+2. One medium-effort tool canary per model — ✅ three of three artifacts passed
+   independent content and SHA-256 verification; each canary's two model
+   requests returned HTTP 200.
+3. OAuth routing with no direct provider key — ✅ every parsed request used the
+   Codex OAuth route, while `OPENAI_API_KEY` and `ANTHROPIC_API_KEY` were unset;
+   no provider key, OAuth token, or proxy key is committed.
+4. Exact pass-through is distinguished from mapping — ✅ the receipt records
+   15/15 requested-to-inbound exact, 3/15 requested-to-upstream exact, and the
+   explicit `low|medium|high|xhigh|max → medium` mapping.
+5. Full tests and focused merged PR — ✅ 81/81 tests pass in an isolated HOME;
+   [PR #142](https://github.com/miguelrios/unc-skills/pull/142) is the focused
+   merge.
+
+## The running delta table
+
+| Loop | Sol text | Terra text | Luna text | Exact upstream effort | Tool canaries | Kimi P2 |
+|---|---:|---:|---:|---:|---:|---:|
+| G0 | catalog only | catalog only | catalog only | not run | 0/3 | PAUSED |
+| G1 | 5/5 | 5/5 | 5/5 | 3/15 (`medium` only) | 3/3 | PAUSED |
+
+MEASURE for G1 is transport and wire fidelity. It makes no comparative model
+quality, latency, token-use, or long-session reliability claim.
+
+## exit → G2
+
+At the re-plan gate, present the honest product verdict and ask the user to
+choose the successor: patch CLIProxyAPI and repeat this matrix, prove a GPT
+parent calling a named GPT subagent, or run repeated reliability canaries.
+Kimi remains explicitly paused until subscriptions reopen and the operator
+resumes it.

--- a/parable/docs/evidence/g1-gpt-model-effort-live/mechanism.md
+++ b/parable/docs/evidence/g1-gpt-model-effort-live/mechanism.md
@@ -1,0 +1,41 @@
+# Why every requested effort became `medium`
+
+This diagnosis is version-pinned. It describes stock Claude Code `2.1.215`
+talking to CLIProxyAPI `v7.2.88` at commit
+`93d74a890a44802f656d7f39a573916b2611896e`.
+
+The fifteen live invocations all carried the requested value in the inbound
+Anthropic-shaped `output_config.effort` field. None carried a `thinking`
+object. CLIProxyAPI's pinned Claude-to-Codex translator initializes
+`reasoning.effort` to `medium`, then reads `output_config.effort` only inside
+the `thinking.type == adaptive || auto` branch:
+
+- [pinned translator, lines 312–341](https://github.com/router-for-me/CLIProxyAPI/blob/93d74a890a44802f656d7f39a573916b2611896e/internal/translator/codex/claude/codex_claude_request.go#L312-L341)
+- source SHA-256:
+  `85559604a0da1bd57f537baf007d46ab223e32392111763f2cf81cda341a8a74`
+
+That makes the observed mapping deterministic:
+
+| Claude Code `--effort` | Inbound `output_config.effort` | Upstream GPT `reasoning.effort` |
+|---|---|---|
+| `low` | `low` | `medium` |
+| `medium` | `medium` | `medium` |
+| `high` | `high` | `medium` |
+| `xhigh` | `xhigh` | `medium` |
+| `max` | `max` | `medium` |
+
+Setting the original alias's
+`CLAUDE_CODE_ALWAYS_ENABLE_EFFORT=1` did not change the wire shape in a
+separate Sol/low diagnostic: the request still omitted `thinking`, and the
+translated request still used `medium`.
+
+This is a translator compatibility gap, not a model-routing failure. The
+smallest general repair belongs in CLIProxyAPI: when a Claude request contains
+a valid top-level `output_config.effort`, the Claude-to-Codex translator should
+use it even when the third-party model id causes Claude Code to omit
+`thinking`. That repair needs translator unit tests and a repeat of this exact
+15-cell matrix before any non-medium effort is documented as effective.
+
+No raw prompt, response, proxy log, credential, or local private path is
+published here. The sanitized receipt contains only routing fields, status
+codes, deterministic hashes, runtime pins, and aggregate counts.

--- a/parable/docs/evidence/g1-gpt-model-effort-live/receipt.json
+++ b/parable/docs/evidence/g1-gpt-model-effort-live/receipt.json
@@ -1,0 +1,317 @@
+{
+  "schema_version": 1,
+  "loop": "G1",
+  "captured_interval_utc": {
+    "started": "2026-07-20T03:38:23Z",
+    "finished": "2026-07-20T03:39:31Z"
+  },
+  "baseline_head": "b292d38b4e4d47c44e4b40460688dad8f71cbe3c",
+  "runtime": {
+    "parable_version": "0.1.9",
+    "claude_code_version": "2.1.215",
+    "cliproxyapi_release": "v7.2.88",
+    "cliproxyapi_commit": "93d74a890a44802f656d7f39a573916b2611896e",
+    "cliproxyapi_binary_sha256": "8d1bce338662629e51e81a5cdbb8cd61f7755d5bc5a3c087b8fda9a3c9791238",
+    "loopback_only": true
+  },
+  "summary": {
+    "models": 3,
+    "requested_efforts": 5,
+    "text_cells": 15,
+    "successful_text_cells": 15,
+    "requested_to_inbound_exact": 15,
+    "requested_to_upstream_exact": 3,
+    "upstream_effort_counts": {
+      "medium": 15
+    },
+    "successful_tool_canaries": 3,
+    "tool_canaries": 3
+  },
+  "invocation_contract": {
+    "harness": "stock Claude Code launched by parable claude",
+    "flags": [
+      "--safe-mode",
+      "--no-session-persistence",
+      "--name <unique-cell-id>",
+      "-p",
+      "--effort <requested>",
+      "--tools="
+    ],
+    "text_requests_per_cell": 1,
+    "direct_provider_api_keys_unset": [
+      "OPENAI_API_KEY",
+      "ANTHROPIC_API_KEY"
+    ],
+    "matrix_inherited_claude_code_always_enable_effort": false
+  },
+  "effort_mapping": {
+    "low": "medium",
+    "medium": "medium",
+    "high": "medium",
+    "xhigh": "medium",
+    "max": "medium"
+  },
+  "cells": [
+    {
+      "model": "gpt-5.6-sol",
+      "requested_effort": "low",
+      "inbound_effort": "low",
+      "upstream_effort": "medium",
+      "upstream_exact": false,
+      "exit_code": 0,
+      "http_statuses": [200, 200],
+      "request_count": 1,
+      "stream_completed": true,
+      "deterministic_check": true,
+      "synthetic_marker_sha256": "4942da4dc0d36e12787f1d824328c1783fce1d332a3b3f2601c59870fe89a9b7"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "requested_effort": "medium",
+      "inbound_effort": "medium",
+      "upstream_effort": "medium",
+      "upstream_exact": true,
+      "exit_code": 0,
+      "http_statuses": [200, 200],
+      "request_count": 1,
+      "stream_completed": true,
+      "deterministic_check": true,
+      "synthetic_marker_sha256": "affe3b846e425c3e325b4ab1b8aa4b1020696aab3f6c019eefddc4fd1777f142"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "requested_effort": "high",
+      "inbound_effort": "high",
+      "upstream_effort": "medium",
+      "upstream_exact": false,
+      "exit_code": 0,
+      "http_statuses": [200, 200],
+      "request_count": 1,
+      "stream_completed": true,
+      "deterministic_check": true,
+      "synthetic_marker_sha256": "c2a46432605ff9795cded8c06bbeaade9b57996104e980338f3eac8ea61f1b17"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "requested_effort": "xhigh",
+      "inbound_effort": "xhigh",
+      "upstream_effort": "medium",
+      "upstream_exact": false,
+      "exit_code": 0,
+      "http_statuses": [200, 200],
+      "request_count": 1,
+      "stream_completed": true,
+      "deterministic_check": true,
+      "synthetic_marker_sha256": "354f50c5fbca52ceee003a42515da21d6cdb79ede73ddfbe71b22f2d17e02ff6"
+    },
+    {
+      "model": "gpt-5.6-sol",
+      "requested_effort": "max",
+      "inbound_effort": "max",
+      "upstream_effort": "medium",
+      "upstream_exact": false,
+      "exit_code": 0,
+      "http_statuses": [200, 200],
+      "request_count": 1,
+      "stream_completed": true,
+      "deterministic_check": true,
+      "synthetic_marker_sha256": "1e84a7994bb2f0f89e33a1b73aad6a6797833a6b5509141cd9d82748944e5445"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "requested_effort": "low",
+      "inbound_effort": "low",
+      "upstream_effort": "medium",
+      "upstream_exact": false,
+      "exit_code": 0,
+      "http_statuses": [200, 200],
+      "request_count": 1,
+      "stream_completed": true,
+      "deterministic_check": true,
+      "synthetic_marker_sha256": "bd3aa18de0bab791e888c9033ecf87b1906fafba2010f9f66c794db1d29478c3"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "requested_effort": "medium",
+      "inbound_effort": "medium",
+      "upstream_effort": "medium",
+      "upstream_exact": true,
+      "exit_code": 0,
+      "http_statuses": [200, 200],
+      "request_count": 1,
+      "stream_completed": true,
+      "deterministic_check": true,
+      "synthetic_marker_sha256": "f12b576e3974bab5da44db19bd36a29f43840601c3323b78ac198be6be08c725"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "requested_effort": "high",
+      "inbound_effort": "high",
+      "upstream_effort": "medium",
+      "upstream_exact": false,
+      "exit_code": 0,
+      "http_statuses": [200, 200],
+      "request_count": 1,
+      "stream_completed": true,
+      "deterministic_check": true,
+      "synthetic_marker_sha256": "b6fda5551faf221f02a436346333958203f9458be610106a1ce6c28ede25a2a5"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "requested_effort": "xhigh",
+      "inbound_effort": "xhigh",
+      "upstream_effort": "medium",
+      "upstream_exact": false,
+      "exit_code": 0,
+      "http_statuses": [200, 200],
+      "request_count": 1,
+      "stream_completed": true,
+      "deterministic_check": true,
+      "synthetic_marker_sha256": "57dd936b5231da92a10e4d90668876534b38088002fde8238988466a11f9d2e5"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "requested_effort": "max",
+      "inbound_effort": "max",
+      "upstream_effort": "medium",
+      "upstream_exact": false,
+      "exit_code": 0,
+      "http_statuses": [200, 200],
+      "request_count": 1,
+      "stream_completed": true,
+      "deterministic_check": true,
+      "synthetic_marker_sha256": "77d1cc385387b5f7c3c8154ed9b1417f755112211b8fa58d16bd562ec8ca56a6"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "requested_effort": "low",
+      "inbound_effort": "low",
+      "upstream_effort": "medium",
+      "upstream_exact": false,
+      "exit_code": 0,
+      "http_statuses": [200, 200],
+      "request_count": 1,
+      "stream_completed": true,
+      "deterministic_check": true,
+      "synthetic_marker_sha256": "867dce3f334258bc92fbfc67843342e3f4e36c8473f7c2d8d436a1619532c03a"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "requested_effort": "medium",
+      "inbound_effort": "medium",
+      "upstream_effort": "medium",
+      "upstream_exact": true,
+      "exit_code": 0,
+      "http_statuses": [200, 200],
+      "request_count": 1,
+      "stream_completed": true,
+      "deterministic_check": true,
+      "synthetic_marker_sha256": "cff1c9645b2d8055597ded13c25e86ea0a9041863a7938dd67c908b6735a5c11"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "requested_effort": "high",
+      "inbound_effort": "high",
+      "upstream_effort": "medium",
+      "upstream_exact": false,
+      "exit_code": 0,
+      "http_statuses": [200, 200],
+      "request_count": 1,
+      "stream_completed": true,
+      "deterministic_check": true,
+      "synthetic_marker_sha256": "ccee16281454bffa48cc08dda1fe2944fa1993cf567d1f6680da04a88f823bc3"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "requested_effort": "xhigh",
+      "inbound_effort": "xhigh",
+      "upstream_effort": "medium",
+      "upstream_exact": false,
+      "exit_code": 0,
+      "http_statuses": [200, 200],
+      "request_count": 1,
+      "stream_completed": true,
+      "deterministic_check": true,
+      "synthetic_marker_sha256": "88f7d94f1f17f42607dbc9984e0c3ac5d3e1bdea665d2d9227be13e5a55959dc"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "requested_effort": "max",
+      "inbound_effort": "max",
+      "upstream_effort": "medium",
+      "upstream_exact": false,
+      "exit_code": 0,
+      "http_statuses": [200, 200],
+      "request_count": 1,
+      "stream_completed": true,
+      "deterministic_check": true,
+      "synthetic_marker_sha256": "7ac01532632334ae84f9282b544fe2dae6bf47815cf30e213dfbbbf594c68f2b"
+    }
+  ],
+  "tool_canaries": [
+    {
+      "model": "gpt-5.6-sol",
+      "requested_effort": "medium",
+      "inbound_efforts": ["medium", "medium"],
+      "upstream_efforts": ["medium", "medium"],
+      "request_count": 2,
+      "exit_code": 0,
+      "http_statuses": [200, 200, 200, 200],
+      "codex_oauth_route": true,
+      "deterministic_check": true,
+      "artifact_sha256": "0087fb9607a21f2026ec3c21bc2e2b98cda2744f82cf8567e0c8474d7ae006da"
+    },
+    {
+      "model": "gpt-5.6-terra",
+      "requested_effort": "medium",
+      "inbound_efforts": ["medium", "medium"],
+      "upstream_efforts": ["medium", "medium"],
+      "request_count": 2,
+      "exit_code": 0,
+      "http_statuses": [200, 200, 200, 200],
+      "codex_oauth_route": true,
+      "deterministic_check": true,
+      "artifact_sha256": "ca14bfb26c4953346d597036a9f13d6f79e0a83ae8343b0d3478177142ab51c8"
+    },
+    {
+      "model": "gpt-5.6-luna",
+      "requested_effort": "medium",
+      "inbound_efforts": ["medium", "medium"],
+      "upstream_efforts": ["medium", "medium"],
+      "request_count": 2,
+      "exit_code": 0,
+      "http_statuses": [200, 200, 200, 200],
+      "codex_oauth_route": true,
+      "deterministic_check": true,
+      "artifact_sha256": "82354ccc6fa6b22d89d4080b99769b86afb21d888a56148eef45351543312876"
+    }
+  ],
+  "mechanism_diagnostics": {
+    "matrix_inbound_thinking_object_present_count": 0,
+    "matrix_inbound_output_config_effort_present_count": 15,
+    "always_enable_effort_pilot": {
+      "model": "gpt-5.6-sol",
+      "requested_effort": "low",
+      "environment_value": "1",
+      "inbound_effort": "low",
+      "inbound_thinking_object_present": false,
+      "upstream_effort": "medium",
+      "exit_code": 0,
+      "http_statuses": [200, 200],
+      "deterministic_check": true
+    },
+    "pinned_translator_source": {
+      "url": "https://github.com/router-for-me/CLIProxyAPI/blob/93d74a890a44802f656d7f39a573916b2611896e/internal/translator/codex/claude/codex_claude_request.go#L312-L341",
+      "sha256": "85559604a0da1bd57f537baf007d46ab223e32392111763f2cf81cda341a8a74",
+      "observed_contract": "reasoning.effort defaults to medium; output_config.effort is read only inside thinking.type adaptive or auto"
+    }
+  },
+  "safety": {
+    "auth_kind": "ChatGPT subscription OAuth via CLIProxyAPI",
+    "all_model_requests_used_codex_oauth_route": true,
+    "direct_provider_api_key_used": false,
+    "credential_material_committed": false,
+    "raw_prompt_or_response_committed": false,
+    "raw_proxy_log_committed": false
+  }
+}

--- a/parable/skills/parable/references/providers.md
+++ b/parable/skills/parable/references/providers.md
@@ -179,6 +179,24 @@ every agent's own `model:` field and would otherwise silently route all children
 The proxy owns provider OAuth. Parable stores no provider credential and does not implement an
 OAuth flow.
 
+### Verified GPT effort caveat
+
+With stock Claude Code `2.1.215` and CLIProxyAPI `v7.2.88`, Sol, Terra, and
+Luna all complete text and tool-using requests through ChatGPT subscription
+OAuth. However, only `medium` is currently effective upstream. Claude Code
+sends every explicit `--effort` as `output_config.effort` for these exact
+third-party model ids but omits the `thinking` object; CLIProxyAPI's
+Claude-to-Codex translator therefore defaults every request to
+`reasoning.effort=medium`. Setting
+`CLAUDE_CODE_ALWAYS_ENABLE_EFFORT=1` does not change that wire shape.
+
+Treat `low`, `high`, `xhigh`, and `max` as accepted-but-not-effective for this
+version pair. Do not infer GPT effort from the Claude CLI flag. See the
+[sanitized live receipt](../../../docs/evidence/g1-gpt-model-effort-live/receipt.json)
+and [mechanism diagnosis](../../../docs/evidence/g1-gpt-model-effort-live/mechanism.md).
+Exact non-medium control requires a CLIProxyAPI translator fix followed by a
+repeat of the live matrix.
+
 ## Reading subscription headroom (parable-usage.sh)
 
 Each subscription pool publishes its own remaining headroom over an authenticated endpoint the


### PR DESCRIPTION
## Outcome

Records the G1 live proof for Sol, Terra, and Luna through stock Claude Code, CLIProxyAPI, and ChatGPT subscription OAuth.

- 15/15 deterministic text cells passed
- 3/3 medium-effort tool canaries passed
- all requested efforts reached the proxy unchanged
- CLIProxyAPI v7.2.88 translated every request to upstream `medium`; only 3/15 cells were exact
- `CLAUDE_CODE_ALWAYS_ENABLE_EFFORT=1` did not change the wire shape
- adds a version-pinned mechanism diagnosis and provider documentation warning

No raw prompts, responses, logs, credentials, or private paths are committed.

## Verification

- `python3 -m unittest discover -s parable/tests -v` — 81/81 pass
- receipt invariants checked with `jq`
- staged credential/content safety scan clean
- `git diff --check` clean