### PR TITLE
docs(parable): record green CLIProxy effort fix

### DIFF
--- a/parable/docs/evidence/e1-cliproxy-effort-fix/EXIT.md
+++ b/parable/docs/evidence/e1-cliproxy-effort-fix/EXIT.md
@@ -1,0 +1,79 @@
+# E1 — GENERAL TRANSLATOR FIX · EXIT (2026-07-20)
+
+## Status: COMPLETE
+
+## The headline evidence
+
+The E0 `low → medium` regressions are green after one cross-module change:
+Claude `output_config.effort` is normalized at the canonical thinking boundary
+and used as a fallback only when the request has no `thinking` object. The
+Claude-to-Codex translator consumes that shared normalization.
+
+Explicit `thinking.type=disabled`, budgeted enabled thinking, enabled thinking
+without a budget, and adaptive/auto thinking retain their prior precedence.
+All five user-facing values (`low`, `medium`, `high`, `xhigh`, `max`) are
+pinned in translator tests. The complete CLIProxyAPI Go suite and required
+server build pass.
+
+## What shipped
+
+| Piece | Where |
+|---|---|
+| Upstream-ready local source commit | `ad20a87efbbd41a9d4f24c83ca8bdd934bf34ab7` |
+| Sanitized mechanism/test/build receipt | `docs/evidence/e1-cliproxy-effort-fix/receipt.json` |
+| Focused evidence merge | [PR #145](https://github.com/miguelrios/unc-skills/pull/145) |
+
+## Bound accounting (honest)
+
+- Correctly wired fix PROVE runs: 1. Focused tests, focused vet, complete Go
+  tests, and the server build all passed on the first implementation.
+- Evidence failures: 0.
+- Instrument failures: 0.
+- Review rounds: 1. The base-to-fix diff was reviewed for semantic precedence,
+  invalid/blank inputs, fake-success defaults, model-specific branching,
+  credential handling, formatting, and test coverage. No critical issue or
+  warning remained; review verdict 5/5. Grep-specific Python/React conventions
+  were not applicable to this Go change.
+
+ZEN check: one normalized protocol field feeds the canonical extractor and
+direct translator. The fix has no GPT slug check, Parable launcher mutation,
+static effort table, credential path, or provider-account special case.
+
+## Acceptance criteria → evidence
+
+1. E0 regression passes — ✅ the direct translator and cross-protocol
+   top-level-effort tests both exit zero and assert `low → low`.
+2. Existing thinking modes and default are pinned — ✅ 12 canonical precedence
+   subcases and 11 translator subcases cover absent/blank/non-string effort,
+   all five user values, adaptive behavior, explicit disabled, explicit budget,
+   enabled-without-budget, and the default `medium` fallback.
+3. Relevant broader Go tests pass — ✅ focused vet passes,
+   `go test -count=1 ./...` passes, and the required server build exits zero
+   under official Go `1.26.5`.
+4. No provider/model-specific shim — ✅ the receipt records cross-module
+   `internal/thinking` plus `internal/translator/codex/claude` scope,
+   `model_name_condition_added=false`, and `credential_handling_added=false`.
+5. Source commit and authorized publication state — ✅ local commit
+   `ad20a87efbbd41a9d4f24c83ca8bdd934bf34ab7` is clean and its two-commit patch
+   SHA-256 is recorded. The required GitHub App lacks upstream permission, so
+   no issue, PR, or external merge is claimed.
+6. E1 EXIT merged into Parable — ✅ 81/81 Parable tests pass in an isolated
+   HOME; PR #145 is merged and verified at current `main`.
+
+## The running delta table
+
+| Loop | Translator regression | Canonical regression | Full CLIProxy tests | Exact live effort | Upstream route | Kimi P2 |
+|---|---|---|---|---:|---|---|
+| G1 baseline | not pinned | not pinned | release binary | 3/15 | none | PAUSED |
+| E0 | RED: low→medium | RED: low→medium | not run with red tests | 3/15 | auth blocked | PAUSED |
+| E1 | GREEN: low→low | GREEN: low→low | PASS | not rerun | auth blocked | PAUSED |
+
+MEASURE for E1 is the semantic test delta from two red layers to both green.
+The subscription-backed live fidelity delta is reserved for E2.
+
+## exit → E2
+
+Run binary SHA-256
+`139e1305a878e08026dd0fb6d85a3817801f32e40a40c1954ea1973c5bb9d697`
+on a dedicated loopback port and repeat the exact 15-cell plus 3-tool G1
+protocol. Runtime wire evidence, not these unit tests, decides support.

--- a/parable/docs/evidence/e1-cliproxy-effort-fix/receipt.json
+++ b/parable/docs/evidence/e1-cliproxy-effort-fix/receipt.json
@@ -1,0 +1,77 @@
+{
+  "schema_version": 1,
+  "loop": "E1",
+  "captured_at_utc": "2026-07-20T04:22:31Z",
+  "parable_baseline_head": "f9fc5c05d139de72a42bdcc0704573e016d9bb30",
+  "source": {
+    "repository": "router-for-me/CLIProxyAPI",
+    "upstream_base_commit": "93d74a890a44802f656d7f39a573916b2611896e",
+    "local_regression_commit": "6db675c2e884f1cb9db97409f5c1bfc36f76a2b2",
+    "local_fix_commit": "ad20a87efbbd41a9d4f24c83ca8bdd934bf34ab7",
+    "two_commit_patch_sha256": "2d6c5371b79ffabc027f93cdedd817d83f9554c81c6df294f064395134163582",
+    "working_tree_clean": true
+  },
+  "mechanism": {
+    "scope": [
+      "internal/thinking",
+      "internal/translator/codex/claude"
+    ],
+    "top_level_effort_normalized_once": true,
+    "canonical_fallback_requires_missing_thinking_object": true,
+    "translator_fallback_requires_missing_thinking_object": true,
+    "preserved_precedence": [
+      "thinking.type=disabled",
+      "thinking.type=enabled with budget_tokens",
+      "thinking.type=enabled without budget_tokens",
+      "thinking.type=adaptive or auto"
+    ],
+    "model_name_condition_added": false,
+    "credential_handling_added": false
+  },
+  "tests": {
+    "canonical_precedence_subcases": 12,
+    "translator_effort_subcases": 11,
+    "cross_protocol_regressions": 1,
+    "focused_commands": [
+      {
+        "target": "internal/thinking",
+        "exit_code": 0
+      },
+      {
+        "target": "internal/translator/codex/claude",
+        "exit_code": 0
+      },
+      {
+        "target": "test/Claude-to-Codex top-level effort",
+        "exit_code": 0
+      }
+    ],
+    "go_vet_focused_exit_code": 0,
+    "go_test_all_exit_code": 0,
+    "server_build_exit_code": 0
+  },
+  "build": {
+    "go_version": "go1.26.5 linux/amd64",
+    "binary_version": "dev",
+    "binary_sha256": "139e1305a878e08026dd0fb6d85a3817801f32e40a40c1954ea1973c5bb9d697"
+  },
+  "review": {
+    "style": "Claudio-Michel",
+    "rounds": 1,
+    "critical_findings": 0,
+    "warnings": 0,
+    "verdict_out_of_5": 5
+  },
+  "upstream_status": {
+    "issue_url": null,
+    "pull_request_url": null,
+    "authorization_blocker": "The required Claudio Michel GitHub App has no permission on router-for-me/CLIProxyAPI.",
+    "external_merge_claimed": false
+  },
+  "safety": {
+    "credential_material_committed": false,
+    "raw_prompt_or_response_committed": false,
+    "raw_proxy_log_committed": false,
+    "private_path_committed": false
+  }
+}


### PR DESCRIPTION
## Summary

Records the completed E1 source fix against CLIProxyAPI v7.2.88. The cross-module change makes top-level Claude effort canonical when `thinking` is absent and preserves all explicit thinking-mode precedence.

- 12 canonical precedence subcases pass
- 11 direct translator effort subcases pass
- E0 cross-protocol regression is green
- full CLIProxyAPI `go test -count=1 ./...` passes
- required server build passes
- no model-name shim or credential logic added

## Test Results

- focused thinking, translator, and cross-protocol tests: PASS
- `go vet ./internal/thinking ./internal/translator/codex/claude`: PASS
- `go test -count=1 ./...`: PASS
- `go build -o <temporary-output> ./cmd/server`: PASS
- `python3 -m unittest discover -s parable/tests -v`: 81/81 PASS

## Notes

The source commit is locally upstream-ready, but the mandated Claudio Michel GitHub App has no permission on `router-for-me/CLIProxyAPI`; no upstream issue/PR/merge is claimed. Live Sol/Terra/Luna proof follows in E2. No credentials, private paths, raw logs, or model content are committed.