### PR TITLE
docs(parable): pin CLIProxy effort fidelity successor

### DIFF
--- a/parable/docs/LOOP_CHAIN_2026-07-20-cliproxy-effort-fidelity.md
+++ b/parable/docs/LOOP_CHAIN_2026-07-20-cliproxy-effort-fidelity.md
@@ -172,3 +172,30 @@ comes after live fidelity, so OSS instructions never promise an unproved patch.
 9. Public evidence is synthetic or content-free. Raw logs, prompts, responses,
    credentials, tokens, customer data, and private paths stay out of Git.
 10. Kimi remains paused until the operator explicitly resumes it.
+
+## E0 re-plan note — canonical thinking boundary (2026-07-20)
+
+The required permission check reported no `WRITE`, `MAINTAIN`, or `ADMIN`
+access to `router-for-me/CLIProxyAPI`. Its repository instructions forbid a
+standalone `internal/translator` edit in that state.
+
+Read-only inspection then found the same gate in the canonical thinking
+pipeline: `internal/thinking/extractClaudeConfig` reads
+`output_config.effort` only when `thinking.type` is `adaptive` or `auto`.
+Stock Claude Code's exact third-party GPT model ids send the effort but omit
+`thinking`, so both the canonical extractor and the direct Claude-to-Codex
+translator lose the setting.
+
+E0/E1 are therefore broadened at the genuine architecture boundary:
+
+1. pin one canonical conversion regression and one direct translator
+   regression;
+2. make top-level effort a valid canonical Claude input while preserving
+   explicit disabled/budget/adaptive precedence;
+3. consume that same semantics in the Claude-to-Codex translator;
+4. review the resulting cross-module change, not a standalone translator shim.
+
+The source commit can be made and live-proved locally. Opening an upstream
+issue or PR remains externally blocked because the mandated GitHub App is not
+installed on that repository; no personal-account fallback is permitted. E3
+must report that state honestly unless authorization changes.

