### PR TITLE
feat(recall): add immutable Cloudflare R2 archive

### DIFF
--- a/recall/server/deploy/README.md
+++ b/recall/server/deploy/README.md
@@ -139,9 +139,31 @@ PLANETSCALE_SERVICE_TOKEN
 RENDER_API_KEY
 RECALL_DATABASE_URL
 RECALL_EMBEDDING_API_KEY
+RECALL_ARCHIVE_ACCESS_KEY_ID
+RECALL_ARCHIVE_SECRET_ACCESS_KEY
+RECALL_ARCHIVE_NAMESPACE_KEY
 TAILSCALE_OAUTH_CLIENT_ID
 TAILSCALE_OAUTH_CLIENT_SECRET
 ```
+
+For a managed Cloudflare R2 raw archive, also set the non-secret configuration:
+
+```text
+RECALL_ARCHIVE_BACKEND=r2
+RECALL_ARCHIVE_BUCKET=recall-raw-owner
+RECALL_ARCHIVE_ENDPOINT_URL=https://ACCOUNT_ID.r2.cloudflarestorage.com
+RECALL_ARCHIVE_REGION=auto
+```
+
+The R2 credential must have Object Read & Write permission for that bucket only.
+`RECALL_ARCHIVE_NAMESPACE_KEY` is a separate base64-encoded 32-byte random key;
+do not derive it from either R2 credential. Recall uses immutable opaque object
+keys and conditional writes because R2 does not expose S3 object version IDs.
+R2 rejects S3 SSE headers and applies provider-managed encryption automatically.
+Recall does not read a Cloudflare management API token. Validate the configured
+archive with `python -m recall_server.cli archive-check`; the probe writes,
+replays, reads, deletes, and verifies absence using synthetic bytes, then emits
+only a content-free status.
 
 `RECALL_DATABASE_URL` must be a PlanetScale application role URL with
 `sslmode=verify-full` and an explicit trust root. Prefer

--- a/recall/server/deploy/service.env.example
+++ b/recall/server/deploy/service.env.example
@@ -3,6 +3,15 @@ RECALL_AUTH_REQUIRED=1
 RECALL_TRUST_TAILSCALE_HEADERS=1
 RECALL_TRUSTED_PROXY_UIDS=0,65534
 RECALL_ALLOWED_TAILSCALE_USERS=owner@example.com
+# Private raw archive. Keep the bucket private and scope the S3 credential to it.
+# RECALL_ARCHIVE_BACKEND=r2
+# RECALL_ARCHIVE_BUCKET=recall-raw-owner
+# RECALL_ARCHIVE_ENDPOINT_URL=https://ACCOUNT_ID.r2.cloudflarestorage.com
+# RECALL_ARCHIVE_REGION=auto
+# RECALL_ARCHIVE_ACCESS_KEY_ID is injected by the deployment secret manager.
+# RECALL_ARCHIVE_SECRET_ACCESS_KEY is injected by the deployment secret manager.
+# RECALL_ARCHIVE_NAMESPACE_KEY is an independent base64-encoded 32-byte secret.
+# Cloudflare management API tokens are neither required nor read by Recall.
 # Browser MCP clients must match this exact comma-separated allow-list.
 # Non-browser agent clients normally omit Origin.
 # RECALL_MCP_ALLOWED_ORIGINS=https://approved-agent.example

--- a/recall/server/recall_server/archive.py
+++ b/recall/server/recall_server/archive.py
@@ -20,6 +20,9 @@ DEFAULT_MAXIMUM_BYTES = 64 * 1024 * 1024
 IDENTITY_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9:._/@+-]{1,255}")
 MEDIA_TYPE_RE = re.compile(r"[a-z0-9][a-z0-9.+-]{0,63}/[a-z0-9][a-z0-9.+-]{0,127}")
 BUCKET_RE = re.compile(r"[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]")
+R2_HOST_RE = re.compile(
+    r"[0-9a-f]{32}\.(?:(?:eu|fedramp)\.)?r2\.cloudflarestorage\.com"
+)
 SHA256_RE = re.compile(r"[0-9a-f]{64}")
 OBJECT_KEY_RE = re.compile(r"objects/[0-9a-f]{2}/[0-9a-f]{64}")
 ARTIFACT_ID_RE = re.compile(r"art_[0-9a-f]{32}")
@@ -483,6 +486,7 @@ class S3ArchiveStore(_ArchiveStore):
         client: S3Client,
         maximum_bytes: int = DEFAULT_MAXIMUM_BYTES,
         kms_key_id: str | None = None,
+        compatibility_profile: str = "aws",
     ) -> None:
         super().__init__(namespace_key=namespace_key, maximum_bytes=maximum_bytes)
         parsed = urlsplit(endpoint_url)
@@ -490,15 +494,63 @@ class S3ArchiveStore(_ArchiveStore):
             raise ValueError("S3 endpoint must use credential-free HTTPS")
         if parsed.query or parsed.fragment:
             raise ValueError("S3 endpoint must use credential-free HTTPS")
+        if compatibility_profile not in {"aws", "r2"}:
+            raise ValueError("S3 compatibility profile is invalid")
+        if compatibility_profile == "r2" and (
+            not R2_HOST_RE.fullmatch(parsed.hostname)
+            or parsed.port is not None
+            or parsed.path not in {"", "/"}
+        ):
+            raise ValueError("R2 endpoint is invalid")
         if not BUCKET_RE.fullmatch(bucket):
             raise ValueError("S3 bucket is invalid")
         if kms_key_id is not None and (not isinstance(kms_key_id, str) or not kms_key_id):
             raise ValueError("S3 KMS key is invalid")
+        if compatibility_profile == "r2" and kms_key_id is not None:
+            raise ValueError("R2 does not support an S3 KMS key")
         self.bucket = bucket
         self.endpoint_url = endpoint_url
         self.client = client
         self.kms_key_id = kms_key_id
+        self.compatibility_profile = compatibility_profile
         self.encryption = "sse-kms" if kms_key_id else "sse-s3"
+
+    def _version_id(self, content_sha256: str, response: dict[str, Any]) -> str:
+        if self.compatibility_profile == "r2":
+            return "r2-sha256-" + content_sha256
+        version_id = response.get("VersionId")
+        if not isinstance(version_id, str) or not version_id:
+            raise ArchiveError("archive bucket versioning is required")
+        return version_id
+
+    def _version_kwargs(self, reference: ArtifactReference) -> dict[str, str]:
+        if self.compatibility_profile != "r2":
+            return {"VersionId": reference.version_id}
+        expected = "r2-sha256-" + reference.content_sha256
+        if not hmac.compare_digest(reference.version_id, expected):
+            raise ArchiveNotFound("archive object not found")
+        return {}
+
+    def _existing_reference(
+        self,
+        request: ArchiveRequest,
+        *,
+        content_sha256: str,
+        size_bytes: int,
+        response: dict[str, Any],
+    ) -> ArtifactReference:
+        reference = self._reference(
+            request,
+            content_sha256=content_sha256,
+            size_bytes=size_bytes,
+            version_id=self._version_id(content_sha256, response),
+        )
+        if (
+            response.get("ContentLength") != size_bytes
+            or response.get("Metadata") != _metadata(reference)
+        ):
+            raise ArchiveCorruption("archive object conflicts with existing version")
+        return reference
 
     def put_stream(
         self,
@@ -528,40 +580,71 @@ class S3ArchiveStore(_ArchiveStore):
         except Exception as error:
             raise ArchiveError("archive provider request failed") from error
         else:
-            version_id = existing.get("VersionId")
-            reference = self._reference(
+            return self._existing_reference(
                 request,
                 content_sha256=content_sha256,
                 size_bytes=size_bytes,
-                version_id=version_id,
+                response=existing,
             )
-            if isinstance(version_id, str) and version_id and existing.get("Metadata") == _metadata(reference):
-                return reference
-            raise ArchiveCorruption("archive object conflicts with existing version")
         kwargs: dict[str, Any] = {
             "Bucket": self.bucket,
             "Key": pending.object_key,
             "Body": payload,
             "ContentLength": size_bytes,
             "ContentType": request.media_type,
-            "ServerSideEncryption": "aws:kms" if self.kms_key_id else "AES256",
             "Metadata": _metadata(pending),
-            "ChecksumSHA256": b64encode(hashlib.sha256(payload).digest()).decode(),
         }
-        if self.kms_key_id:
-            kwargs["SSEKMSKeyId"] = self.kms_key_id
+        if self.compatibility_profile == "r2":
+            # R2 encrypts every object at rest but rejects S3 SSE and VersionId
+            # headers. The opaque key is immutable and the conditional write
+            # prevents a concurrent overwrite.
+            kwargs["IfNoneMatch"] = "*"
+        else:
+            kwargs["ServerSideEncryption"] = (
+                "aws:kms" if self.kms_key_id else "AES256"
+            )
+            kwargs["ChecksumSHA256"] = b64encode(
+                hashlib.sha256(payload).digest()
+            ).decode()
+            if self.kms_key_id:
+                kwargs["SSEKMSKeyId"] = self.kms_key_id
         try:
             response = self.client.put_object(**kwargs)
         except Exception as error:
+            if self.compatibility_profile == "r2":
+                try:
+                    existing = self.client.head_object(
+                        Bucket=self.bucket, Key=pending.object_key,
+                    )
+                    return self._existing_reference(
+                        request,
+                        content_sha256=content_sha256,
+                        size_bytes=size_bytes,
+                        response=existing,
+                    )
+                except ArchiveCorruption:
+                    raise
+                except Exception:
+                    pass
             raise ArchiveError("archive provider request failed") from error
-        version_id = response.get("VersionId")
-        if not isinstance(version_id, str) or not version_id:
-            raise ArchiveError("archive bucket versioning is required")
-        return self._reference(
+        if self.compatibility_profile != "r2":
+            return self._reference(
+                request,
+                content_sha256=content_sha256,
+                size_bytes=size_bytes,
+                version_id=self._version_id(content_sha256, response),
+            )
+        try:
+            stored = self.client.head_object(
+                Bucket=self.bucket, Key=pending.object_key,
+            )
+        except Exception as error:
+            raise ArchiveError("archive provider request failed") from error
+        return self._existing_reference(
             request,
             content_sha256=content_sha256,
             size_bytes=size_bytes,
-            version_id=version_id,
+            response=stored,
         )
 
     def read(
@@ -573,11 +656,12 @@ class S3ArchiveStore(_ArchiveStore):
     ) -> bytes:
         self._validate_reference(reference)
         self._authorize(reference, tenant_id=tenant_id, source_id=source_id)
+        version_kwargs = self._version_kwargs(reference)
         try:
             response = self.client.get_object(
                 Bucket=self.bucket,
                 Key=reference.object_key,
-                VersionId=reference.version_id,
+                **version_kwargs,
             )
         except ArchiveNotFound:
             raise
@@ -604,21 +688,25 @@ class S3ArchiveStore(_ArchiveStore):
     ) -> bool:
         self._validate_reference(reference)
         self._authorize(reference, tenant_id=tenant_id, source_id=source_id)
+        version_kwargs = self._version_kwargs(reference)
         try:
-            self.client.head_object(
+            existing = self.client.head_object(
                 Bucket=self.bucket,
                 Key=reference.object_key,
-                VersionId=reference.version_id,
+                **version_kwargs,
             )
         except ArchiveNotFound:
             return False
         except Exception as error:
             raise ArchiveError("archive provider request failed") from error
+        _verify_metadata(reference, existing.get("Metadata"))
+        if existing.get("ContentLength") != reference.size_bytes:
+            raise ArchiveCorruption("archive metadata mismatch")
         try:
             self.client.delete_object(
                 Bucket=self.bucket,
                 Key=reference.object_key,
-                VersionId=reference.version_id,
+                **version_kwargs,
             )
         except Exception as error:
             raise ArchiveError("archive provider request failed") from error

--- a/recall/server/recall_server/archive_runtime.py
+++ b/recall/server/recall_server/archive_runtime.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import base64
+import binascii
+import os
+from collections.abc import Callable, Mapping
+from typing import Any
+
+from .archive import (
+    ArchiveError,
+    ArchiveNotFound,
+    ArchiveRequest,
+    ArtifactReference,
+    S3ArchiveStore,
+)
+
+
+R2_REQUIRED_ENV = (
+    "RECALL_ARCHIVE_BUCKET",
+    "RECALL_ARCHIVE_ENDPOINT_URL",
+    "RECALL_ARCHIVE_REGION",
+    "RECALL_ARCHIVE_ACCESS_KEY_ID",
+    "RECALL_ARCHIVE_SECRET_ACCESS_KEY",
+    "RECALL_ARCHIVE_NAMESPACE_KEY",
+)
+
+
+class BotoS3Client:
+    """Translate provider-specific missing-object errors into the archive contract."""
+
+    def __init__(self, client: Any):
+        self.client = client
+
+    @staticmethod
+    def _missing(error: Exception) -> bool:
+        response = getattr(error, "response", None)
+        if not isinstance(response, dict):
+            return False
+        status = response.get("ResponseMetadata", {}).get("HTTPStatusCode")
+        code = response.get("Error", {}).get("Code")
+        return status == 404 and code in {None, "404", "NotFound", "NoSuchKey"}
+
+    def _call(self, operation: str, **kwargs: Any) -> dict[str, Any]:
+        try:
+            return getattr(self.client, operation)(**kwargs)
+        except Exception as error:
+            if self._missing(error):
+                raise ArchiveNotFound("archive object not found") from None
+            raise
+
+    def put_object(self, **kwargs: Any) -> dict[str, Any]:
+        return self._call("put_object", **kwargs)
+
+    def head_object(self, **kwargs: Any) -> dict[str, Any]:
+        return self._call("head_object", **kwargs)
+
+    def get_object(self, **kwargs: Any) -> dict[str, Any]:
+        return self._call("get_object", **kwargs)
+
+    def delete_object(self, **kwargs: Any) -> dict[str, Any]:
+        return self._call("delete_object", **kwargs)
+
+
+def _required(environment: Mapping[str, str], name: str) -> str:
+    value = environment.get(name)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError("archive configuration is incomplete")
+    return value.strip()
+
+
+def _namespace_key(value: str) -> bytes:
+    try:
+        decoded = base64.b64decode(value, validate=True)
+    except (binascii.Error, ValueError):
+        raise ValueError("archive namespace key is invalid") from None
+    if len(decoded) != 32:
+        raise ValueError("archive namespace key is invalid")
+    return decoded
+
+
+def build_archive_store(
+    environment: Mapping[str, str] | None = None,
+    *,
+    client_factory: Callable[..., Any] | None = None,
+) -> S3ArchiveStore:
+    values = os.environ if environment is None else environment
+    backend = _required(values, "RECALL_ARCHIVE_BACKEND")
+    if backend != "r2":
+        raise ValueError("archive configuration backend is unsupported")
+    configured = {name: _required(values, name) for name in R2_REQUIRED_ENV}
+    if configured["RECALL_ARCHIVE_REGION"] != "auto":
+        raise ValueError("R2 region must be auto")
+    namespace_key = _namespace_key(configured["RECALL_ARCHIVE_NAMESPACE_KEY"])
+
+    if client_factory is None:
+        import boto3
+
+        client_factory = boto3.client
+    client = client_factory(
+        service_name="s3",
+        endpoint_url=configured["RECALL_ARCHIVE_ENDPOINT_URL"],
+        region_name=configured["RECALL_ARCHIVE_REGION"],
+        aws_access_key_id=configured["RECALL_ARCHIVE_ACCESS_KEY_ID"],
+        aws_secret_access_key=configured["RECALL_ARCHIVE_SECRET_ACCESS_KEY"],
+    )
+    return S3ArchiveStore(
+        bucket=configured["RECALL_ARCHIVE_BUCKET"],
+        endpoint_url=configured["RECALL_ARCHIVE_ENDPOINT_URL"],
+        namespace_key=namespace_key,
+        client=BotoS3Client(client),
+        compatibility_profile="r2",
+    )
+
+
+def probe_archive(store: S3ArchiveStore) -> dict[str, Any]:
+    """Exercise the complete private object lifecycle without source content."""
+    payload = os.urandom(32)
+    reference: ArtifactReference | None = None
+    deleted = False
+    try:
+        request = ArchiveRequest(
+            tenant_id="tenant:archive-check",
+            source_id="source:archive-check",
+            native_id="probe:" + os.urandom(16).hex(),
+            media_type="application/octet-stream",
+            payload=payload,
+        )
+        reference = store.put(request)
+        replay = store.put(request)
+        read = store.read(
+            reference,
+            tenant_id=request.tenant_id,
+            source_id=request.source_id,
+        )
+        deleted = store.delete(
+            reference,
+            tenant_id=request.tenant_id,
+            source_id=request.source_id,
+        )
+        if store.delete(
+            reference,
+            tenant_id=request.tenant_id,
+            source_id=request.source_id,
+        ):
+            raise ArchiveError("archive probe failed")
+        try:
+            store.read(
+                reference,
+                tenant_id=request.tenant_id,
+                source_id=request.source_id,
+            )
+        except ArchiveNotFound:
+            absent = True
+        else:
+            absent = False
+        if replay != reference or read != payload or not deleted or not absent:
+            raise ArchiveError("archive probe failed")
+        return {
+            "status": "ok",
+            "backend": store.storage_backend,
+            "write": True,
+            "replay": True,
+            "read": True,
+            "delete": True,
+            "absent": True,
+        }
+    finally:
+        if reference is not None and not deleted:
+            try:
+                store.delete(
+                    reference,
+                    tenant_id="tenant:archive-check",
+                    source_id="source:archive-check",
+                )
+            except ArchiveError:
+                pass

--- a/recall/server/recall_server/cli.py
+++ b/recall/server/recall_server/cli.py
@@ -9,6 +9,8 @@ from pathlib import Path
 
 from . import SCHEMA_VERSION
 from .app import serve, serve_unix
+from .archive import ArchiveError
+from .archive_runtime import build_archive_store, probe_archive
 from .capabilities import CapabilityError, probe_database
 from .db import BrainStore
 from .deployment import DeploymentManifestError, load_manifest, preview
@@ -39,6 +41,7 @@ def main() -> None:
     ap.add_argument("--dsn", default=os.environ.get("RECALL_DATABASE_URL"))
     sub = ap.add_subparsers(dest="command", required=True)
     sub.add_parser("migrate")
+    sub.add_parser("archive-check")
     capability = sub.add_parser("capability-check")
     capability.add_argument(
         "--profile", choices=("production", "local-fixture"), default="production"
@@ -203,6 +206,19 @@ def main() -> None:
             print(
                 json.dumps(
                     {"status": "rejected", "code": "mcp_conformance_failed"}
+                ),
+                file=sys.stderr,
+            )
+            raise SystemExit(2) from None
+        return
+    if args.command == "archive-check":
+        try:
+            print(json.dumps(probe_archive(build_archive_store()), sort_keys=True))
+        except (ArchiveError, ValueError):
+            print(
+                json.dumps(
+                    {"status": "rejected", "code": "archive_check_failed"},
+                    sort_keys=True,
                 ),
                 file=sys.stderr,
             )

--- a/recall/server/requirements.txt
+++ b/recall/server/requirements.txt
@@ -1,3 +1,4 @@
+boto3==1.43.51
 psycopg[binary]==3.3.4
 psycopg-pool==3.3.1
 typing-extensions==4.16.0

--- a/recall/tests/test_archive_runtime.py
+++ b/recall/tests/test_archive_runtime.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import base64
+import unittest
+
+from server.recall_server.archive import ArchiveNotFound, S3ArchiveStore
+from server.recall_server.archive_runtime import build_archive_store, probe_archive
+
+
+class FakeBody:
+    def __init__(self, payload: bytes):
+        self.payload = payload
+        self.offset = 0
+
+    def read(self, size: int) -> bytes:
+        chunk = self.payload[self.offset:self.offset + size]
+        self.offset += len(chunk)
+        return chunk
+
+
+class FakeR2:
+    def __init__(self):
+        self.objects = {}
+
+    def put_object(self, **kwargs):
+        identity = (kwargs["Bucket"], kwargs["Key"])
+        if kwargs.get("IfNoneMatch") == "*" and identity in self.objects:
+            raise RuntimeError("precondition failed")
+        self.objects[identity] = dict(kwargs)
+        return {"ETag": '"synthetic-etag"'}
+
+    def head_object(self, **kwargs):
+        try:
+            value = self.objects[(kwargs["Bucket"], kwargs["Key"])]
+        except KeyError as error:
+            raise ArchiveNotFound("archive object not found") from error
+        return {
+            "ContentLength": value["ContentLength"],
+            "Metadata": value["Metadata"],
+            "ETag": '"synthetic-etag"',
+        }
+
+    def get_object(self, **kwargs):
+        value = self.head_object(**kwargs)
+        stored = self.objects[(kwargs["Bucket"], kwargs["Key"])]
+        return {**value, "Body": FakeBody(stored["Body"])}
+
+    def delete_object(self, **kwargs):
+        self.objects.pop((kwargs["Bucket"], kwargs["Key"]), None)
+        return {}
+
+
+class ArchiveRuntimeTest(unittest.TestCase):
+    def test_r2_environment_builds_a_bucket_scoped_s3_client(self):
+        calls = []
+        client = object()
+        environment = {
+            "RECALL_ARCHIVE_BACKEND": "r2",
+            "RECALL_ARCHIVE_BUCKET": "recall-raw-synthetic",
+            "RECALL_ARCHIVE_ENDPOINT_URL": (
+                "https://0123456789abcdef0123456789abcdef."
+                "r2.cloudflarestorage.com"
+            ),
+            "RECALL_ARCHIVE_REGION": "auto",
+            "RECALL_ARCHIVE_ACCESS_KEY_ID": "synthetic-access-id",
+            "RECALL_ARCHIVE_SECRET_ACCESS_KEY": "synthetic-secret",
+            "RECALL_ARCHIVE_NAMESPACE_KEY": base64.b64encode(b"k" * 32).decode(),
+            "CF_R2_API_TOKEN": "must-not-be-used",
+        }
+
+        def client_factory(**kwargs):
+            calls.append(kwargs)
+            return client
+
+        store = build_archive_store(
+            environment,
+            client_factory=client_factory,
+        )
+
+        self.assertIsInstance(store, S3ArchiveStore)
+        self.assertEqual(store.compatibility_profile, "r2")
+        self.assertIs(store.client.client, client)
+        self.assertEqual(
+            calls,
+            [{
+                "service_name": "s3",
+                "endpoint_url": environment["RECALL_ARCHIVE_ENDPOINT_URL"],
+                "region_name": "auto",
+                "aws_access_key_id": "synthetic-access-id",
+                "aws_secret_access_key": "synthetic-secret",
+            }],
+        )
+        self.assertNotIn("CF_R2_API_TOKEN", calls[0])
+
+    def test_r2_environment_fails_closed_on_missing_or_invalid_values(self):
+        base = {
+            "RECALL_ARCHIVE_BACKEND": "r2",
+            "RECALL_ARCHIVE_BUCKET": "recall-raw-synthetic",
+            "RECALL_ARCHIVE_ENDPOINT_URL": (
+                "https://0123456789abcdef0123456789abcdef."
+                "r2.cloudflarestorage.com"
+            ),
+            "RECALL_ARCHIVE_REGION": "auto",
+            "RECALL_ARCHIVE_ACCESS_KEY_ID": "synthetic-access-id",
+            "RECALL_ARCHIVE_SECRET_ACCESS_KEY": "synthetic-secret",
+            "RECALL_ARCHIVE_NAMESPACE_KEY": base64.b64encode(b"k" * 32).decode(),
+        }
+        for name in base:
+            with self.subTest(name=name):
+                invalid = dict(base)
+                invalid.pop(name)
+                with self.assertRaisesRegex(ValueError, "archive configuration"):
+                    build_archive_store(invalid, client_factory=lambda **_: object())
+
+        invalid_region = {**base, "RECALL_ARCHIVE_REGION": "us-east-1"}
+        with self.assertRaisesRegex(ValueError, "R2 region"):
+            build_archive_store(
+                invalid_region,
+                client_factory=lambda **_: object(),
+            )
+
+        invalid_namespace = {**base, "RECALL_ARCHIVE_NAMESPACE_KEY": "not-base64"}
+        with self.assertRaisesRegex(ValueError, "namespace key"):
+            build_archive_store(
+                invalid_namespace,
+                client_factory=lambda **_: object(),
+            )
+
+    def test_probe_proves_write_replay_read_delete_and_absence(self):
+        client = FakeR2()
+        store = S3ArchiveStore(
+            bucket="recall-synthetic",
+            endpoint_url=(
+                "https://0123456789abcdef0123456789abcdef."
+                "r2.cloudflarestorage.com"
+            ),
+            namespace_key=b"k" * 32,
+            client=client,
+            compatibility_profile="r2",
+        )
+
+        self.assertEqual(
+            probe_archive(store),
+            {
+                "status": "ok",
+                "backend": "s3",
+                "write": True,
+                "replay": True,
+                "read": True,
+                "delete": True,
+                "absent": True,
+            },
+        )
+        self.assertEqual(client.objects, {})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/recall/tests/test_archive_store_v2.py
+++ b/recall/tests/test_archive_store_v2.py
@@ -100,6 +100,51 @@ class FakeS3:
         return {}
 
 
+class FakeR2:
+    def __init__(self):
+        self.objects: dict[tuple[str, str], dict] = {}
+        self.put_calls: list[dict] = []
+        self.get_calls: list[dict] = []
+        self.delete_calls: list[dict] = []
+
+    def put_object(self, **kwargs):
+        self.put_calls.append(kwargs)
+        identity = (kwargs["Bucket"], kwargs["Key"])
+        if kwargs.get("IfNoneMatch") == "*" and identity in self.objects:
+            raise RuntimeError("precondition failed")
+        self.objects[identity] = dict(kwargs)
+        return {"ETag": '"synthetic-etag"'}
+
+    def get_object(self, **kwargs):
+        self.get_calls.append(kwargs)
+        try:
+            value = self.objects[(kwargs["Bucket"], kwargs["Key"])]
+        except KeyError as error:
+            raise ArchiveNotFound("archive object not found") from error
+        return {
+            "Body": FakeBody(value["Body"]),
+            "ContentLength": value["ContentLength"],
+            "Metadata": value["Metadata"],
+            "ETag": '"synthetic-etag"',
+        }
+
+    def head_object(self, **kwargs):
+        try:
+            value = self.objects[(kwargs["Bucket"], kwargs["Key"])]
+        except KeyError as error:
+            raise ArchiveNotFound("archive object not found") from error
+        return {
+            "ContentLength": value["ContentLength"],
+            "Metadata": value["Metadata"],
+            "ETag": '"synthetic-etag"',
+        }
+
+    def delete_object(self, **kwargs):
+        self.delete_calls.append(kwargs)
+        self.objects.pop((kwargs["Bucket"], kwargs["Key"]), None)
+        return {}
+
+
 class ArchiveStoreParityTest(unittest.TestCase):
     def setUp(self) -> None:
         self.key = b"k" * 32
@@ -250,6 +295,48 @@ class ArchiveStoreParityTest(unittest.TestCase):
                 client=self.s3_client,
             )
         self.assertEqual(len(self.s3_client.put_calls), 1)
+
+    def test_r2_uses_immutable_keys_without_unsupported_s3_features(self):
+        client = FakeR2()
+        store = S3ArchiveStore(
+            bucket="recall-synthetic",
+            endpoint_url=(
+                "https://0123456789abcdef0123456789abcdef."
+                "r2.cloudflarestorage.com"
+            ),
+            namespace_key=self.key,
+            client=client,
+            compatibility_profile="r2",
+        )
+
+        first = store.put(request())
+        replay = store.put(request())
+        self.assertEqual(first, replay)
+        self.assertEqual(
+            first.version_id,
+            "r2-sha256-" + hashlib.sha256(PAYLOAD).hexdigest(),
+        )
+        call = client.put_calls[-1]
+        self.assertEqual(call["IfNoneMatch"], "*")
+        self.assertNotIn("ServerSideEncryption", call)
+        self.assertNotIn("ChecksumSHA256", call)
+        self.assertNotIn("ACL", call)
+        self.assertEqual(
+            store.read(first, tenant_id=TENANT, source_id=SOURCE),
+            PAYLOAD,
+        )
+        self.assertNotIn("VersionId", client.get_calls[-1])
+        self.assertTrue(store.delete(first, tenant_id=TENANT, source_id=SOURCE))
+        self.assertNotIn("VersionId", client.delete_calls[-1])
+
+        with self.assertRaisesRegex(ValueError, "R2 endpoint"):
+            S3ArchiveStore(
+                bucket="recall-synthetic",
+                endpoint_url="https://objects.example.test",
+                namespace_key=self.key,
+                client=client,
+                compatibility_profile="r2",
+            )
 
     def test_bounds_are_enforced_before_storage_io(self):
         oversized = b"x" * 1025


### PR DESCRIPTION
Closes the managed-archive foundation in #139.

- supports Cloudflare R2 without unsupported S3 versioning or SSE headers
- uses opaque immutable keys plus conditional writes and end-to-end digest verification
- adds strict environment wiring and a content-free write/replay/read/delete/absence probe
- validates the exact R2 endpoint and ignores Cloudflare management tokens

Verification:
- `npm test` (578 Python tests, 3 Node tests)
- production Python 3.12 Docker image build
- staged gitleaks scan: zero findings

No private source content, transcripts, credentials, or cascade evidence are included.