### PR TITLE
docs(parable): close E2 at merged main

### DIFF
--- a/parable/docs/evidence/e2-cliproxy-effort-live/EXIT.md
+++ b/parable/docs/evidence/e2-cliproxy-effort-live/EXIT.md
@@ -76,7 +76,7 @@ token-use, or long-session reliability.
 - Parable tests: 81/81 PASS in an isolated HOME.
 - Review verdict: 5/5.
 - Focused evidence PR: [#146](https://github.com/miguelrios/unc-skills/pull/146).
-- Verified merged `main`: pending.
+- Verified merged `main`: `7500f48ac286ee9e720fe984f35c0c2c9e8ff129`.
 
 ## exit → E3
 


### PR DESCRIPTION
Records the actual merged-main commit for E2 after PR #146. This removes the final pending marker without pre-claiming the merge.