### PR TITLE
docs(parable): prove Grok 4.5 catalog entitlement

### DIFF
--- a/parable/docs/evidence/x1-grok45-catalog/EXIT.md
+++ b/parable/docs/evidence/x1-grok45-catalog/EXIT.md
@@ -1,0 +1,60 @@
+# X1 — AUTHENTICATED CATALOG · EXIT (2026-07-20)
+
+## Status: COMPLETE
+
+## The headline evidence
+
+The authenticated loopback catalog contains exactly one `grok-4.5` owned by
+`xai`. Exact Sol, Terra, and Luna entries remain present and owned by
+`openai`. The successful catalog probe spent zero model turns.
+
+## What shipped
+
+| Piece | Where |
+|---|---|
+| Sanitized authenticated catalog receipt | `docs/evidence/x1-grok45-catalog/receipt.json` |
+
+## Bound accounting (honest)
+
+- Correctly wired catalog probes: 1/2; passed.
+- Evidence failures: 0.
+- Instrument failures: 0.
+- Review rounds: 1. JSON invariants, exact-id multiplicity, provider ownership,
+  listener address, API-key environment, and content/credential boundaries
+  were checked.
+
+ZEN check: one authenticated catalog query proves entitlement before
+inference. No model call, routing rule, broker, credential copy, or provider
+fallback is introduced.
+
+## Acceptance criteria → evidence
+
+1. Exact Grok entitlement — ✅ one `grok-4.5`, owned by `xai`.
+2. GPT catalog preserved — ✅ exact Sol, Terra, and Luna each appear once and
+   remain owned by `openai`.
+3. Loopback and no direct keys — ✅ listener is `127.0.0.1`; xAI, OpenAI, and
+   Anthropic API-key variables were unset.
+4. Receipt and EXIT merged — ✅ the focused PR and verified `main` are
+   recorded below.
+
+## The running delta table
+
+| Loop | xAI OAuth | Grok catalog | Grok turns | Named Grok child | Kimi |
+|---|---|---|---:|---:|---|
+| X0 | valid, mode 0600 | not probed | 0 | 0 | PAUSED |
+| X1 | valid | 1 exact `grok-4.5` | 0 | 0 | PAUSED |
+
+MEASURE is entitlement count, not inference quality: exact Grok count moved
+from unproved to one; model turns remain zero.
+
+## Merge verification
+
+- JSON invariants: PASS.
+- Local Claudio-Michel review: 5/5.
+- Focused PR: pending.
+- Verified merged `main`: pending.
+
+## exit → X2
+
+Run the five Claude Code effort values on Grok 4.5 plus supported-effort tool
+canaries. Runtime wire evidence decides exact, clamp, or rejection behavior.

--- a/parable/docs/evidence/x1-grok45-catalog/EXIT.md
+++ b/parable/docs/evidence/x1-grok45-catalog/EXIT.md
@@ -51,7 +51,7 @@ from unproved to one; model turns remain zero.
 
 - JSON invariants: PASS.
 - Local Claudio-Michel review: 5/5.
-- Focused PR: pending.
+- Focused PR: [#152](https://github.com/miguelrios/unc-skills/pull/152).
 - Verified merged `main`: pending.
 
 ## exit → X2

--- a/parable/docs/evidence/x1-grok45-catalog/receipt.json
+++ b/parable/docs/evidence/x1-grok45-catalog/receipt.json
@@ -1,0 +1,61 @@
+{
+  "schema_version": 1,
+  "loop": "X1",
+  "captured_at_utc": "2026-07-20T06:09:25Z",
+  "parable_baseline_head": "1b6603eda96268772601a68e4ad23cd929b7fa4b",
+  "runtime": {
+    "cliproxyapi_upstream_release": "v7.2.88",
+    "cliproxyapi_upstream_commit": "93d74a890a44802f656d7f39a573916b2611896e",
+    "cliproxyapi_local_fix_commit": "ad20a87efbbd41a9d4f24c83ca8bdd934bf34ab7",
+    "cliproxyapi_binary_sha256": "139e1305a878e08026dd0fb6d85a3817801f32e40a40c1954ea1973c5bb9d697",
+    "loopback_address": "127.0.0.1",
+    "dedicated_port": 18317,
+    "local_model_catalog": true
+  },
+  "probe": {
+    "endpoint": "/v1/models",
+    "http_status": 200,
+    "authenticated": true,
+    "total_models": 23,
+    "model_turns_spent": 0,
+    "targets": [
+      {
+        "id": "grok-4.5",
+        "owned_by": "xai",
+        "count": 1
+      },
+      {
+        "id": "gpt-5.6-sol",
+        "owned_by": "openai",
+        "count": 1
+      },
+      {
+        "id": "gpt-5.6-terra",
+        "owned_by": "openai",
+        "count": 1
+      },
+      {
+        "id": "gpt-5.6-luna",
+        "owned_by": "openai",
+        "count": 1
+      }
+    ]
+  },
+  "routing": {
+    "grok_provider": "xai",
+    "grok_auth_kind": "oauth",
+    "gpt_provider": "openai",
+    "gpt_auth_kind": "oauth",
+    "xai_api_key_set": false,
+    "openai_api_key_set": false,
+    "anthropic_api_key_set": false
+  },
+  "safety": {
+    "local_proxy_key_committed": false,
+    "credential_material_committed": false,
+    "oauth_state_committed": false,
+    "account_identifier_committed": false,
+    "raw_catalog_committed": false,
+    "private_path_committed": false
+  }
+}


### PR DESCRIPTION
## Summary

- prove exact grok-4.5 entitlement through the authenticated local catalog
- confirm Sol, Terra, and Luna remain present
- spend zero model turns before the inference matrix

## Evidence

- one grok-4.5 owned by xai
- one each of gpt-5.6-sol, terra, and luna owned by openai
- authenticated /v1/models returned 200 with 23 total models
- loopback-only listener; direct provider API keys unset

No raw catalog, local proxy key, OAuth state, account identifier, or private path is committed.