--- a/parable/docs/LOOP_CHAIN_2026-07-20-cliproxy-effort-fidelity.md
+++ b/parable/docs/LOOP_CHAIN_2026-07-20-cliproxy-effort-fidelity.md
@@ -1,0 +1,174 @@
+# The Loop Chain — CLIProxyAPI GPT effort fidelity (2026-07-20)
+
+> Successor to the merged G0/G1 model matrix and its G2 human choice: patch the
+> Claude-to-Codex translation boundary, then rerun the same live proof. Each
+> loop has a self-contained prompt, checkable safe evidence, and a hard bound.
+> Raw prompts, responses, proxy logs, credentials, and private paths never
+> enter the repository.
+>
+> **Pacing:** autonomous, with an external-maintainer gate for any upstream
+> CLIProxyAPI merge and a final human re-plan gate.
+
+## Loop anatomy
+
+| Field | Meaning |
+|---|---|
+| `goal` | One sentence describing the state change. |
+| `prompt` | Self-contained execution instructions for a fresh session. |
+| `accept` | Evidence-based exit criteria naming safe, checkable artifacts. |
+| `bound` | Maximum evidence and review iterations before honest escalation. |
+| `exit →` | The next loop triggered by a valid exit. |
+
+## The ribbon
+
+Every loop follows:
+
+```text
+RE-PLAN → BUILD → PIN → PROVE → MEASURE → REVIEW → MERGE → EXIT
+```
+
+The source patch is built in a fresh CLIProxyAPI checkout pinned to release
+`v7.2.88` / commit `93d74a890a44802f656d7f39a573916b2611896e`.
+The live proof uses stock Claude Code `2.1.215`, the merged Parable launcher,
+a dedicated loopback-only proxy process, exact model ids
+`gpt-5.6-{sol,terra,luna}`, and ChatGPT subscription OAuth. Direct provider API
+keys remain unset. Public evidence contains only runtime pins, model and effort
+fields, status codes, counts, booleans, and deterministic hashes.
+
+**Bound + escalation:** at most two correctly wired failed PROVE runs and
+three REVIEW→fix rounds per loop. At the bound, write an `AT_BOUND` EXIT naming
+the unmet criteria and stop. Harness/instrument faults are diagnosed separately
+and do not consume evidence attempts.
+
+## Order rationale
+
+Pin the fake-success regression before editing the translator. Prove the
+smallest protocol-level fix with unit tests before spending subscription turns.
+Only then rebuild and repeat the identical live matrix. Packaging/upstreaming
+comes after live fidelity, so OSS instructions never promise an unproved patch.
+
+## The chain
+
+### E0 — CONTRACT AND FAILING REPRO
+
+- **goal:** Pin the contribution route and a unit regression that reproduces
+  the dropped top-level effort.
+- **prompt:**
+  > Create a fresh CLIProxyAPI checkout at the pinned v7.2.88 commit and read
+  > its repository instructions. Determine the authorized GitHub contribution
+  > route without using a personal account. Add a focused translator test whose
+  > input has `output_config.effort=low` and no `thinking` object, matching
+  > stock Claude Code with an exact third-party GPT model id. Prove that the
+  > unmodified translator emits `reasoning.effort=medium`. Publish only a
+  > content-free receipt and the source/test pins in Parable.
+- **accept:**
+  1. Fresh source checkout is clean and pinned to the exact release commit.
+  2. The focused test fails for the intended semantic reason: expected `low`,
+     observed `medium`; compilation or harness failures do not count.
+  3. Receipt records the authorized contribution route and no credential
+     material.
+  4. Full Parable tests pass; focused contract PR is merged and verified at
+     current `main`.
+- **bound:** 2 PROVE runs / 3 review rounds.
+- **exit →** E1.
+
+### E1 — GENERAL TRANSLATOR FIX
+
+- **goal:** Make a valid top-level Claude `output_config.effort` survive
+  Claude-to-Codex translation even when `thinking` is absent.
+- **prompt:**
+  > Starting from E0's failing test, implement the smallest general change in
+  > `ConvertClaudeRequestToCodex`. Preserve the existing explicit
+  > `thinking.enabled`, `thinking.adaptive|auto`, and `thinking.disabled`
+  > semantics. Pin precedence and normalization with table-driven tests,
+  > including absent effort, effort without thinking, adaptive effort,
+  > budget-derived effort, and disabled thinking. Run gofmt, the focused
+  > package tests, and the repository's relevant broader test slice. Commit an
+  > upstreamable change in the isolated source checkout.
+- **accept:**
+  1. E0 regression passes and directly asserts `low → low`.
+  2. Tests pin existing thinking modes and the default `medium` fallback.
+  3. Focused and broader relevant Go tests pass on the pinned toolchain.
+  4. Diff contains no provider/model-specific routing rule or credential
+     handling.
+  5. Source change is committed and an authorized PR is opened when repository
+     permissions allow; external maintainer merge is not fabricated.
+  6. E1 EXIT is merged into Parable and verified at current `main`.
+- **bound:** 2 PROVE runs / 3 review rounds.
+- **exit →** E2.
+
+### E2 — PATCHED LIVE MATRIX
+
+- **goal:** Prove whether the patched proxy provides exact effort control for
+  Sol, Terra, and Luna in stock Claude Code.
+- **prompt:**
+  > Build the pinned E1 CLIProxyAPI commit and run it on a dedicated loopback
+  > port with the existing ChatGPT OAuth state. Repeat the G1 protocol exactly:
+  > fifteen fresh named non-persistent text cells for three models ×
+  > `low|medium|high|xhigh|max`, plus one medium Bash tool canary per model.
+  > Independently verify synthetic hashes and parse only inbound
+  > `output_config.effort`, translated `reasoning.effort`, statuses, completion,
+  > and OAuth-route booleans. Record every provider clamp or rejection; never
+  > infer fidelity from the CLI flag.
+- **accept:**
+  1. All 15 cells have non-null requested, inbound, and upstream effort plus a
+     successful deterministic hash, or exit `AT_BOUND` naming exact failures.
+  2. Requested-to-upstream exact fidelity is 15/15, unless the live provider
+     returns a documented clamp/rejection that forces an honest `AT_BOUND`.
+  3. Sol, Terra, and Luna each complete a deterministic tool canary.
+  4. All requests use ChatGPT OAuth with direct provider API keys unset.
+  5. Sanitized receipt and updated OSS caveat are merged in a focused Parable
+     PR and verified at current `main`.
+- **bound:** 2 correctly wired attempts per cell / 3 review rounds.
+- **exit →** E3.
+
+### E3 — OSS DELIVERY AND UPSTREAM STATUS
+
+- **goal:** Leave OSS users a reproducible supported path while the upstream
+  patch moves through maintainer review.
+- **prompt:**
+  > Read E0–E2 EXITs and the source PR state. If upstream merged and released,
+  > pin the first good release. If the PR remains open, document the exact
+  > source commit/build route without vendoring credentials or silently
+  > replacing CLIProxyAPI. Ensure the five-minute setup clearly separates
+  > released support from patched-source support. Re-run Parable tests and link
+  > only sanitized merged evidence.
+- **accept:**
+  1. OSS instructions identify the exact known-good source/release state.
+  2. No unmerged patch is represented as an upstream release.
+  3. Upstream PR state is recorded with a public URL, or the precise
+     authorization blocker is documented.
+  4. Full tests pass; focused delivery PR is merged and verified at `main`.
+- **bound:** 2 documentation proofs / 3 review rounds.
+- **exit →** E4.
+
+### E4 — RE-PLAN GATE
+
+- **goal:** Present the verified effort-control verdict and choose the next
+  model-routing proof.
+- **prompt:**
+  > Read all EXITs and state the exact released or patched setup, its model and
+  > effort fidelity, test counts, and upstream status. Keep Kimi explicitly
+  > paused. Recommend either GPT-parent→named-GPT-subagent proof, reliability
+  > repetitions, or waiting for upstream release, then pause for the user.
+- **accept:**
+  1. Verdict maps every claim to merged receipts.
+  2. Released and locally patched states are clearly distinguished.
+  3. Kimi P2 remains `PAUSED`.
+  4. User chooses the successor.
+- **bound:** 2 verdict drafts; user sign-off wait is unbounded.
+- **exit →** a new successor chain.
+
+## Chain invariants
+
+1. No translator edit precedes E0's failing semantic regression.
+2. No loop advances without an `EXIT.md` mapping every criterion to evidence.
+3. Deltas are cumulative; regression reopens the affected cell.
+4. `AT_BOUND` is an honest stop, never completion.
+5. Instrument failures are separate from evidence failures.
+6. External maintainer review is a human gate; no upstream merge is assumed.
+7. ZEN applies at every BUILD: one general protocol rule, no model-name shim.
+8. This chain is append-forward; its final gate creates a successor document.
+9. Public evidence is synthetic or content-free. Raw logs, prompts, responses,
+   credentials, tokens, customer data, and private paths stay out of Git.
+10. Kimi remains paused until the operator explicitly resumes it.

