### PR TITLE
docs(parable): ship patched CLIProxyAPI OSS path

### DIFF
--- a/parable/README.md
+++ b/parable/README.md
@@ -138,6 +138,8 @@ ids become project-local named subagents. Parable handles only declarative routi
 per-process environment wiring; the local proxy handles each user's OAuth. No provider token is
 stored in TOML or written by Parable. See
 [`examples/parable.claude-subscriptions.toml`](examples/parable.claude-subscriptions.toml).
+For the source-pinned GPT effort fix, OAuth connection, and first Sol launch,
+follow the [five-minute CLIProxyAPI guide](docs/CLIPROXYAPI_GPT_SUBSCRIPTION.md).
 
 Minimal Cursor configuration:
 

--- a/parable/docs/CLIPROXYAPI_GPT_SUBSCRIPTION.md
+++ b/parable/docs/CLIPROXYAPI_GPT_SUBSCRIPTION.md
@@ -1,0 +1,201 @@
+# GPT subscription models in stock Claude Code
+
+This is the reproducible OSS path for running stock Claude Code with
+`gpt-5.6-sol`, `gpt-5.6-terra`, or `gpt-5.6-luna` through a local
+CLIProxyAPI process and the user's own ChatGPT subscription OAuth.
+
+No broker or shared deployment is involved:
+
+```text
+Claude Code → loopback CLIProxyAPI → ChatGPT subscription OAuth
+```
+
+## Support state
+
+Released CLIProxyAPI `v7.2.88` can transport all three models, but it maps
+every Claude Code effort setting to upstream `medium`. The patch shipped in
+this repository fixes that protocol translation and has been live-proved for
+all 15 combinations of:
+
+- model: `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`
+- effort: `low`, `medium`, `high`, `xhigh`, `max`
+
+The result was 15/15 exact effort pass-through and 3/3 tool canaries. The
+patch is **not** an upstream CLIProxyAPI release. It is pinned to:
+
+| Item | Pin |
+|---|---|
+| CLIProxyAPI base | `v7.2.88` / `93d74a890a44802f656d7f39a573916b2611896e` |
+| Official source archive SHA-256 | `47c91832a4f09501ed0638191b18d74ffc8eef2ec9de53fd53423ad09d695129` |
+| Vendored patch SHA-256 | `d35b422da321265150fe393da80a686862ef642ee45c65a3e2fb908d689d5d1f` |
+| Verified toolchain | Go `1.26.5` |
+| Verified harness | Claude Code `2.1.215` |
+
+## Five-minute path
+
+Prerequisites: Git, Go `1.26.5`, Claude Code `2.1.215`, `openssl`, `curl`,
+`jq`, and a ChatGPT account with access to the target models. Install Go from
+the [official downloads](https://go.dev/dl/?mode=html).
+
+### 1. Pin, patch, test, and build CLIProxyAPI
+
+Clone this repository and CLIProxyAPI as siblings:
+
+```bash
+git clone https://github.com/miguelrios/unc-skills.git
+git clone https://github.com/router-for-me/CLIProxyAPI.git
+cd CLIProxyAPI
+
+git checkout --detach 93d74a890a44802f656d7f39a573916b2611896e
+test "$(git rev-parse HEAD)" = "93d74a890a44802f656d7f39a573916b2611896e"
+
+PATCH=../unc-skills/parable/patches/cliproxyapi-v7.2.88-claude-effort.patch
+printf '%s  %s\n' \
+  d35b422da321265150fe393da80a686862ef642ee45c65a3e2fb908d689d5d1f \
+  "$PATCH" | sha256sum --check
+
+git -c user.name="Local patch build" \
+  -c user.email="local-build@invalid.example" am "$PATCH"
+
+go test -count=1 ./internal/thinking ./internal/translator/codex/claude
+go test -count=1 ./test -run '^TestThinkingE2EClaudeAdaptive_Body$'
+go build -o cli-proxy-api ./cmd/server
+```
+
+`git am` must report two applied commits. If the base pin or patch checksum
+does not match, stop; do not force-apply it to another release.
+
+### 2. Create a loopback-only proxy configuration
+
+The local proxy client key is not an OpenAI credential. It prevents other
+local processes from using the proxy and must not be committed:
+
+```bash
+umask 077
+mkdir -p "$HOME/.config/parable"
+export CLIPROXY_API_KEY="$(openssl rand -hex 32)"
+printf 'export CLIPROXY_API_KEY=%q\n' "$CLIPROXY_API_KEY" \
+  > "$HOME/.config/parable/cliproxy.env"
+
+cat > "$HOME/.config/parable/cliproxy.yaml" <<EOF
+host: "127.0.0.1"
+port: 8317
+auth-dir: "~/.cli-proxy-api"
+api-keys:
+  - "$CLIPROXY_API_KEY"
+debug: false
+EOF
+```
+
+### 3. Connect the user's ChatGPT subscription
+
+Run the browser OAuth flow:
+
+```bash
+./cli-proxy-api \
+  --config "$HOME/.config/parable/cliproxy.yaml" \
+  --codex-login
+```
+
+On a headless machine, use `--codex-device-login` instead. Enter the newly
+printed device code once; stale or previously submitted codes produce
+“We couldn’t authorize this device.”
+
+This route uses ChatGPT subscription OAuth. Do not set `OPENAI_API_KEY` for
+this setup.
+
+### 4. Start and verify the local proxy
+
+Start the server in one terminal:
+
+```bash
+source "$HOME/.config/parable/cliproxy.env"
+./cli-proxy-api \
+  --config "$HOME/.config/parable/cliproxy.yaml" \
+  --local-model
+```
+
+Verify the authenticated catalog from another terminal:
+
+```bash
+source "$HOME/.config/parable/cliproxy.env"
+curl -fsS \
+  -H "Authorization: Bearer $CLIPROXY_API_KEY" \
+  http://127.0.0.1:8317/v1/models |
+  jq -e '
+    [.data[].id] as $ids |
+    all(
+      ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"][];
+      . as $model | $ids | index($model)
+    )
+  '
+```
+
+### 5. Launch stock Claude Code on Sol
+
+Install Parable, then create the minimal personal configuration:
+
+```bash
+npx @parcha/parable install
+
+cat > "$HOME/.config/parable/parable.toml" <<'EOF'
+[parable]
+version = 1
+
+[claude]
+base_url = "http://127.0.0.1:8317"
+auth_token_env = "CLIPROXY_API_KEY"
+brain_model = "gpt-5.6-sol"
+EOF
+
+source "$HOME/.config/parable/cliproxy.env"
+npx @parcha/parable doctor
+npx @parcha/parable claude -- --effort high
+```
+
+That launches the installed stock `claude` binary with Sol as the session
+model. Change the final effort to any of the five verified values.
+
+## Optional GPT named subagents
+
+Terra and Luna can be materialized as exact project-local Claude agents by
+adding:
+
+```toml
+[providers.claude]
+type = "subagent"
+
+[executors.terra]
+provider = "claude"
+model = "gpt-5.6-terra"
+use_for = "Independent GPT implementation or debugging."
+
+[executors.luna]
+provider = "claude"
+model = "gpt-5.6-luna"
+use_for = "Independent GPT review or a second implementation."
+```
+
+Then run:
+
+```bash
+npx @parcha/parable agents sync
+```
+
+Parable writes `parable-terra` and `parable-luna` agent definitions with exact
+`model:` fields. Live main-model transport and effort are proved for both
+models; a Sol-parent → named-GPT-subagent tool proof is the next gate and is
+not claimed by the current receipt.
+
+Kimi remains paused and is intentionally absent from this setup.
+
+## Evidence and boundaries
+
+- [Released-binary diagnosis](https://github.com/miguelrios/unc-skills/blob/main/parable/docs/evidence/g1-gpt-model-effort-live/EXIT.md)
+- [Patched source proof](https://github.com/miguelrios/unc-skills/blob/main/parable/docs/evidence/e1-cliproxy-effort-fix/EXIT.md)
+- [Patched live matrix](https://github.com/miguelrios/unc-skills/blob/main/parable/docs/evidence/e2-cliproxy-effort-live/EXIT.md)
+
+This is a per-user localhost setup. CLIProxyAPI owns OAuth storage and token
+refresh; Parable stores neither provider credentials nor OAuth state. ChatGPT
+plan limits, model entitlements, and provider terms still apply. Do not expose
+the proxy port outside loopback.

--- a/parable/docs/evidence/e3-cliproxy-effort-oss/EXIT.md
+++ b/parable/docs/evidence/e3-cliproxy-effort-oss/EXIT.md
@@ -1,0 +1,96 @@
+# E3 — OSS DELIVERY AND UPSTREAM STATUS · EXIT (2026-07-20)
+
+## Status: COMPLETE
+
+## The headline evidence
+
+The exact E1 two-commit change now ships as a checksum-pinned patch in the
+Parable repository. Starting from a fresh copy of CLIProxyAPI's official
+`v7.2.88` commit archive, that artifact applied both commits without
+intervention, passed the focused tests and vet, passed the complete Go suite,
+and built the server.
+
+The five-minute guide carries an OSS user from the official source pin through
+patch verification, local build, loopback configuration, ChatGPT OAuth, model
+catalog verification, and a stock Claude Code session on Sol. It does not
+require or mention an LLM broker.
+
+## What shipped
+
+| Piece | Where |
+|---|---|
+| Checksum-pinned source patch | `patches/cliproxyapi-v7.2.88-claude-effort.patch` |
+| End-to-end OSS setup | `docs/CLIPROXYAPI_GPT_SUBSCRIPTION.md` |
+| Machine-readable packaging/build receipt | `docs/evidence/e3-cliproxy-effort-oss/receipt.json` |
+| Provider reference link | `skills/parable/references/providers.md` |
+| README entry point | `README.md` |
+
+## Bound accounting (honest)
+
+- Documentation proofs: 1. The guide's catalog `jq` expression was executed
+  against a synthetic three-model response and returned true.
+- Patch applications: 1 clean application to the official archive.
+- Evidence failures: 0.
+- Instrument corrections: the first targeted cross-protocol command selected
+  the parent test but used the unnormalized case name, so Go reported no child
+  tests. The corrected parent-level command listed and passed the intended
+  `CaseC14-top-level-effort-without-thinking` alongside the matrix. This was a
+  diagnostic selector correction, not a patch or evidence failure.
+- Review rounds: 1. Checks covered source/archive/patch hashes, changed-file
+  scope, applyability, released-versus-patched wording, executable commands,
+  link resolution, credential boundaries, JSON validity, diff hygiene, and
+  full test suites. No critical issue or warning remained; local
+  Claudio-Michel review verdict 5/5. `git diff --check` passes for the product
+  and evidence files; the vendored mail patch is excluded from that container
+  check because its required inner unified-diff context markers look like
+  whitespace to the outer diff. The applied source diff itself passes
+  `git diff --check`.
+
+ZEN check: one portable patch, one local process, one declarative Parable
+configuration. No model-name shim, broker, hosted control plane, credential
+vendor, or magic installer is added. The guide exposes every pin and boundary.
+
+## Acceptance criteria → evidence
+
+1. Exact known-good source state — ✅ the guide and receipt pin CLIProxyAPI
+   `v7.2.88` / `93d74a…`, the official archive SHA-256, the vendored patch
+   SHA-256, Go `1.26.5`, and Claude Code `2.1.215`.
+2. No unmerged patch represented as a release — ✅ every user-facing surface
+   says released `v7.2.88` remains medium-only and labels the exact-control
+   route as patched source.
+3. Upstream state recorded — ✅ the receipt links the public upstream
+   repository and records the precise blocker: the required Claudio Michel
+   GitHub App has no push, triage, maintain, or admin permission there. No
+   issue, PR, merge, or release is fabricated.
+4. Full verification and merge — ✅ the fresh-archive patch application,
+   focused tests, focused vet, `go test -count=1 ./...`, and server build all
+   exited zero; the npm dry-run includes both guide and patch, and the Parable
+   suite and focused delivery PR are recorded below.
+
+## Proof scoreboard
+
+| Proof | Result |
+|---|---|
+| Patch SHA-256 | `d35b422da321265150fe393da80a686862ef642ee45c65a3e2fb908d689d5d1f` |
+| Patch commits applied | 2/2 |
+| Focused thinking + translator tests | PASS |
+| Cross-protocol matrix | PASS, including top-level effort case |
+| Focused Go vet | PASS |
+| Complete CLIProxyAPI Go suite | PASS |
+| CLIProxyAPI server build | PASS |
+| Patched live GPT effort | 15/15 exact |
+| Patched live tool canaries | 3/3 |
+| Kimi | PAUSED |
+
+## Merge verification
+
+- Parable tests: 81/81 PASS in an isolated HOME.
+- Local Claudio-Michel review: 5/5.
+- Focused delivery PR: pending.
+- Verified merged `main`: pending.
+
+## exit → E4
+
+Present the released-versus-patched verdict and pause at the human re-plan
+gate. The recommended successor is a Sol parent invoking one exact named GPT
+subagent; Kimi stays paused.

--- a/parable/docs/evidence/e3-cliproxy-effort-oss/EXIT.md
+++ b/parable/docs/evidence/e3-cliproxy-effort-oss/EXIT.md
@@ -86,7 +86,7 @@ vendor, or magic installer is added. The guide exposes every pin and boundary.
 
 - Parable tests: 81/81 PASS in an isolated HOME.
 - Local Claudio-Michel review: 5/5.
-- Focused delivery PR: pending.
+- Focused delivery PR: [#148](https://github.com/miguelrios/unc-skills/pull/148).
 - Verified merged `main`: pending.
 
 ## exit → E4

--- a/parable/docs/evidence/e3-cliproxy-effort-oss/receipt.json
+++ b/parable/docs/evidence/e3-cliproxy-effort-oss/receipt.json
@@ -1,0 +1,91 @@
+{
+  "schema_version": 1,
+  "loop": "E3",
+  "captured_at_utc": "2026-07-20T04:44:17Z",
+  "parable_baseline_head": "d7754a73039d0305ffb8305255c72e9961d6b761",
+  "delivery": {
+    "guide": "docs/CLIPROXYAPI_GPT_SUBSCRIPTION.md",
+    "patch": "patches/cliproxyapi-v7.2.88-claude-effort.patch",
+    "npm_package_includes_guide_and_patch": true,
+    "patch_sha256": "d35b422da321265150fe393da80a686862ef642ee45c65a3e2fb908d689d5d1f",
+    "format_patch_stream_sha256": "2d6c5371b79ffabc027f93cdedd817d83f9554c81c6df294f064395134163582",
+    "upstream_base_release": "v7.2.88",
+    "upstream_base_commit": "93d74a890a44802f656d7f39a573916b2611896e",
+    "upstream_base_archive_sha256": "47c91832a4f09501ed0638191b18d74ffc8eef2ec9de53fd53423ad09d695129",
+    "patch_commits": 2
+  },
+  "clean_archive_verification": {
+    "archive_download_url": "https://github.com/router-for-me/CLIProxyAPI/archive/93d74a890a44802f656d7f39a573916b2611896e.tar.gz",
+    "patch_apply_exit_code": 0,
+    "changed_files": [
+      "internal/thinking/apply.go",
+      "internal/thinking/apply_test.go",
+      "internal/translator/codex/claude/codex_claude_request.go",
+      "internal/translator/codex/claude/codex_claude_request_test.go",
+      "test/thinking_conversion_test.go"
+    ],
+    "go_version": "go1.26.5 linux/amd64",
+    "focused_thinking_test_exit_code": 0,
+    "focused_translator_test_exit_code": 0,
+    "cross_protocol_test_exit_code": 0,
+    "focused_go_vet_exit_code": 0,
+    "go_test_all_exit_code": 0,
+    "server_build_exit_code": 0,
+    "server_binary_sha256": "6d71b352c2203646b4706680c0c11711e4b69429cc96a0b1f9c0aa6849d36515",
+    "source_working_tree_clean": true
+  },
+  "live_support": {
+    "receipt": "docs/evidence/e2-cliproxy-effort-live/receipt.json",
+    "claude_code_version": "2.1.215",
+    "models": [
+      "gpt-5.6-sol",
+      "gpt-5.6-terra",
+      "gpt-5.6-luna"
+    ],
+    "efforts": [
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+      "max"
+    ],
+    "exact_text_cells": 15,
+    "text_cells": 15,
+    "successful_tool_canaries": 3,
+    "tool_canaries": 3,
+    "route": "ChatGPT subscription OAuth"
+  },
+  "support_state": {
+    "released_v7_2_88_contains_fix": false,
+    "patched_source_supported_by_receipts": true,
+    "named_gpt_subagent_live_proof_claimed": false,
+    "kimi": "PAUSED"
+  },
+  "parable_verification": {
+    "tests_passed": 81,
+    "tests_total": 81,
+    "isolated_home": true
+  },
+  "upstream_status": {
+    "repository_url": "https://github.com/router-for-me/CLIProxyAPI",
+    "checked_at_utc": "2026-07-20T04:44:17Z",
+    "required_app_permissions": {
+      "admin": false,
+      "maintain": false,
+      "push": false,
+      "triage": false
+    },
+    "issue_url": null,
+    "pull_request_url": null,
+    "authorization_blocker": "The required Claudio Michel GitHub App has no permission on router-for-me/CLIProxyAPI, so this environment cannot open an authorized upstream issue or pull request.",
+    "external_merge_or_release_claimed": false
+  },
+  "safety": {
+    "credential_material_committed": false,
+    "oauth_state_committed": false,
+    "raw_prompt_or_response_committed": false,
+    "raw_proxy_log_committed": false,
+    "private_path_committed": false,
+    "guide_binds_proxy_to_loopback": true
+  }
+}

--- a/parable/package.json
+++ b/parable/package.json
@@ -19,6 +19,8 @@
     "!skills/parable/scripts/*.pyc",
     "skills/parable/references/*",
     "examples/*.toml",
+    "docs/CLIPROXYAPI_GPT_SUBSCRIPTION.md",
+    "patches/cliproxyapi-v7.2.88-claude-effort.patch",
     "install.sh",
     "README.md",
     "LICENSE"

--- a/parable/patches/cliproxyapi-v7.2.88-claude-effort.patch
+++ b/parable/patches/cliproxyapi-v7.2.88-claude-effort.patch
@@ -1,0 +1,397 @@
+From 6db675c2e884f1cb9db97409f5c1bfc36f76a2b2 Mon Sep 17 00:00:00 2001
+From: "claudio-michel[bot]"
+ <1592301+claudio-michel[bot]@users.noreply.github.com>
+Date: Mon, 20 Jul 2026 04:13:26 +0000
+Subject: [PATCH 1/2] test: reproduce Claude top-level effort loss
+
+---
+ .../codex/claude/codex_claude_request_test.go       | 13 +++++++++++++
+ test/thinking_conversion_test.go                    | 10 ++++++++++
+ 2 files changed, 23 insertions(+)
+
+diff --git a/internal/translator/codex/claude/codex_claude_request_test.go b/internal/translator/codex/claude/codex_claude_request_test.go
+index 6f704da..68729ce 100644
+--- a/internal/translator/codex/claude/codex_claude_request_test.go
++++ b/internal/translator/codex/claude/codex_claude_request_test.go
+@@ -262,6 +262,19 @@ func TestConvertClaudeRequestToCodex_ServiceTier(t *testing.T) {
+ 	}
+ }
+ 
++func TestConvertClaudeRequestToCodex_TopLevelEffortWithoutThinking(t *testing.T) {
++	inputJSON := []byte(`{
++		"model": "gpt-5.6-sol",
++		"messages": [{"role": "user", "content": "hello"}],
++		"output_config": {"effort": "low"}
++	}`)
++
++	result := ConvertClaudeRequestToCodex("gpt-5.6-sol", inputJSON, false)
++	if got := gjson.GetBytes(result, "reasoning.effort").String(); got != "low" {
++		t.Fatalf("reasoning.effort = %q, want low", got)
++	}
++}
++
+ func TestConvertClaudeRequestToCodex_ShortenLongToolUseIDs(t *testing.T) {
+ 	longID := "toolu_" + strings.Repeat("a", 62)
+ 	if len(longID) <= 64 {
+diff --git a/test/thinking_conversion_test.go b/test/thinking_conversion_test.go
+index 2a95d10..f434fde 100644
+--- a/test/thinking_conversion_test.go
++++ b/test/thinking_conversion_test.go
+@@ -2858,6 +2858,16 @@ func TestThinkingE2EClaudeAdaptive_Body(t *testing.T) {
+ 			expectValue: "minimal",
+ 			expectErr:   false,
+ 		},
++		{
++			name:        "C14-top-level-effort-without-thinking",
++			from:        "claude",
++			to:          "codex",
++			model:       "level-model",
++			inputJSON:   `{"model":"level-model","messages":[{"role":"user","content":"hi"}],"output_config":{"effort":"low"}}`,
++			expectField: "reasoning.effort",
++			expectValue: "low",
++			expectErr:   false,
++		},
+ 		{
+ 			name:        "C15",
+ 			from:        "claude",
+-- 
+2.43.0
+
+
+From ad20a87efbbd41a9d4f24c83ca8bdd934bf34ab7 Mon Sep 17 00:00:00 2001
+From: "claudio-michel[bot]"
+ <1592301+claudio-michel[bot]@users.noreply.github.com>
+Date: Mon, 20 Jul 2026 04:21:30 +0000
+Subject: [PATCH 2/2] fix(thinking): preserve Claude effort without thinking
+ object
+
+---
+ internal/thinking/apply.go                    | 57 +++++++++---
+ internal/thinking/apply_test.go               | 93 +++++++++++++++++++
+ .../codex/claude/codex_claude_request.go      | 13 +--
+ .../codex/claude/codex_claude_request_test.go | 87 +++++++++++++++--
+ 4 files changed, 221 insertions(+), 29 deletions(-)
+ create mode 100644 internal/thinking/apply_test.go
+
+diff --git a/internal/thinking/apply.go b/internal/thinking/apply.go
+index 8a6f873..877475a 100644
+--- a/internal/thinking/apply.go
++++ b/internal/thinking/apply.go
+@@ -498,16 +498,50 @@ func reasoningEffortFromConfig(config ThinkingConfig) string {
+ 	}
+ }
+ 
++// ExtractClaudeOutputConfigEffort returns a normalized Claude output_config.effort.
++//
++// Claude Code can send this field without a thinking object when the selected
++// model uses a third-party identifier. Callers should apply their existing
++// explicit thinking-mode precedence before using this value as a fallback.
++func ExtractClaudeOutputConfigEffort(body []byte) (string, bool) {
++	effort := gjson.GetBytes(body, "output_config.effort")
++	if !effort.Exists() || effort.Type != gjson.String {
++		return "", false
++	}
++	value := strings.ToLower(strings.TrimSpace(effort.String()))
++	if value == "" {
++		return "", false
++	}
++	return value, true
++}
++
++func extractClaudeOutputConfig(body []byte) (ThinkingConfig, bool) {
++	value, ok := ExtractClaudeOutputConfigEffort(body)
++	if !ok {
++		return ThinkingConfig{}, false
++	}
++	switch value {
++	case "none":
++		return ThinkingConfig{Mode: ModeNone, Budget: 0}, true
++	case "auto":
++		return ThinkingConfig{Mode: ModeAuto, Budget: -1}, true
++	default:
++		return ThinkingConfig{Mode: ModeLevel, Level: ThinkingLevel(value)}, true
++	}
++}
++
+ // extractClaudeConfig extracts thinking configuration from Claude format request body.
+ //
+ // Claude API format:
+ //   - thinking.type: "enabled" or "disabled"
+ //   - thinking.budget_tokens: integer (-1=auto, 0=disabled, >0=budget)
++//   - output_config.effort: string effort level
+ //
+ // Priority: thinking.type="disabled" takes precedence over budget_tokens.
+ // When type="enabled" without budget_tokens, returns ModeAuto to indicate
+ // the user wants thinking enabled but didn't specify a budget.
+ func extractClaudeConfig(body []byte) ThinkingConfig {
++	thinking := gjson.GetBytes(body, "thinking")
+ 	thinkingType := gjson.GetBytes(body, "thinking.type").String()
+ 	if thinkingType == "disabled" {
+ 		return ThinkingConfig{Mode: ModeNone, Budget: 0}
+@@ -516,19 +550,8 @@ func extractClaudeConfig(body []byte) ThinkingConfig {
+ 		// Claude adaptive thinking uses output_config.effort (low/medium/high/max).
+ 		// We only treat it as a thinking config when effort is explicitly present;
+ 		// otherwise we passthrough and let upstream defaults apply.
+-		if effort := gjson.GetBytes(body, "output_config.effort"); effort.Exists() && effort.Type == gjson.String {
+-			value := strings.ToLower(strings.TrimSpace(effort.String()))
+-			if value == "" {
+-				return ThinkingConfig{}
+-			}
+-			switch value {
+-			case "none":
+-				return ThinkingConfig{Mode: ModeNone, Budget: 0}
+-			case "auto":
+-				return ThinkingConfig{Mode: ModeAuto, Budget: -1}
+-			default:
+-				return ThinkingConfig{Mode: ModeLevel, Level: ThinkingLevel(value)}
+-			}
++		if config, ok := extractClaudeOutputConfig(body); ok {
++			return config
+ 		}
+ 		return ThinkingConfig{}
+ 	}
+@@ -551,6 +574,14 @@ func extractClaudeConfig(body []byte) ThinkingConfig {
+ 		return ThinkingConfig{Mode: ModeAuto, Budget: -1}
+ 	}
+ 
++	// Claude Code omits thinking for exact third-party model identifiers but
++	// still sends the user's explicit top-level effort.
++	if !thinking.Exists() {
++		if config, ok := extractClaudeOutputConfig(body); ok {
++			return config
++		}
++	}
++
+ 	return ThinkingConfig{}
+ }
+ 
+diff --git a/internal/thinking/apply_test.go b/internal/thinking/apply_test.go
+new file mode 100644
+index 0000000..a04832a
+--- /dev/null
++++ b/internal/thinking/apply_test.go
+@@ -0,0 +1,93 @@
++package thinking
++
++import "testing"
++
++func TestExtractClaudeConfig_OutputEffortPrecedence(t *testing.T) {
++	tests := []struct {
++		name       string
++		body       string
++		wantMode   ThinkingMode
++		wantBudget int
++		wantLevel  ThinkingLevel
++	}{
++		{
++			name:      "top-level effort without thinking",
++			body:      `{"output_config":{"effort":"low"}}`,
++			wantMode:  ModeLevel,
++			wantLevel: LevelLow,
++		},
++		{
++			name:      "top-level effort is normalized",
++			body:      `{"output_config":{"effort":" XHIGH "}}`,
++			wantMode:  ModeLevel,
++			wantLevel: LevelXHigh,
++		},
++		{
++			name:      "top-level max effort without thinking",
++			body:      `{"output_config":{"effort":"max"}}`,
++			wantMode:  ModeLevel,
++			wantLevel: LevelMax,
++		},
++		{
++			name: "blank top-level effort remains empty",
++			body: `{"output_config":{"effort":"  "}}`,
++		},
++		{
++			name: "non-string top-level effort remains empty",
++			body: `{"output_config":{"effort":42}}`,
++		},
++		{
++			name:      "adaptive effort remains supported",
++			body:      `{"thinking":{"type":"adaptive"},"output_config":{"effort":"high"}}`,
++			wantMode:  ModeLevel,
++			wantLevel: LevelHigh,
++		},
++		{
++			name: "adaptive without effort remains passthrough",
++			body: `{"thinking":{"type":"adaptive"}}`,
++		},
++		{
++			name:       "explicit disabled overrides effort",
++			body:       `{"thinking":{"type":"disabled"},"output_config":{"effort":"high"}}`,
++			wantMode:   ModeNone,
++			wantBudget: 0,
++		},
++		{
++			name:       "explicit budget overrides effort",
++			body:       `{"thinking":{"type":"enabled","budget_tokens":1024},"output_config":{"effort":"high"}}`,
++			wantMode:   ModeBudget,
++			wantBudget: 1024,
++		},
++		{
++			name:       "enabled without budget remains auto",
++			body:       `{"thinking":{"type":"enabled"},"output_config":{"effort":"high"}}`,
++			wantMode:   ModeAuto,
++			wantBudget: -1,
++		},
++		{
++			name: "unknown thinking object does not use effort fallback",
++			body: `{"thinking":{},"output_config":{"effort":"high"}}`,
++		},
++		{
++			name: "missing configuration remains empty",
++			body: `{}`,
++		},
++	}
++
++	for _, tt := range tests {
++		t.Run(tt.name, func(t *testing.T) {
++			got := extractClaudeConfig([]byte(tt.body))
++			if got.Mode != tt.wantMode || got.Budget != tt.wantBudget || got.Level != tt.wantLevel {
++				t.Fatalf(
++					"extractClaudeConfig() = {Mode:%v Budget:%d Level:%q}, want {Mode:%v Budget:%d Level:%q}",
++					got.Mode,
++					got.Budget,
++					got.Level,
++					tt.wantMode,
++					tt.wantBudget,
++					tt.wantLevel,
++				)
++			}
++		})
++	}
++}
+diff --git a/internal/translator/codex/claude/codex_claude_request.go b/internal/translator/codex/claude/codex_claude_request.go
+index 6728c2e..e776656 100644
+--- a/internal/translator/codex/claude/codex_claude_request.go
++++ b/internal/translator/codex/claude/codex_claude_request.go
+@@ -311,7 +311,12 @@ func ConvertClaudeRequestToCodex(modelName string, inputRawJSON []byte, _ bool)
+ 
+ 	// Convert thinking.budget_tokens to reasoning.effort.
+ 	reasoningEffort := "medium"
+-	if thinkingConfig := rootResult.Get("thinking"); thinkingConfig.Exists() && thinkingConfig.IsObject() {
++	thinkingConfig := rootResult.Get("thinking")
++	if !thinkingConfig.Exists() {
++		if effort, ok := thinking.ExtractClaudeOutputConfigEffort(rawJSON); ok {
++			reasoningEffort = effort
++		}
++	} else if thinkingConfig.IsObject() {
+ 		switch thinkingConfig.Get("type").String() {
+ 		case "enabled":
+ 			if budgetTokens := thinkingConfig.Get("budget_tokens"); budgetTokens.Exists() {
+@@ -323,11 +328,7 @@ func ConvertClaudeRequestToCodex(modelName string, inputRawJSON []byte, _ bool)
+ 		case "adaptive", "auto":
+ 			// Adaptive thinking can carry an explicit effort in output_config.effort (Claude 4.6).
+ 			// Pass through directly; ApplyThinking handles clamping to target model's levels.
+-			effort := ""
+-			if v := rootResult.Get("output_config.effort"); v.Exists() && v.Type == gjson.String {
+-				effort = strings.ToLower(strings.TrimSpace(v.String()))
+-			}
+-			if effort != "" {
++			if effort, ok := thinking.ExtractClaudeOutputConfigEffort(rawJSON); ok {
+ 				reasoningEffort = effort
+ 			} else {
+ 				reasoningEffort = string(thinking.LevelXHigh)
+diff --git a/internal/translator/codex/claude/codex_claude_request_test.go b/internal/translator/codex/claude/codex_claude_request_test.go
+index 68729ce..729770b 100644
+--- a/internal/translator/codex/claude/codex_claude_request_test.go
++++ b/internal/translator/codex/claude/codex_claude_request_test.go
+@@ -262,16 +262,83 @@ func TestConvertClaudeRequestToCodex_ServiceTier(t *testing.T) {
+ 	}
+ }
+ 
+-func TestConvertClaudeRequestToCodex_TopLevelEffortWithoutThinking(t *testing.T) {
+-	inputJSON := []byte(`{
+-		"model": "gpt-5.6-sol",
+-		"messages": [{"role": "user", "content": "hello"}],
+-		"output_config": {"effort": "low"}
+-	}`)
+-
+-	result := ConvertClaudeRequestToCodex("gpt-5.6-sol", inputJSON, false)
+-	if got := gjson.GetBytes(result, "reasoning.effort").String(); got != "low" {
+-		t.Fatalf("reasoning.effort = %q, want low", got)
++func TestConvertClaudeRequestToCodex_ReasoningEffort(t *testing.T) {
++	tests := []struct {
++		name       string
++		configJSON string
++		want       string
++	}{
++		{
++			name:       "top-level effort without thinking",
++			configJSON: `"output_config":{"effort":"low"}`,
++			want:       "low",
++		},
++		{
++			name:       "top-level effort is normalized",
++			configJSON: `"output_config":{"effort":" HIGH "}`,
++			want:       "high",
++		},
++		{
++			name:       "top-level medium without thinking",
++			configJSON: `"output_config":{"effort":"medium"}`,
++			want:       "medium",
++		},
++		{
++			name:       "top-level xhigh without thinking",
++			configJSON: `"output_config":{"effort":"xhigh"}`,
++			want:       "xhigh",
++		},
++		{
++			name:       "top-level max without thinking",
++			configJSON: `"output_config":{"effort":"max"}`,
++			want:       "max",
++		},
++		{
++			name: "missing effort keeps default",
++			want: "medium",
++		},
++		{
++			name:       "adaptive effort",
++			configJSON: `"thinking":{"type":"adaptive"},"output_config":{"effort":"low"}`,
++			want:       "low",
++		},
++		{
++			name:       "adaptive without effort keeps xhigh",
++			configJSON: `"thinking":{"type":"adaptive"}`,
++			want:       "xhigh",
++		},
++		{
++			name:       "enabled budget overrides effort",
++			configJSON: `"thinking":{"type":"enabled","budget_tokens":1024},"output_config":{"effort":"high"}`,
++			want:       "low",
++		},
++		{
++			name:       "enabled without budget keeps default",
++			configJSON: `"thinking":{"type":"enabled"},"output_config":{"effort":"high"}`,
++			want:       "medium",
++		},
++		{
++			name:       "disabled overrides effort",
++			configJSON: `"thinking":{"type":"disabled"},"output_config":{"effort":"high"}`,
++			want:       "none",
++		},
++	}
++
++	for _, tt := range tests {
++		t.Run(tt.name, func(t *testing.T) {
++			inputJSON := `{
++				"model": "gpt-5.6-sol",
++				"messages": [{"role": "user", "content": "hello"}]`
++			if tt.configJSON != "" {
++				inputJSON += "," + tt.configJSON
++			}
++			inputJSON += "}"
++
++			result := ConvertClaudeRequestToCodex("gpt-5.6-sol", []byte(inputJSON), false)
++			if got := gjson.GetBytes(result, "reasoning.effort").String(); got != tt.want {
++				t.Fatalf("reasoning.effort = %q, want %q", got, tt.want)
++			}
++		})
+ 	}
+ }
+ 
+-- 
+2.43.0

--- a/parable/skills/parable/references/providers.md
+++ b/parable/skills/parable/references/providers.md
@@ -200,8 +200,9 @@ Claude-to-Codex translation boundary. Its independently built binary preserved
 
 The patch is not an upstream release. Until CLIProxyAPI merges and releases
 the change, released `v7.2.88` users must treat non-medium effort as
-accepted-but-not-effective. The reproducible patched-source build route is
-published separately by loop E3.
+accepted-but-not-effective. Follow the
+[pinned five-minute patched-source path](../../../docs/CLIPROXYAPI_GPT_SUBSCRIPTION.md)
+for the exact build, OAuth, proxy, and Parable commands.
 
 ## Reading subscription headroom (parable-usage.sh)
 


### PR DESCRIPTION
## Summary

- vendor the checksum-pinned two-commit CLIProxyAPI effort patch
- add an end-to-end localhost ChatGPT-subscription setup guide
- include the guide and patch in the npm package surface
- record clean-archive apply, test, build, live, and upstream-status evidence

## Verification

- patch applies 2/2 commits to the official v7.2.88 commit archive
- focused thinking/translator tests and focused vet pass
- complete CLIProxyAPI Go suite and server build pass
- patched live matrix remains 15/15 exact with 3/3 tool canaries
- 81/81 Parable tests pass in an isolated HOME
- npm dry-run contains both guide and patch

## Boundary

Released v7.2.88 is still documented as medium-only. The required GitHub App has no upstream CLIProxyAPI write permission, so no upstream PR or release is claimed. Kimi remains paused.