--- a/parable/docs/evidence/e0-cliproxy-effort-repro/EXIT.md
+++ b/parable/docs/evidence/e0-cliproxy-effort-repro/EXIT.md
@@ -1,0 +1,77 @@
+# E0 — CONTRACT AND FAILING REPRO · EXIT (2026-07-20)
+
+## Status: COMPLETE
+
+## The headline evidence
+
+Two correctly wired Go regressions reproduce the same semantic loss at
+CLIProxyAPI `v7.2.88`: a Claude-shaped request with top-level
+`output_config.effort=low` and no `thinking` object becomes Codex
+`reasoning.effort=medium`.
+
+The direct translator test and the canonical cross-protocol conversion test
+both expected `low`, observed `medium`, and exited non-zero for that exact
+assertion. The shared failure proves the repair belongs at the canonical
+thinking boundary plus its direct translator consumer, not in a Parable
+model-name shim.
+
+## What shipped
+
+| Piece | Where |
+|---|---|
+| Autonomous successor chain and E0 re-plan | `docs/LOOP_CHAIN_2026-07-20-cliproxy-effort-fidelity.md` |
+| Source, toolchain, red-test, and permission receipt | `docs/evidence/e0-cliproxy-effort-repro/receipt.json` |
+| Focused contract merge | [PR #144](https://github.com/miguelrios/unc-skills/pull/144) |
+
+## Bound accounting (honest)
+
+- Correctly wired regression PROVE runs: 2, one at each architectural layer;
+  both produced the intended semantic RED.
+- Evidence failures: 0.
+- Instrument failures: 1. The first canonical command used an incomplete Go
+  subtest regex and reported “no tests to run.” Correcting the generated
+  `Case...` subtest name produced the intended expected-`low`,
+  observed-`medium` failure. The miswired selection did not consume an
+  evidence attempt.
+- Review rounds: 1. JSON invariants, credential/private-path scan,
+  `git diff --check`, the full Parable suite, GitHub mergeability, and a
+  Claudio-Michel-style base diff review had no findings. Review verdict: 5/5.
+  The Grep-specific Python/React conventions were not applicable to this
+  Markdown/JSON-only PR. GitHub reported no configured checks or reviewer.
+
+ZEN check: E0 moved the repair to the general canonical thinking boundary
+after source evidence showed the bug exists there too. It adds no model slug
+condition, launcher mutation, credential path, or static effort mapping.
+
+## Acceptance criteria → evidence
+
+1. Clean isolated source pinned to the release commit — ✅ `receipt.json`
+   records upstream commit
+   `93d74a890a44802f656d7f39a573916b2611896e`, official archive SHA-256,
+   matching translator SHA-256, and a clean local source import.
+2. Focused semantic failure — ✅ both receipt entries expected `low`, observed
+   `medium`, exited 1, and mark the semantic failure confirmed.
+3. Authorized contribution route recorded — ✅ the required Claudio Michel
+   GitHub App has no pull/push/triage/maintain/admin permission on the upstream
+   repository. No personal-account fallback was used. E1 may create and prove
+   an upstream-ready local commit but cannot fabricate an issue or PR.
+4. Full Parable tests and focused merged contract PR — ✅ 81/81 tests pass in
+   an isolated HOME; PR #144 is merged and verified at current `main`.
+
+## The running delta table
+
+| Loop | Translator regression | Canonical regression | Exact live effort | Upstream route | Kimi P2 |
+|---|---|---|---:|---|---|
+| G1 baseline | not pinned in source | not pinned in source | 3/15 | none | PAUSED |
+| E0 | RED: low→medium | RED: low→medium | 3/15 | auth blocked | PAUSED |
+
+MEASURE is skipped for E0 beyond the two semantic regressions: this loop pins
+the mechanism and contribution boundary; the live fidelity delta belongs to
+E2.
+
+## exit → E1
+
+Starting from local regression commit
+`6db675c2e884f1cb9db97409f5c1bfc36f76a2b2`, implement and test the
+cross-module canonical fix. Upstream publication remains externally blocked;
+local build and proof continue autonomously.

--- a/parable/docs/evidence/e0-cliproxy-effort-repro/receipt.json
+++ b/parable/docs/evidence/e0-cliproxy-effort-repro/receipt.json
@@ -1,0 +1,72 @@
+{
+  "schema_version": 1,
+  "loop": "E0",
+  "captured_at_utc": "2026-07-20T04:14:08Z",
+  "parable_baseline_head": "d5190ff068732aaf0a7240539b58c2bcb0684af3",
+  "upstream_source": {
+    "repository": "router-for-me/CLIProxyAPI",
+    "release": "v7.2.88",
+    "commit": "93d74a890a44802f656d7f39a573916b2611896e",
+    "archive_sha256": "47c91832a4f09501ed0638191b18d74ffc8eef2ec9de53fd53423ad09d695129",
+    "translator_sha256": "85559604a0da1bd57f537baf007d46ab223e32392111763f2cf81cda341a8a74",
+    "isolated_source_import_clean": true,
+    "local_regression_commit": "6db675c2e884f1cb9db97409f5c1bfc36f76a2b2"
+  },
+  "toolchain": {
+    "go_version": "go1.26.5 linux/amd64",
+    "official_archive": "go1.26.5.linux-amd64.tar.gz",
+    "archive_sha256": "5c2c3b16caefa1d968a94c1daca04a7ca301a496d9b086e17ad77bb81393f053"
+  },
+  "regressions": [
+    {
+      "layer": "direct Claude-to-Codex translator",
+      "test": "TestConvertClaudeRequestToCodex_TopLevelEffortWithoutThinking",
+      "input_shape": {
+        "output_config_effort": "low",
+        "thinking_object_present": false
+      },
+      "expected_reasoning_effort": "low",
+      "observed_reasoning_effort": "medium",
+      "exit_code": 1,
+      "semantic_failure_confirmed": true
+    },
+    {
+      "layer": "canonical thinking conversion",
+      "test": "TestThinkingE2EClaudeAdaptive_Body/CaseC14-top-level-effort-without-thinking_claude->codex_level-model",
+      "input_shape": {
+        "output_config_effort": "low",
+        "thinking_object_present": false
+      },
+      "expected_reasoning_effort": "low",
+      "observed_reasoning_effort": "medium",
+      "exit_code": 1,
+      "semantic_failure_confirmed": true
+    }
+  ],
+  "contribution_route": {
+    "required_actor": "Claudio Michel GitHub App",
+    "viewer_permission": null,
+    "repository_permissions": {
+      "pull": false,
+      "push": false,
+      "maintain": false,
+      "admin": false,
+      "triage": false
+    },
+    "upstream_issue_or_pr_authorized": false,
+    "fallback_personal_account_used": false,
+    "disposition": "Build and prove an upstream-ready local cross-module commit; report the external authorization blocker."
+  },
+  "architecture_finding": {
+    "translator_gate": "output_config.effort is read only when thinking.type is adaptive or auto",
+    "canonical_gate": "extractClaudeConfig has the same adaptive-or-auto condition",
+    "repair_scope": "canonical thinking extraction plus Claude-to-Codex translation and their tests",
+    "standalone_translator_change": false
+  },
+  "safety": {
+    "credential_material_committed": false,
+    "raw_prompt_or_response_committed": false,
+    "raw_proxy_log_committed": false,
+    "private_path_committed": false
+  }
+}


### PR DESCRIPTION
## Summary

- cuts the autonomous successor cascade chosen at the G2 human gate
- pins CLIProxyAPI v7.2.88 source and Go 1.26.5 toolchain hashes
- records two semantic red tests for top-level Claude effort without `thinking`
- broadens the repair to the canonical thinking boundary plus translator, per upstream repository policy
- records that the required GitHub App has no upstream write/issue/PR permission

## Test Results

- direct translator regression: expected `low`, observed `medium` (semantic RED)
- canonical conversion regression: expected `low`, observed `medium` (semantic RED)
- `python3 -m unittest discover -s parable/tests -v` — 81/81 pass
- receipt invariants and JSON parsing pass
- credential/private-path scan clean
- `git diff --check` clean

## Notes

No raw model content, proxy logs, credentials, tokens, or private paths are committed. The source patch will remain local/upstream-ready unless the Claudio Michel App gains permission on `router-for-me/CLIProxyAPI`.