### PR TITLE
feat(recall): canonical v2 writer and private archive

### DIFF
--- a/.github/workflows/recall-ci.yml
+++ b/.github/workflows/recall-ci.yml
@@ -51,6 +51,7 @@ jobs:
             e2e_v2_canonical_plane.py \
             e2e_v2_lifecycle.py \
             e2e_v2_isolation.py \
+            e2e_v2_connector_writer.py \
             e2e_session_source_l1.py \
             e2e_semantic_l2.py \
             e2e_capture_mcp.py \

--- a/recall/client/cli.py
+++ b/recall/client/cli.py
@@ -9,6 +9,8 @@ from pathlib import Path
 
 from client.mac import (
     BrainClient,
+    CanonicalArchiveClient,
+    CanonicalBrainWriter,
     ExportImporter,
     MemoryClient,
     dry_run_manifest,
@@ -98,6 +100,62 @@ def _token(args) -> str:
     if args.token_file:
         return load_file_token(Path(args.token_file))
     return load_keychain_token(args.keychain_service, args.keychain_account)
+
+
+def _connector_runner(
+    *,
+    connector,
+    common: dict,
+    spool_path: Path,
+    privacy: PrivacyPolicy,
+) -> ConnectorRunner:
+    canonical = _canonical_clients(common)
+    if canonical is None:
+        return ConnectorRunner(
+            connector=connector,
+            brain=BrainClient(**common),
+            spool_path=spool_path,
+            privacy=privacy,
+        )
+    brain, archive, tenant_id, principal_id = canonical
+    return ConnectorRunner(
+        connector=connector,
+        brain=brain,
+        archive=archive,
+        tenant_id=tenant_id,
+        principal_id=principal_id,
+        spool_path=spool_path,
+        privacy=privacy,
+    )
+
+
+def _canonical_clients(
+    common: dict,
+) -> tuple[CanonicalBrainWriter, CanonicalArchiveClient, str, str] | None:
+    if os.environ.get("RECALL_CANONICAL_V2_ENABLED") != "1":
+        return None
+    tenant_id = os.environ.get("RECALL_TENANT_ID")
+    principal_id = os.environ.get("RECALL_PRINCIPAL_ID")
+    if (
+        not tenant_id
+        or not principal_id
+        or principal_id != common["principal_id"]
+        or common.get("visibility") != "private"
+    ):
+        raise ValueError("canonical connector identity is incomplete")
+    canonical = {
+        "endpoint": common["endpoint"],
+        "token": common["token"],
+        "source_id": common["source_id"],
+        "tenant_id": tenant_id,
+        "principal_id": principal_id,
+    }
+    return (
+        CanonicalBrainWriter(**canonical),
+        CanonicalArchiveClient(**canonical),
+        tenant_id,
+        principal_id,
+    )
 
 
 def _auth(parser: argparse.ArgumentParser) -> None:
@@ -891,11 +949,15 @@ def main() -> None:
         )
         return
     if args.command == "collect":
+        canonical = _canonical_clients(common)
         collector = Collector(
             root=Path(args.root), harness=args.harness, source_id=args.source_id,
             spool_path=Path(args.spool), endpoint=args.endpoint, token=token,
             principal_id=args.principal_id, visibility=args.visibility,
             privacy=privacy,
+            brain_writer=canonical[0] if canonical else None,
+            archive=canonical[1] if canonical else None,
+            tenant_id=canonical[2] if canonical else None,
         )
         try:
             result = {
@@ -909,8 +971,8 @@ def main() -> None:
         connector = CoworkLocalConnector(
             root=Path(args.root), source_id=args.source_id,
         )
-        runner = ConnectorRunner(
-            connector=connector, brain=BrainClient(**common),
+        runner = _connector_runner(
+            connector=connector, common=common,
             spool_path=Path(args.spool), privacy=privacy,
         )
         try:
@@ -926,8 +988,8 @@ def main() -> None:
             date_min=args.date_min,
             date_max=args.date_max,
         )
-        runner = ConnectorRunner(
-            connector=connector, brain=BrainClient(**common),
+        runner = _connector_runner(
+            connector=connector, common=common,
             spool_path=Path(args.spool), privacy=privacy,
         )
         try:
@@ -944,8 +1006,8 @@ def main() -> None:
             timezone_name=args.timezone,
             page_size=args.page_size,
         )
-        runner = ConnectorRunner(
-            connector=connector, brain=BrainClient(**common),
+        runner = _connector_runner(
+            connector=connector, common=common,
             spool_path=Path(args.spool), privacy=privacy,
         )
         try:
@@ -960,8 +1022,8 @@ def main() -> None:
             max_depth=args.max_depth,
             page_size=args.page_size,
         )
-        runner = ConnectorRunner(
-            connector=connector, brain=BrainClient(**common),
+        runner = _connector_runner(
+            connector=connector, common=common,
             spool_path=Path(args.spool), privacy=privacy,
         )
         try:
@@ -978,8 +1040,8 @@ def main() -> None:
             date_max=args.date_max,
             page_size=args.page_size,
         )
-        runner = ConnectorRunner(
-            connector=connector, brain=BrainClient(**common),
+        runner = _connector_runner(
+            connector=connector, common=common,
             spool_path=Path(args.spool), privacy=privacy,
         )
         try:
@@ -994,8 +1056,8 @@ def main() -> None:
             date_max=args.date_max,
             page_size=args.page_size,
         )
-        runner = ConnectorRunner(
-            connector=connector, brain=BrainClient(**common),
+        runner = _connector_runner(
+            connector=connector, common=common,
             spool_path=Path(args.spool), privacy=privacy,
         )
         try:
@@ -1012,8 +1074,8 @@ def main() -> None:
             date_max=args.date_max,
             page_size=args.page_size,
         )
-        runner = ConnectorRunner(
-            connector=connector, brain=BrainClient(**common),
+        runner = _connector_runner(
+            connector=connector, common=common,
             spool_path=Path(args.spool), privacy=privacy,
         )
         try:
@@ -1042,8 +1104,8 @@ def main() -> None:
             removed_native_ids=tuple(sorted(args.remove_native_id)),
             page_size=args.page_size,
         )
-        runner = ConnectorRunner(
-            connector=connector, brain=BrainClient(**common),
+        runner = _connector_runner(
+            connector=connector, common=common,
             spool_path=Path(args.spool), privacy=privacy,
         )
         try:
@@ -1051,11 +1113,11 @@ def main() -> None:
         finally:
             runner.close()
     elif args.command == "feed-sync":
-        runner = ConnectorRunner(
+        runner = _connector_runner(
             connector=FeedConnector(
                 url=args.url, feed_id=args.feed_id, source_id=args.source_id,
             ),
-            brain=BrainClient(**common),
+            common=common,
             spool_path=Path(args.spool),
             privacy=privacy,
         )
@@ -1064,7 +1126,7 @@ def main() -> None:
         finally:
             runner.close()
     elif args.command == "jsonl-import-sync":
-        runner = ConnectorRunner(
+        runner = _connector_runner(
             connector=SelectedJsonlConnector(
                 root=Path(args.root),
                 source_id=args.source_id,
@@ -1072,7 +1134,7 @@ def main() -> None:
                 max_depth=args.max_depth,
                 page_size=args.page_size,
             ),
-            brain=BrainClient(**common),
+            common=common,
             spool_path=Path(args.spool),
             privacy=privacy,
         )
@@ -1092,8 +1154,8 @@ def main() -> None:
             inbox=Path(args.inbox), catalog_path=Path(args.catalog),
             source_id=args.source_id, privacy_mode=args.privacy_mode,
         )
-        runner = ConnectorRunner(
-            connector=connector, brain=BrainClient(**common),
+        runner = _connector_runner(
+            connector=connector, common=common,
             spool_path=Path(args.spool), privacy=privacy,
         )
         try:
@@ -1113,8 +1175,8 @@ def main() -> None:
             api_key=grep_key,
             source_id=args.source_id, max_pages=args.max_pages, page_size=args.page_size,
         )
-        runner = ConnectorRunner(
-            connector=connector, brain=BrainClient(**common),
+        runner = _connector_runner(
+            connector=connector, common=common,
             spool_path=Path(args.spool), privacy=privacy,
         )
         try:

--- a/recall/client/mac.py
+++ b/recall/client/mac.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import copy
+import base64
 import hashlib
 import json
 import os
@@ -8,6 +9,7 @@ import platform
 import re
 import stat
 import urllib.parse
+import urllib.error
 import urllib.request
 import uuid
 import zipfile
@@ -33,14 +35,22 @@ FORBIDDEN_PRIVATE_PATHS = (
 PATTERNS = {"claude": "*.jsonl", "codex": "rollout-*.jsonl"}
 SAFE_EXPORT_SUFFIXES = {".json", ".jsonl"}
 SOURCE_ID = re.compile(r"^[A-Za-z0-9_.:@-]{3,160}$")
+V2_IDENTITY = re.compile(r"[A-Za-z0-9][A-Za-z0-9:._/@+-]{1,255}\Z")
 MAX_INGEST_BYTES = 8_000_000
 MAX_INGEST_EVENTS = 500
+MAX_CANONICAL_ARCHIVE_BYTES = 8_000_000
 MAX_EXPORT_BYTES = 256_000_000
 MAX_ARCHIVE_MEMBERS = 10_000
 
 
 class PrivacyError(ValueError):
     pass
+
+
+class CanonicalClientError(RuntimeError):
+    def __init__(self, error_code: str):
+        self.error_code = error_code
+        super().__init__(error_code)
 
 
 def iso_now() -> str:
@@ -433,6 +443,106 @@ class BrainClient:
 
     def doctor(self) -> dict:
         return self._request("/v1/doctor")
+
+
+class _CanonicalClient(BrainClient):
+    def __init__(
+        self,
+        *,
+        endpoint: str,
+        token: str,
+        source_id: str,
+        tenant_id: str,
+        principal_id: str,
+    ):
+        if not isinstance(tenant_id, str) or not V2_IDENTITY.fullmatch(tenant_id):
+            raise ValueError("invalid tenant id")
+        if not isinstance(principal_id, str) or not V2_IDENTITY.fullmatch(principal_id):
+            raise ValueError("invalid principal id")
+        super().__init__(
+            endpoint=endpoint,
+            token=token,
+            source_id=source_id,
+            principal_id=principal_id,
+            visibility="private",
+        )
+        self.tenant_id = tenant_id
+
+
+class CanonicalArchiveClient(_CanonicalClient):
+    """Source-scoped client for archive writes fenced by the canonical service."""
+
+    def put_raw(
+        self,
+        *,
+        tenant_id: str,
+        source_id: str,
+        native_id: str,
+        payload: bytes,
+        media_type: str,
+        created_at: str,
+    ) -> dict[str, Any]:
+        if tenant_id != self.tenant_id or source_id != self.source_id:
+            raise PermissionError("canonical archive scope mismatch")
+        if not isinstance(payload, bytes) or len(payload) > MAX_CANONICAL_ARCHIVE_BYTES:
+            raise ValueError("canonical archive payload is invalid")
+        if not isinstance(native_id, str) or not V2_IDENTITY.fullmatch(native_id):
+            raise ValueError("canonical archive identity is invalid")
+        try:
+            return self._request(
+                "/v2/archive/objects",
+                body={
+                    "tenant_id": self.tenant_id,
+                    "principal_id": self.principal_id,
+                    "source_id": self.source_id,
+                    "native_id": native_id,
+                    "payload_base64": base64.b64encode(payload).decode(),
+                    "media_type": media_type,
+                    "created_at": created_at,
+                },
+            )
+        except urllib.error.HTTPError as error:
+            error_code = "archive_unavailable"
+            try:
+                response = json.loads(error.read(4096))
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                response = {}
+            if (
+                error.code == 409
+                and response.get("error") == "archive_identity_forgotten"
+            ):
+                error_code = "archive_identity_forgotten"
+            raise CanonicalClientError(error_code) from None
+
+
+class CanonicalBrainWriter(_CanonicalClient):
+    """Connector BrainWriter that commits only privacy-safe canonical envelopes."""
+
+    def ingest(self, events: list[dict[str, Any]]) -> dict[str, Any]:
+        if not events or len(events) > MAX_INGEST_EVENTS:
+            raise ValueError("canonical ingest batch is invalid")
+        for event in events:
+            if (
+                not isinstance(event, dict)
+                or event.get("source_id") != self.source_id
+                or event.get("principal_id") != self.principal_id
+                or not isinstance(event.get("provenance", {}).get("artifact_ref"), dict)
+            ):
+                raise PermissionError("canonical ingest scope mismatch")
+        body = {
+            "tenant_id": self.tenant_id,
+            "principal_id": self.principal_id,
+            "events": events,
+        }
+        encoded = canonical_json(body)
+        if len(encoded) > MAX_INGEST_BYTES:
+            raise ValueError("canonical ingest batch exceeds client size limit")
+        key = "canonical-v2-" + hashlib.sha256(encoded).hexdigest()
+        return self._request(
+            "/v2/ingest/canonical",
+            body=body,
+            idempotency_key=key,
+        )
 
 
 class MemoryClient(BrainClient):

--- a/recall/collector/cli.py
+++ b/recall/collector/cli.py
@@ -7,7 +7,11 @@ import time
 from pathlib import Path
 
 from .collector import Collector
-from client.mac import load_file_token
+from client.mac import (
+    CanonicalArchiveClient,
+    CanonicalBrainWriter,
+    load_file_token,
+)
 from privacy.policy import AgenticJudge, PrivacyPolicy, load_scoped_virtual_key
 
 
@@ -47,13 +51,40 @@ def main() -> None:
         model=args.privacy_judge_model,
     ) if all(judge_values) else None
     privacy = PrivacyPolicy(mode=args.privacy_mode, judge=judge, judge_failure=args.privacy_judge_failure)
+    token = token_from_file(args.token_file) if args.token_file else "unused"
+    canonical = None
+    if os.environ.get("RECALL_CANONICAL_V2_ENABLED") == "1":
+        tenant_id = os.environ.get("RECALL_TENANT_ID")
+        principal_id = os.environ.get("RECALL_PRINCIPAL_ID")
+        if (
+            not tenant_id
+            or not principal_id
+            or principal_id != args.principal_id
+            or args.visibility != "private"
+        ):
+            parser.error("canonical collector identity is incomplete")
+        common = {
+            "endpoint": args.endpoint,
+            "token": token,
+            "source_id": args.source_id,
+            "tenant_id": tenant_id,
+            "principal_id": principal_id,
+        }
+        canonical = (
+            CanonicalBrainWriter(**common),
+            CanonicalArchiveClient(**common),
+            tenant_id,
+        )
     collector = Collector(
         root=Path(args.root), harness=args.harness, source_id=args.source_id,
         spool_path=Path(args.spool), endpoint=args.endpoint or "http://127.0.0.1:1",
-        token=token_from_file(args.token_file) if args.token_file else "unused",
+        token=token,
         principal_id=args.principal_id,
         visibility=args.visibility,
         privacy=privacy,
+        brain_writer=canonical[0] if canonical else None,
+        archive=canonical[1] if canonical else None,
+        tenant_id=canonical[2] if canonical else None,
     )
     if args.shard_count < 1 or not 0 <= args.shard_index < args.shard_count:
         parser.error("shard index must be within shard count")

--- a/recall/collector/collector.py
+++ b/recall/collector/collector.py
@@ -76,11 +76,16 @@ class Collector:
     def __init__(self, *, root: Path, harness: str, source_id: str, spool_path: Path,
                  endpoint: str, token: str, principal_id: str = "owner",
                  visibility: str = "private", batch_size: int = 500,
-                 privacy: PrivacyPolicy | None = None):
+                 privacy: PrivacyPolicy | None = None, brain_writer: Any = None,
+                 archive: Any = None, tenant_id: str | None = None):
         if harness not in {"claude", "codex"}:
             raise ValueError("harness must be claude or codex")
         if visibility not in {"private", "shared"}:
             raise ValueError("visibility must be private or shared")
+        if (brain_writer is None) != (archive is None) or (
+            archive is not None and not tenant_id
+        ):
+            raise ValueError("canonical collector runtime is incomplete")
         self.root = Path(root).expanduser().resolve()
         self.harness = harness
         self.source_id = source_id
@@ -91,6 +96,9 @@ class Collector:
         self.visibility = visibility
         self.batch_size = batch_size
         self.privacy = privacy or PrivacyPolicy(mode="off")
+        self.brain_writer = brain_writer
+        self.archive = archive
+        self.tenant_id = tenant_id
         self.shard_count = 1
         self.shard_index = 0
         self.spool_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
@@ -183,8 +191,21 @@ class Collector:
         return int.from_bytes(hashlib.sha256(path.encode()).digest()[:8], "big") & ((1 << 63) - 1)
 
     def _envelope(self, path: Path, native_id: str, kind: str, content: Any,
-                  occurred_at: str, start: int, end: int) -> dict:
+                  occurred_at: str, start: int, end: int,
+                  artifact_ref: dict[str, Any] | None = None) -> dict:
         clean = sanitize(content)
+        provenance = {
+            "harness": self.harness,
+            "connector_id": f"{self.harness}.jsonl",
+            "connector_schema_version": COLLECTOR_VERSION,
+            "collector_version": COLLECTOR_VERSION,
+            "privacy_policy_version": self.privacy.apply({}).policy_version,
+            "original_path": str(path),
+            "byte_start": start,
+            "byte_end": end,
+        }
+        if artifact_ref is not None:
+            provenance["artifact_ref"] = artifact_ref
         return {
             "schema_version": 1,
             "source_id": self.source_id,
@@ -198,15 +219,26 @@ class Collector:
             "content_type": "application/json",
             "content": clean,
             "content_sha256": hashlib.sha256(canonical_json(clean)).hexdigest(),
-            "provenance": {
-                "harness": self.harness,
-                "collector_version": COLLECTOR_VERSION,
-                "privacy_policy_version": self.privacy.apply({}).policy_version,
-                "original_path": str(path),
-                "byte_start": start,
-                "byte_end": end,
-            },
+            "provenance": provenance,
         }
+
+    def _archive_raw(
+        self,
+        *,
+        native_id: str,
+        payload: bytes,
+        occurred_at: str,
+    ) -> dict[str, Any] | None:
+        if self.archive is None:
+            return None
+        return self.archive.put_raw(
+            tenant_id=self.tenant_id,
+            source_id=self.source_id,
+            native_id=native_id,
+            payload=payload,
+            media_type="application/x-ndjson",
+            created_at=occurred_at,
+        )
 
     def _versioned_record_content(self, native_id: str, content: dict, *, was_active: bool) -> dict:
         clean = sanitize(content)
@@ -301,8 +333,16 @@ class Collector:
                             self.db.execute("INSERT OR IGNORE INTO scan_members(path,native_id) VALUES (?,?)", (path_text, native_id))
                         continue
                     content = privacy.value
+                    artifact_ref = self._archive_raw(
+                        native_id=native_id,
+                        payload=line,
+                        occurred_at=occurred_at,
+                    )
                     versioned_content = self._versioned_record_content(native_id, content, was_active=native_id in old_active)
-                    envelope = self._envelope(path, native_id, "transcript_record", versioned_content, occurred_at, line_start, complete_end)
+                    envelope = self._envelope(
+                        path, native_id, "transcript_record", versioned_content,
+                        occurred_at, line_start, complete_end, artifact_ref,
+                    )
                     if self._queue(path, envelope, complete_end):
                         summary["records_queued"] += 1
                     self.db.execute(
@@ -321,7 +361,19 @@ class Collector:
                     if native_id in seen_native:
                         continue
                     content = {"target_native_id": native_id, "deletion_id": scan_id}
-                    envelope = self._envelope(path, native_id, "tombstone", content, iso_now(), old["start_offset"], old["end_offset"])
+                    occurred_at = iso_now()
+                    artifact_ref = self._archive_raw(
+                        native_id=native_id,
+                        payload=canonical_json({
+                            "deleted": True,
+                            "native_id": native_id,
+                        }),
+                        occurred_at=occurred_at,
+                    )
+                    envelope = self._envelope(
+                        path, native_id, "tombstone", content, occurred_at,
+                        old["start_offset"], old["end_offset"], artifact_ref,
+                    )
                     if self._queue(path, envelope, complete_end):
                         summary["tombstones_queued"] += 1
                     self.db.execute("DELETE FROM active_records WHERE path=? AND native_id=?", (path_text, native_id))
@@ -336,7 +388,21 @@ class Collector:
         for item in missing:
             for old in self.db.execute("SELECT * FROM active_records WHERE path=?", (item["path"],)):
                 path = Path(item["path"])
-                envelope = self._envelope(path, old["native_id"], "tombstone", {"target_native_id": old["native_id"], "deletion_id": scan_id}, iso_now(), old["start_offset"], old["end_offset"])
+                occurred_at = iso_now()
+                artifact_ref = self._archive_raw(
+                    native_id=old["native_id"],
+                    payload=canonical_json({
+                        "deleted": True,
+                        "native_id": old["native_id"],
+                    }),
+                    occurred_at=occurred_at,
+                )
+                envelope = self._envelope(
+                    path, old["native_id"], "tombstone",
+                    {"target_native_id": old["native_id"], "deletion_id": scan_id},
+                    occurred_at, old["start_offset"], old["end_offset"],
+                    artifact_ref,
+                )
                 if self._queue(path, envelope, old["end_offset"]):
                     summary["tombstones_queued"] += 1
             self.db.execute("DELETE FROM active_records WHERE path=?", (item["path"],))
@@ -372,10 +438,19 @@ class Collector:
                     result["recovered"] += 1
                     continue
                 versioned = self._versioned_record_content(row["native_id"], privacy.value, was_active=True)
+                occurred_at = normalized_timestamp(
+                    content.get("timestamp"),
+                    path.stat().st_mtime,
+                )
+                artifact_ref = self._archive_raw(
+                    native_id=row["native_id"],
+                    payload=raw,
+                    occurred_at=occurred_at,
+                )
                 envelope = self._envelope(
                     path, row["native_id"], "transcript_record", versioned,
-                    normalized_timestamp(content.get("timestamp"), path.stat().st_mtime),
-                    row["start_offset"], row["end_offset"],
+                    occurred_at, row["start_offset"], row["end_offset"],
+                    artifact_ref,
                 )
                 self.db.execute(
                     "UPDATE outbox SET state='pending',content_sha256=?,envelope_json=?,queued_at=?,acked_at=NULL,receipt=NULL WHERE id=?",
@@ -488,10 +563,19 @@ class Collector:
             acknowledgement = None
             for attempt in range(5):
                 try:
-                    with open_no_redirect(request, timeout=60) as response:
-                        acknowledgement = json.loads(response.read())
-                        if response.status not in {200, 201} or acknowledgement.get("status") != "committed":
-                            raise RuntimeError("server did not return a commit acknowledgement")
+                    if self.brain_writer is not None:
+                        acknowledgement = self.brain_writer.ingest(events)
+                    else:
+                        with open_no_redirect(request, timeout=60) as response:
+                            acknowledgement = json.loads(response.read())
+                            if response.status not in {200, 201}:
+                                raise RuntimeError(
+                                    "server did not return a commit acknowledgement"
+                                )
+                    if acknowledgement.get("status") != "committed":
+                        raise RuntimeError(
+                            "server did not return a commit acknowledgement"
+                        )
                     break
                 except urllib.error.HTTPError as exc:
                     result["errors"] += 1

--- a/recall/connectors/README.md
+++ b/recall/connectors/README.md
@@ -212,6 +212,12 @@ A provider failure changes only that job's backoff. Supervisor state and spools
 survive image restarts; an unchanged provider cycle advances a bounded private
 cycle generation without creating another acknowledged content version.
 
+For canonical v2, set `RECALL_CANONICAL_V2_ENABLED=1`,
+`RECALL_TENANT_ID`, and `RECALL_PRINCIPAL_ID` in the worker environment.
+The host then replaces the legacy Brain client with the tenant-scoped canonical
+archive client and writer. The existing per-job Brain credential must have been
+created with the matching tenant, principal, source, and `write` scope.
+
 ### Portable mail, calendar, and contacts
 
 The first portable-import pack reads one explicitly selected file: EML or
@@ -594,7 +600,8 @@ recall-brain connector-supervisor-run --config "$PRIVATE/host.json" \
 Without `--once`, the host runs bounded supervisor cycles. TERM/INT wake and
 stop it; HUP wakes the current cycle and reloads the private config between
 cycles. Only the closed factory may construct `ExportInboxConnector`,
-`GrepAIConnector`, `BrainClient`, `PrivacyPolicy`, and `ConnectorRunner`.
+`GrepAIConnector`, the selected legacy or canonical Brain writer,
+`PrivacyPolicy`, and `ConnectorRunner`.
 
 The macOS installer accepts `--connector-supervisor-config FILE` to install the
 fixed `ai.parcha.recall.connector-supervisor` LaunchAgent. The plist passes the

--- a/recall/connectors/host.py
+++ b/recall/connectors/host.py
@@ -16,7 +16,13 @@ from types import MappingProxyType
 from typing import Any, Callable, Mapping
 from urllib.parse import urlparse
 
-from client.mac import BrainClient, load_file_token, load_keychain_token
+from client.mac import (
+    BrainClient,
+    CanonicalArchiveClient,
+    CanonicalBrainWriter,
+    load_file_token,
+    load_keychain_token,
+)
 from connectors.export_inbox import ExportInboxConnector
 from connectors.grep_ai import GrepAIConnector, load_private_api_key, validate_api_key
 from connectors.google_workspace import (
@@ -26,7 +32,7 @@ from connectors.google_workspace import (
     GoogleDriveConnector,
 )
 from connectors.registry import ConnectorRegistryError, validate_policy
-from connectors.sdk import SOURCE_ID, ConnectorRunner
+from connectors.sdk import IDENTITY, SOURCE_ID, ConnectorRunner
 from connectors.supervisor import (
     ConnectorSupervisor,
     ScheduleDefinition,
@@ -690,13 +696,40 @@ def build_host(
     runners: list[ConnectorRunner] = []
     connectors: list[Any] = []
     jobs: list[ScheduledJob] = []
+    canonical_v2 = os.environ.get("RECALL_CANONICAL_V2_ENABLED") == "1"
+    tenant_id = os.environ.get("RECALL_TENANT_ID") if canonical_v2 else None
+    principal_id = os.environ.get("RECALL_PRINCIPAL_ID") if canonical_v2 else "owner"
+    if canonical_v2 and (
+        not isinstance(tenant_id, str)
+        or not IDENTITY.fullmatch(tenant_id)
+        or not isinstance(principal_id, str)
+        or not IDENTITY.fullmatch(principal_id)
+    ):
+        store.close()
+        raise ConnectorHostError("invalid_canonical_identity")
     try:
         for item in config.jobs:
             privacy = PrivacyPolicy(mode=item.privacy_mode)
-            brain = BrainClient(
-                endpoint=item.endpoint, token=item.brain_authority.load_brain(),
-                source_id=item.source_id, principal_id="owner", visibility="private",
-            )
+            token = item.brain_authority.load_brain()
+            if canonical_v2:
+                common = {
+                    "endpoint": item.endpoint,
+                    "token": token,
+                    "source_id": item.source_id,
+                    "tenant_id": tenant_id,
+                    "principal_id": principal_id,
+                }
+                brain = CanonicalBrainWriter(**common)
+                archive = CanonicalArchiveClient(**common)
+            else:
+                brain = BrainClient(
+                    endpoint=item.endpoint,
+                    token=token,
+                    source_id=item.source_id,
+                    principal_id="owner",
+                    visibility="private",
+                )
+                archive = None
             factory = HOSTED_FACTORIES[item.schedule.connector_id]
             transport = (
                 grep_transport
@@ -707,7 +740,13 @@ def build_host(
                 item.connector, item.source_id, item.privacy_mode, transport,
             )
             runner = ConnectorRunner(
-                connector=connector, brain=brain, spool_path=spool, privacy=privacy,
+                connector=connector,
+                brain=brain,
+                spool_path=spool,
+                privacy=privacy,
+                archive=archive,
+                tenant_id=tenant_id,
+                principal_id=principal_id,
             )
             connectors.append(connector)
             runners.append(runner)

--- a/recall/connectors/sdk.py
+++ b/recall/connectors/sdk.py
@@ -117,7 +117,10 @@ def _validate_acknowledgement(value: Any, events: list[dict[str, Any]]) -> None:
         if (
             not isinstance(receipt, str)
             or not receipt.startswith(prefix)
-            or not re.fullmatch(r"[1-9][0-9]*", receipt.removeprefix(prefix))
+            or not re.fullmatch(
+                r"[1-9][0-9]*(?:#item=0)?",
+                receipt.removeprefix(prefix),
+            )
         ):
             raise ConnectorRunError("brain_invalid_acknowledgement")
 
@@ -655,26 +658,30 @@ class ConnectorRunner:
         forgotten = 0
         for record in page.records:
             was_forgotten = False
+            was_deduplicated = False
             provenance_decision = PrivacyPolicy(mode="scrub").apply(record.provenance)
             safe_provenance = provenance_decision.value
             if record.deleted:
-                decision = PrivacyPolicy(mode="off").apply({"content": {}, "provenance": safe_provenance})
-                try:
-                    artifact_ref = self._archive_raw(record)
-                except ConnectorRunError as error:
-                    if error.error_code != "archive_identity_forgotten":
-                        raise
-                    artifact_ref = None
-                    event = None
-                    forgotten += 1
-                    was_forgotten = True
-                else:
-                    archived += int(artifact_ref is not None)
-                    event = self._event(record, {}, decision.value["provenance"], artifact_ref)
+                decision = PrivacyPolicy(mode="off").apply(
+                    {"content": {}, "provenance": safe_provenance}
+                )
             else:
-                decision = self.privacy.apply({"content": record.content, "provenance": safe_provenance})
-                if decision.action == "drop":
+                decision = self.privacy.apply(
+                    {"content": record.content, "provenance": safe_provenance}
+                )
+            if decision.action == "drop":
+                event = None
+            else:
+                content = {} if record.deleted else decision.value["content"]
+                preliminary = self._event(
+                    record,
+                    content,
+                    decision.value["provenance"],
+                )
+                if self._acknowledged(preliminary):
                     event = None
+                    deduplicated += 1
+                    was_deduplicated = True
                 else:
                     try:
                         artifact_ref = self._archive_raw(record)
@@ -689,15 +696,13 @@ class ConnectorRunner:
                         archived += int(artifact_ref is not None)
                         event = self._event(
                             record,
-                            decision.value["content"],
+                            content,
                             decision.value["provenance"],
                             artifact_ref,
                         )
             receipts.append(decision.receipt())
             if event is None:
-                dropped += int(not was_forgotten)
-            elif self._acknowledged(event):
-                deduplicated += 1
+                dropped += int(not was_forgotten and not was_deduplicated)
             else:
                 events.append(event)
         privacy = summarize_receipts(receipts, self.privacy.mode)

--- a/recall/server/deploy/README.md
+++ b/recall/server/deploy/README.md
@@ -61,7 +61,7 @@ infrastructure. The example is synthetic; a live manifest belongs in a private m
 location and contains references, never credential values.
 
 The production database gate requires a standard PostgreSQL URL with
-`sslmode=verify-full` and an explicit trust root, schema migrations 1 through 26,
+`sslmode=verify-full` and an explicit trust root, schema migrations 1 through 27,
 pgvector 0.8.0 or newer, and a runtime role without superuser, database/role creation,
 replication, or RLS-bypass privilege:
 
@@ -164,6 +164,26 @@ Recall does not read a Cloudflare management API token. Validate the configured
 archive with `python -m recall_server.cli archive-check`; the probe writes,
 replays, reads, deletes, and verifies absence using synthetic bytes, then emits
 only a content-free status.
+
+Enable the canonical v2 write plane only after the archive probe and database
+migrations pass:
+
+```text
+RECALL_CANONICAL_V2_ENABLED=1
+RECALL_CANONICAL_INGEST_PUBLIC=1
+RECALL_TENANT_ID=tenant:personal
+RECALL_PRINCIPAL_ID=principal:owner
+```
+
+`RECALL_CANONICAL_INGEST_PUBLIC=1` adds only the authenticated
+`POST /v2/archive/objects` and `POST /v2/ingest/canonical` routes to a public
+profile. Both require a write credential bound to the exact tenant, principal,
+and source. Create one such credential per source with `token-create --tenant
+TENANT --principal PRINCIPAL --source SOURCE --scopes write`. The connector
+runner archives raw bytes through the fenced archive route, applies privacy,
+writes only the redacted envelope to its private spool, and advances its cursor
+only after the canonical ACK. Do not enable this flag on an MCP-only service
+that has no collector ingress.
 
 `RECALL_DATABASE_URL` must be a PlanetScale application role URL with
 `sslmode=verify-full` and an explicit trust root. Prefer

--- a/recall/server/deploy/service.env.example
+++ b/recall/server/deploy/service.env.example
@@ -12,6 +12,11 @@ RECALL_ALLOWED_TAILSCALE_USERS=owner@example.com
 # RECALL_ARCHIVE_SECRET_ACCESS_KEY is injected by the deployment secret manager.
 # RECALL_ARCHIVE_NAMESPACE_KEY is an independent base64-encoded 32-byte secret.
 # Cloudflare management API tokens are neither required nor read by Recall.
+# Canonical v2 cutover. Keep disabled until archive-check and migrations pass.
+# RECALL_CANONICAL_V2_ENABLED=1
+# RECALL_CANONICAL_INGEST_PUBLIC=1
+# RECALL_TENANT_ID=tenant:personal
+# RECALL_PRINCIPAL_ID=principal:owner
 # Browser MCP clients must match this exact comma-separated allow-list.
 # Non-browser agent clients normally omit Origin.
 # RECALL_MCP_ALLOWED_ORIGINS=https://approved-agent.example

--- a/recall/server/recall_server/__init__.py
+++ b/recall/server/recall_server/__init__.py
@@ -1,4 +1,4 @@
 """Recall central BrainStore service."""
 
-SCHEMA_VERSION = 26
+SCHEMA_VERSION = 27
 PROJECTOR_VERSION = 3

--- a/recall/server/recall_server/app.py
+++ b/recall/server/recall_server/app.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import base64
+import binascii
 import json
 import logging
 import os
@@ -12,6 +14,12 @@ import time
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from urllib.parse import parse_qs, urlsplit
 
+from .archive_runtime import build_archive_store
+from .canonical import (
+    CanonicalArchiveGateway,
+    CanonicalLifecycleError,
+    CanonicalPlane,
+)
 from .db import BrainStore, IdempotencyConflict
 from .mcp import (
     SUPPORTED_PROTOCOL_VERSIONS,
@@ -39,6 +47,8 @@ COUNTER_LOCK = threading.Lock()
 
 class Handler(BaseHTTPRequestHandler):
     store: BrainStore
+    archive_store = None
+    canonical_plane: CanonicalPlane | None = None
 
     def log_message(self, fmt: str, *args) -> None:
         LOG.info(
@@ -146,6 +156,7 @@ class Handler(BaseHTTPRequestHandler):
             principal = {
                 "kind": "collector",
                 "name": credential["name"],
+                "tenant_id": credential.get("tenant_id"),
                 "source_id": credential["source_id"],
                 "principal_id": credential.get("principal_id"),
                 "capture_origin": credential.get("capture_origin"),
@@ -212,6 +223,43 @@ class Handler(BaseHTTPRequestHandler):
         self.send_json(401, {"error": "unauthorized"})
         return None
 
+    def canonical_authority(
+        self,
+        principal: dict,
+        body: dict,
+    ) -> tuple[str, str, str] | None:
+        if not isinstance(body, dict):
+            self.send_json(400, {"error": "canonical request invalid"})
+            return None
+        tenant_id = body.get("tenant_id")
+        principal_id = body.get("principal_id")
+        source_id = body.get("source_id")
+        if source_id is None:
+            events = body.get("events")
+            if (
+                isinstance(events, list)
+                and events
+                and all(isinstance(event, dict) for event in events)
+            ):
+                sources = {event.get("source_id") for event in events}
+                if len(sources) == 1:
+                    source_id = sources.pop()
+        allowed = principal.get("kind") == "development" or (
+            principal.get("kind") == "collector"
+            and principal.get("tenant_id") == tenant_id
+            and principal.get("principal_id") == principal_id
+            and principal.get("source_id") == source_id
+        )
+        if allowed and all(
+            isinstance(value, str) and value
+            for value in (tenant_id, principal_id, source_id)
+        ):
+            return tenant_id, principal_id, source_id
+        with COUNTER_LOCK:
+            COUNTERS["auth_denied"] += 1
+        self.send_json(403, {"error": "canonical authority forbidden"})
+        return None
+
     def metrics(self) -> bytes:
         db = self.store.service_metrics()
         with COUNTER_LOCK:
@@ -275,6 +323,11 @@ class Handler(BaseHTTPRequestHandler):
         )
         if self.public_edge_profile():
             allowed = allowed or (method == "POST" and path == WEBHOOK_PATH)
+        if os.environ.get("RECALL_CANONICAL_INGEST_PUBLIC") == "1":
+            allowed = allowed or (
+                method == "POST"
+                and path in {"/v2/archive/objects", "/v2/ingest/canonical"}
+            )
         if allowed:
             return False
         self.send_json(404, {"error": "not found"})
@@ -337,6 +390,114 @@ class Handler(BaseHTTPRequestHandler):
     def do_POST(self) -> None:
         path = urlsplit(self.path).path
         if self.hide_non_public_route("POST", path):
+            return
+        if path == "/v2/archive/objects":
+            principal = self.require("write")
+            if not principal:
+                return
+            length = self.body_length(MAX_BODY_BYTES)
+            if length is None:
+                return
+            try:
+                body = json.loads(self.rfile.read(length))
+                authority = self.canonical_authority(principal, body)
+                if authority is None:
+                    return
+                tenant_id, principal_id, source_id = authority
+                if self.archive_store is None:
+                    self.send_json(503, {"error": "canonical archive unavailable"})
+                    return
+                payload = base64.b64decode(
+                    body.get("payload_base64", ""),
+                    validate=True,
+                )
+                gateway = CanonicalArchiveGateway(
+                    self.store,
+                    self.archive_store,
+                    tenant_id=tenant_id,
+                    principal_id=principal_id,
+                )
+                reference = gateway.put_raw(
+                    tenant_id=tenant_id,
+                    source_id=source_id,
+                    native_id=body.get("native_id"),
+                    payload=payload,
+                    media_type=body.get("media_type"),
+                    created_at=body.get("created_at"),
+                )
+                self.send_json(201, reference)
+            except (binascii.Error, json.JSONDecodeError, TypeError, ValueError):
+                self.send_json(400, {"error": "canonical archive request invalid"})
+            except CanonicalLifecycleError as exc:
+                status = (
+                    409
+                    if exc.error_code == "archive_identity_forgotten"
+                    else 403
+                    if exc.error_code == "archive_authority_forbidden"
+                    else 400
+                )
+                self.send_json(status, {"error": exc.error_code})
+            except Exception as exc:
+                LOG.error("canonical archive failed type=%s", type(exc).__name__)
+                self.send_json(503, {"error": "canonical archive unavailable"})
+            return
+        if path == "/v2/ingest/canonical":
+            principal = self.require("write")
+            if not principal:
+                return
+            length = self.body_length(MAX_BODY_BYTES)
+            if length is None:
+                return
+            try:
+                body = json.loads(self.rfile.read(length))
+                authority = self.canonical_authority(principal, body)
+                if authority is None:
+                    return
+                tenant_id, principal_id, source_id = authority
+                events = body.get("events")
+                if (
+                    not isinstance(events, list)
+                    or any(
+                        not isinstance(event, dict)
+                        or event.get("source_id") != source_id
+                        for event in events
+                    )
+                ):
+                    self.send_json(403, {"error": "canonical authority forbidden"})
+                    return
+                if self.canonical_plane is None:
+                    self.send_json(503, {"error": "canonical plane unavailable"})
+                    return
+                acknowledgement = self.canonical_plane.ingest_batch(
+                    tenant_id=tenant_id,
+                    principal_id=principal_id,
+                    events=events,
+                )
+                with COUNTER_LOCK:
+                    COUNTERS[
+                        "ingest_replays"
+                        if acknowledgement["replay"]
+                        else "ingest_commits"
+                    ] += 1
+                self.send_json(
+                    200 if acknowledgement["replay"] else 201,
+                    acknowledgement,
+                )
+            except (json.JSONDecodeError, TypeError, ValueError):
+                self.send_json(400, {"error": "canonical ingest request invalid"})
+            except CanonicalLifecycleError as exc:
+                status = (
+                    409
+                    if exc.error_code == "canonical_identity_forgotten"
+                    else 403
+                    if exc.error_code
+                    in {"canonical_authority_forbidden", "canonical_lineage_invalid"}
+                    else 400
+                )
+                self.send_json(status, {"error": exc.error_code})
+            except Exception as exc:
+                LOG.error("canonical ingest failed type=%s", type(exc).__name__)
+                self.send_json(500, {"error": "canonical ingest failed"})
             return
         if path == WEBHOOK_PATH:
             principal = self.require("webhook")
@@ -581,11 +742,31 @@ def validate_http_profile() -> None:
     profile = os.environ.get("RECALL_HTTP_PROFILE", "")
     if profile not in {"", "public-edge", "public-mcp"}:
         raise RuntimeError("unsupported HTTP profile")
+    if os.environ.get("RECALL_CANONICAL_INGEST_PUBLIC") == "1" and (
+        os.environ.get("RECALL_AUTH_REQUIRED", "0") != "1"
+        or os.environ.get("RECALL_CANONICAL_V2_ENABLED") != "1"
+    ):
+        raise RuntimeError(
+            "public canonical ingest requires authentication and canonical v2"
+        )
     if profile in {"public-edge", "public-mcp"}:
         if os.environ.get("RECALL_AUTH_REQUIRED", "0") != "1":
             raise RuntimeError("public HTTP profile requires authentication")
         if os.environ.get("RECALL_TRUST_TAILSCALE_HEADERS", "0") == "1":
             raise RuntimeError("public HTTP profile forbids trusted identity headers")
+
+
+def configure_runtime(dsn: str) -> None:
+    Handler.store = BrainStore(dsn, semantic_runtime=SemanticRuntime.from_env())
+    if os.environ.get("RECALL_CANONICAL_V2_ENABLED") == "1":
+        Handler.archive_store = build_archive_store()
+        Handler.canonical_plane = CanonicalPlane(
+            Handler.store,
+            Handler.archive_store,
+        )
+    else:
+        Handler.archive_store = None
+        Handler.canonical_plane = None
 
 
 def serve(dsn: str, host: str = "127.0.0.1", port: int = 8788) -> None:
@@ -596,7 +777,7 @@ def serve(dsn: str, host: str = "127.0.0.1", port: int = 8788) -> None:
         "::1",
     }:
         raise RuntimeError("authentication is required for a non-loopback TCP bind")
-    Handler.store = BrainStore(dsn, semantic_runtime=SemanticRuntime.from_env())
+    configure_runtime(dsn)
     server = ThreadingHTTPServer((host, port), Handler)
     LOG.info("brainstore listening host=%s port=%s", host, port)
     try:
@@ -623,7 +804,7 @@ def serve_unix(dsn: str, path: str) -> None:
         if not stat.S_ISSOCK(existing.st_mode):
             raise RuntimeError("refusing to replace a non-socket Unix path")
         os.unlink(path)
-    Handler.store = BrainStore(dsn, semantic_runtime=SemanticRuntime.from_env())
+    configure_runtime(dsn)
     server = ThreadingUnixHTTPServer(path, Handler)
     os.chmod(path, 0o600)
     LOG.info("brainstore listening unix_socket=%s", path)

--- a/recall/server/recall_server/canonical.py
+++ b/recall/server/recall_server/canonical.py
@@ -205,6 +205,7 @@ class CanonicalPlane:
             raise CanonicalLifecycleError("canonical_contract_invalid") from None
         source_id = event["source_id"]
         native_id = event["native_id"]
+        is_tombstone = event["kind"] == "tombstone"
         if (
             artifact["tenant_id"] != tenant_id
             or artifact["source_id"] != source_id
@@ -316,42 +317,57 @@ class CanonicalPlane:
                            tenant_id,source_id,event_id,native_id,native_parent_id,
                            artifact_id,job_id,kind,content_sha256,revision,
                            occurred_at,observed_at,is_tombstone,canonical_redacted
-                       ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,false,%s)""",
+                       ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)""",
                     (
                         tenant_id, source_id, event_id, native_id,
                         event.get("native_parent_id"), artifact["artifact_id"], job_id,
                         event["kind"], raw_sha256, revision, event["occurred_at"],
-                        event["observed_at"], json.dumps(event),
+                        event["observed_at"], is_tombstone, json.dumps(event),
                     ),
                 )
                 conn.execute(
                     """UPDATE canonical_documents
-                       SET is_current=false
+                       SET is_current=false,
+                           deleted_at=CASE WHEN %s THEN now() ELSE deleted_at END
                        WHERE tenant_id=%s AND source_id=%s AND native_id=%s
                          AND is_current""",
-                    (tenant_id, source_id, native_id),
+                    (is_tombstone, tenant_id, source_id, native_id),
                 )
-                conn.execute(
-                    """INSERT INTO canonical_documents(
-                           tenant_id,source_id,document_id,event_id,artifact_id,native_id,
-                           content_sha256,revision,is_current,text_redacted,text_sha256
-                       ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,true,%s,%s)""",
-                    (
-                        tenant_id, source_id, document_id, event_id,
-                        artifact["artifact_id"], native_id, raw_sha256, revision,
-                        text_redacted, text_sha256,
-                    ),
-                )
-                conn.execute(
-                    """INSERT INTO canonical_chunks(
-                           tenant_id,source_id,chunk_id,document_id,ordinal,receipt,
-                           text_redacted,text_sha256
-                       ) VALUES (%s,%s,%s,%s,0,%s,%s,%s)""",
-                    (
-                        tenant_id, source_id, chunk_id, document_id, receipt,
-                        text_redacted, text_sha256,
-                    ),
-                )
+                if is_tombstone:
+                    conn.execute(
+                        """UPDATE canonical_chunks chunk
+                           SET deleted_at=now()
+                           FROM canonical_documents document
+                           WHERE chunk.tenant_id=document.tenant_id
+                             AND chunk.source_id=document.source_id
+                             AND chunk.document_id=document.document_id
+                             AND document.tenant_id=%s AND document.source_id=%s
+                             AND document.native_id=%s
+                             AND chunk.deleted_at IS NULL""",
+                        (tenant_id, source_id, native_id),
+                    )
+                else:
+                    conn.execute(
+                        """INSERT INTO canonical_documents(
+                               tenant_id,source_id,document_id,event_id,artifact_id,native_id,
+                               content_sha256,revision,is_current,text_redacted,text_sha256
+                           ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,true,%s,%s)""",
+                        (
+                            tenant_id, source_id, document_id, event_id,
+                            artifact["artifact_id"], native_id, raw_sha256, revision,
+                            text_redacted, text_sha256,
+                        ),
+                    )
+                    conn.execute(
+                        """INSERT INTO canonical_chunks(
+                               tenant_id,source_id,chunk_id,document_id,ordinal,receipt,
+                               text_redacted,text_sha256
+                           ) VALUES (%s,%s,%s,%s,0,%s,%s,%s)""",
+                        (
+                            tenant_id, source_id, chunk_id, document_id, receipt,
+                            text_redacted, text_sha256,
+                        ),
+                    )
                 conn.execute(
                     """INSERT INTO canonical_audit_events(
                            tenant_id,source_id,audit_id,operation,status,
@@ -370,6 +386,45 @@ class CanonicalPlane:
             "revision": revision,
             "receipt": receipt,
             "replay": False,
+        }
+
+    def ingest_batch(
+        self,
+        *,
+        tenant_id: str,
+        principal_id: str,
+        events: list[dict[str, Any]],
+    ) -> dict[str, Any]:
+        if not isinstance(events, list) or not 1 <= len(events) <= 500:
+            raise CanonicalLifecycleError("canonical_batch_invalid")
+        results = []
+        for envelope in events:
+            provenance = envelope.get("provenance", {})
+            connector_id = provenance.get("connector_id")
+            artifact_ref = provenance.get("artifact_ref")
+            text_redacted = json.dumps(
+                envelope.get("content"),
+                sort_keys=True,
+                separators=(",", ":"),
+                ensure_ascii=False,
+                allow_nan=False,
+            )
+            results.append(self.ingest_document(
+                tenant_id=tenant_id,
+                principal_id=principal_id,
+                connector_id=connector_id,
+                artifact_ref=artifact_ref,
+                envelope=envelope,
+                text_redacted="" if envelope.get("kind") == "tombstone" else text_redacted,
+            ))
+        return {
+            "status": "committed",
+            "inserted": sum(result["inserted"] for result in results),
+            "duplicate_events": sum(
+                result["duplicate_events"] for result in results
+            ),
+            "receipts": [result["receipt"] for result in results],
+            "replay": all(result["replay"] for result in results),
         }
 
     def _archive_references(

--- a/recall/server/recall_server/cli.py
+++ b/recall/server/recall_server/cli.py
@@ -88,6 +88,10 @@ def main() -> None:
     create_token.add_argument("name")
     create_token.add_argument("--source")
     create_token.add_argument(
+        "--tenant",
+        help="bind a canonical v2 write credential to exactly one tenant",
+    )
+    create_token.add_argument(
         "--principal",
         help="read every source granted to this principal; writes stay source-bound",
     )
@@ -308,6 +312,7 @@ def main() -> None:
             args.name,
             args.source,
             [scope.strip() for scope in args.scopes.split(",") if scope.strip()],
+            tenant_id=args.tenant,
             principal_id=args.principal,
             capture_origin=args.capture_origin,
             webhook_privacy_mode=args.webhook_privacy_mode,

--- a/recall/server/recall_server/db.py
+++ b/recall/server/recall_server/db.py
@@ -34,6 +34,7 @@ TURN_USER_MARKER = "User request:\n"
 TURN_ASSISTANT_MARKER = "\nAssistant response:\n"
 TURN_CONTINUATION_MARKER = "\n\nAssistant continuation:\n"
 TURN_EMBEDDING_CONTRACT = "recall.turn-embedding.v1:question-complete-response"
+V2_AUTHORITY_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9:._/@+-]{1,255}\Z")
 
 
 class IdempotencyConflict(Exception):
@@ -179,6 +180,7 @@ class BrainStore:
         source_id: str | None,
         scopes: list[str],
         *,
+        tenant_id: str | None = None,
         principal_id: str | None = None,
         capture_origin: str | None = None,
         webhook_privacy_mode: str | None = None,
@@ -188,6 +190,15 @@ class BrainStore:
             raise ValueError("invalid collector credential")
         if "write" in scopes and not source_id:
             raise ValueError("write credential requires a source")
+        if tenant_id is not None and (
+            not V2_AUTHORITY_RE.fullmatch(tenant_id)
+            or "write" not in scopes
+            or not isinstance(source_id, str)
+            or not V2_AUTHORITY_RE.fullmatch(source_id)
+            or not isinstance(principal_id, str)
+            or not V2_AUTHORITY_RE.fullmatch(principal_id)
+        ):
+            raise ValueError("invalid canonical tenant credential")
         if capture_origin is not None and (
             "write" not in scopes
             or not source_id
@@ -211,18 +222,12 @@ class BrainStore:
         with self.connect() as conn:
             conn.execute(
                 """INSERT INTO collector_credentials(
-                       id,name,token_sha256,source_id,scopes,principal_id,
+                       id,name,token_sha256,tenant_id,source_id,scopes,principal_id,
                        capture_origin,webhook_privacy_mode
-                   ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s)""",
+                   ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s)""",
                 (
-                    credential_id,
-                    name,
-                    digest,
-                    source_id,
-                    scopes,
-                    principal_id,
-                    capture_origin,
-                    webhook_privacy_mode,
+                    credential_id, name, digest, tenant_id, source_id, scopes,
+                    principal_id, capture_origin, webhook_privacy_mode,
                 ),
             )
             conn.execute(
@@ -230,6 +235,7 @@ class BrainStore:
                 (json.dumps({
                     "credential_id": str(credential_id),
                     "name": name,
+                    "tenant_id": tenant_id,
                     "source_id": source_id,
                     "principal_id": principal_id,
                     "capture_origin": capture_origin,
@@ -241,6 +247,7 @@ class BrainStore:
             "id": str(credential_id),
             "name": name,
             "token": plaintext,
+            "tenant_id": tenant_id,
             "source_id": source_id,
             "principal_id": principal_id,
             "capture_origin": capture_origin,
@@ -359,7 +366,7 @@ class BrainStore:
         digest = hashlib.sha256(plaintext.encode()).hexdigest()
         with self.connect() as conn:
             row = conn.execute(
-                """SELECT id,name,source_id,principal_id,capture_origin,
+                """SELECT id,name,tenant_id,source_id,principal_id,capture_origin,
                           webhook_privacy_mode,scopes
                    FROM collector_credentials
                    WHERE token_sha256=%s AND revoked_at IS NULL""",

--- a/recall/server/schema/027_canonical_tenant_credentials.sql
+++ b/recall/server/schema/027_canonical_tenant_credentials.sql
@@ -1,0 +1,24 @@
+BEGIN;
+
+ALTER TABLE collector_credentials
+    ADD COLUMN IF NOT EXISTS tenant_id text;
+
+ALTER TABLE collector_credentials
+    DROP CONSTRAINT IF EXISTS collector_credentials_tenant_id_check;
+
+ALTER TABLE collector_credentials
+    ADD CONSTRAINT collector_credentials_tenant_id_check
+    CHECK (
+        tenant_id IS NULL
+        OR (
+            length(tenant_id) BETWEEN 2 AND 256
+            AND tenant_id ~ '^[A-Za-z0-9][A-Za-z0-9:._/@+-]{1,255}$'
+        )
+    );
+
+CREATE INDEX IF NOT EXISTS collector_credentials_tenant_source_idx
+    ON collector_credentials(tenant_id, source_id)
+    WHERE revoked_at IS NULL AND tenant_id IS NOT NULL;
+
+INSERT INTO schema_migrations(version) VALUES (27) ON CONFLICT DO NOTHING;
+COMMIT;

--- a/recall/server/tests/e2e_v2_connector_writer.py
+++ b/recall/server/tests/e2e_v2_connector_writer.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""Fresh-PostgreSQL proof for the production canonical connector path."""
+
+from __future__ import annotations
+
+import io
+import json
+import logging
+import os
+import sys
+import tempfile
+import threading
+from http.server import ThreadingHTTPServer
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(ROOT / "recall"))
+sys.path.insert(0, str(ROOT / "recall/server"))
+
+from client.mac import (
+    CanonicalArchiveClient,
+    CanonicalBrainWriter,
+    CanonicalClientError,
+)
+from connectors.sdk import ConnectorPage, ConnectorRecord, ConnectorRunner
+from privacy.policy import PrivacyPolicy
+from recall_server.app import Handler
+from recall_server.archive import FilesystemArchiveStore
+from recall_server.archive_snapshot import (
+    backup_filesystem_archive,
+    restore_filesystem_archive,
+    verify_filesystem_archive,
+)
+from recall_server.canonical import CanonicalPlane
+from recall_server.db import BrainStore
+
+
+TENANT = "tenant:personal:e2e"
+PRINCIPAL = "principal:owner:e2e"
+SOURCE = "source:v2:e2e"
+NATIVE = "native:v2:e2e"
+CANARY = "synthetic-v2-private-canary-8741"
+OCCURRED = "2026-07-20T00:00:00Z"
+
+
+class CountingArchive:
+    def __init__(self, archive: FilesystemArchiveStore):
+        self.archive = archive
+        self.puts = 0
+
+    def put_raw(self, **kwargs):
+        self.puts += 1
+        return self.archive.put_raw(**kwargs)
+
+    def delete_raw(self, reference):
+        return self.archive.delete_raw(reference)
+
+
+class RevisionConnector:
+    connector_id = "synthetic.v2"
+    source_id = SOURCE
+
+    @staticmethod
+    def record(text: str, *, deleted: bool = False) -> ConnectorRecord:
+        return ConnectorRecord(
+            schema_version=1,
+            native_id=NATIVE,
+            native_parent_id=NATIVE,
+            occurred_at=OCCURRED,
+            content={} if deleted else {
+                "text": text,
+                "password": CANARY,
+            },
+            provenance={"uri": "connector://synthetic-v2/e2e"},
+            deleted=deleted,
+        )
+
+    def pull(self, cursor: str | None) -> ConnectorPage:
+        pages = {
+            None: (self.record("safe revision one"), "cursor:1"),
+            "cursor:1": (self.record("safe revision two"), "cursor:2"),
+            "cursor:2": (self.record("", deleted=True), "cursor:3"),
+            "cursor:3": (self.record("safe revision one"), "cursor:4"),
+            "cursor:4": (self.record("safe resurrection attempt"), "cursor:5"),
+        }
+        record, next_cursor = pages[cursor]
+        return ConnectorPage(records=(record,), next_cursor=next_cursor, has_more=True)
+
+
+def main() -> None:
+    store = BrainStore(os.environ["RECALL_DATABASE_URL"])
+    store.migrate()
+    credential = store.create_collector_token(
+        "canonical-v2-e2e",
+        SOURCE,
+        ["write"],
+        tenant_id=TENANT,
+        principal_id=PRINCIPAL,
+    )
+    previous = {
+        name: os.environ.get(name)
+        for name in (
+            "RECALL_AUTH_REQUIRED",
+            "RECALL_HTTP_PROFILE",
+            "RECALL_CANONICAL_INGEST_PUBLIC",
+        )
+    }
+    os.environ.update({
+        "RECALL_AUTH_REQUIRED": "1",
+        "RECALL_HTTP_PROFILE": "public-mcp",
+        "RECALL_CANONICAL_INGEST_PUBLIC": "1",
+    })
+    logs = io.StringIO()
+    handler = logging.StreamHandler(logs)
+    logger = logging.getLogger("recall.brainstore")
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+    with tempfile.TemporaryDirectory() as temporary:
+        root = Path(temporary)
+        archive = FilesystemArchiveStore(
+            root / "archive",
+            namespace_key=b"e" * 32,
+        )
+        counting = CountingArchive(archive)
+        plane = CanonicalPlane(store, counting)
+        Handler.store = store
+        Handler.archive_store = counting
+        Handler.canonical_plane = plane
+        server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        endpoint = f"http://127.0.0.1:{server.server_port}"
+        common = {
+            "endpoint": endpoint,
+            "token": credential["token"],
+            "source_id": SOURCE,
+            "tenant_id": TENANT,
+            "principal_id": PRINCIPAL,
+        }
+        for forged in (
+            {**common, "tenant_id": "tenant:forged:e2e"},
+            {**common, "source_id": "source:forged:e2e"},
+        ):
+            try:
+                CanonicalArchiveClient(**forged).put_raw(
+                    tenant_id=forged["tenant_id"],
+                    source_id=forged["source_id"],
+                    native_id=NATIVE,
+                    payload=b'{"forged":true}',
+                    media_type="application/json",
+                    created_at=OCCURRED,
+                )
+            except CanonicalClientError:
+                pass
+            else:
+                raise RuntimeError("cross-scope archive write was accepted")
+        if counting.puts:
+            raise RuntimeError("cross-scope write reached private archive")
+        spool_root = root / "spool"
+        spool_root.mkdir(mode=0o700)
+        spool = spool_root / "connector.db"
+        runner = ConnectorRunner(
+            connector=RevisionConnector(),
+            brain=CanonicalBrainWriter(**common),
+            archive=CanonicalArchiveClient(**common),
+            tenant_id=TENANT,
+            principal_id=PRINCIPAL,
+            spool_path=spool,
+            privacy=PrivacyPolicy(mode="scrub"),
+        )
+        try:
+            results = [runner.run_once() for _ in range(3)]
+            if [result["acked"] for result in results] != [1, 1, 1]:
+                raise RuntimeError("canonical revisions did not ACK")
+            if counting.puts != 3:
+                raise RuntimeError("raw archive ordering failed")
+            replay = runner.run_once()
+            if (
+                replay["acked"] != 0
+                or replay["deduplicated"] != 1
+                or counting.puts != 3
+            ):
+                raise RuntimeError("acknowledged replay rearchived or duplicated")
+
+            before = verify_filesystem_archive(archive.root)
+            snapshot = root / "snapshot"
+            restored = root / "restored"
+            backup_filesystem_archive(archive.root, snapshot)
+            restore_filesystem_archive(snapshot, restored)
+            after = verify_filesystem_archive(restored)
+            if before != after or before["object_count"] != 3:
+                raise RuntimeError("archive restore fingerprint failed")
+
+            with store.connect() as connection:
+                state = connection.execute(
+                    """SELECT
+                         (SELECT count(*) FROM canonical_events
+                           WHERE tenant_id=%s AND source_id=%s) AS events,
+                         (SELECT count(*) FROM canonical_documents
+                           WHERE tenant_id=%s AND source_id=%s) AS documents,
+                         (SELECT count(*) FROM canonical_chunks
+                           WHERE tenant_id=%s AND source_id=%s) AS chunks,
+                         (SELECT count(*) FROM canonical_documents
+                           WHERE tenant_id=%s AND source_id=%s
+                             AND is_current) AS current_documents,
+                         (SELECT count(*) FROM canonical_events
+                           WHERE tenant_id=%s AND source_id=%s
+                             AND canonical_redacted::text LIKE %s) AS leaks,
+                         (SELECT receipt FROM canonical_chunks
+                           WHERE tenant_id=%s AND source_id=%s
+                           ORDER BY created_at LIMIT 1) AS receipt""",
+                    (
+                        TENANT, SOURCE, TENANT, SOURCE, TENANT, SOURCE,
+                        TENANT, SOURCE, TENANT, SOURCE, f"%{CANARY}%",
+                        TENANT, SOURCE,
+                    ),
+                ).fetchone()
+            if tuple(state[key] for key in (
+                "events", "documents", "chunks", "current_documents", "leaks",
+            )) != (3, 2, 2, 0, 0):
+                raise RuntimeError("canonical revision or tombstone state failed")
+            private_spool = b"".join(
+                path.read_bytes()
+                for path in spool.parent.glob(spool.name + "*")
+                if path.is_file()
+            )
+            if CANARY.encode() in private_spool or CANARY in logs.getvalue():
+                raise RuntimeError("privacy canary escaped archive")
+
+            forget = plane.forget({
+                "contract": "recall.forget-request.v1",
+                "schema_version": 1,
+                "tenant_id": TENANT,
+                "principal_id": PRINCIPAL,
+                "source_id": SOURCE,
+                "target_receipt": state["receipt"],
+                "mode": "explicit_forget",
+                "reason": "owner_requested",
+                "requested_at": "2026-07-20T00:05:00Z",
+                "idempotency_key": "-".join(("canonical", "v2", "e2e", "forget")),
+            })
+            resurrection = runner.run_once()
+            if (
+                forget["raw_deleted"] != 3
+                or resurrection["forgotten"] != 1
+                or resurrection["acked"] != 0
+                or counting.puts != 3
+            ):
+                raise RuntimeError("forget fence accepted resurrection")
+            with store.connect() as connection:
+                remaining = connection.execute(
+                    """SELECT
+                         (SELECT count(*) FROM canonical_events
+                           WHERE tenant_id=%s AND source_id=%s)
+                       + (SELECT count(*) FROM canonical_documents
+                           WHERE tenant_id=%s AND source_id=%s)
+                       + (SELECT count(*) FROM canonical_chunks
+                           WHERE tenant_id=%s AND source_id=%s) AS count""",
+                    (TENANT, SOURCE, TENANT, SOURCE, TENANT, SOURCE),
+                ).fetchone()["count"]
+            if remaining or verify_filesystem_archive(archive.root)["object_count"]:
+                raise RuntimeError("forget left canonical or raw evidence")
+        finally:
+            runner.close()
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=5)
+            logger.removeHandler(handler)
+            for name, value in previous.items():
+                if value is None:
+                    os.environ.pop(name, None)
+                else:
+                    os.environ[name] = value
+    store.close()
+    print(json.dumps({
+        "status": "pass",
+        "canonical_revisions": 2,
+        "canonical_tombstones": 1,
+        "exact_replay_duplicates": 0,
+        "exact_replay_archive_writes": 0,
+        "privacy_leaks": 0,
+        "archive_restore_fingerprint": True,
+        "cross_scope_writes": 0,
+        "resurrections": 0,
+    }, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/recall/tests/central_brain/test_brainstore_unit.py
+++ b/recall/tests/central_brain/test_brainstore_unit.py
@@ -645,6 +645,23 @@ class HttpBoundaryContractTest(unittest.TestCase):
             with self.assertRaisesRegex(RuntimeError, "unsupported HTTP profile"):
                 validate_http_profile()
 
+    def test_public_canonical_routes_require_auth_and_enabled_v2_runtime(self) -> None:
+        base = {
+            "RECALL_HTTP_PROFILE": "public-mcp",
+            "RECALL_CANONICAL_INGEST_PUBLIC": "1",
+            "RECALL_TRUST_TAILSCALE_HEADERS": "0",
+        }
+        for values in (
+            {**base, "RECALL_AUTH_REQUIRED": "0", "RECALL_CANONICAL_V2_ENABLED": "1"},
+            {**base, "RECALL_AUTH_REQUIRED": "1", "RECALL_CANONICAL_V2_ENABLED": "0"},
+        ):
+            with self.subTest(values=values), mock.patch.dict(
+                os.environ,
+                values,
+                clear=True,
+            ), self.assertRaisesRegex(RuntimeError, "canonical ingest"):
+                validate_http_profile()
+
     def test_unix_server_refuses_to_replace_a_regular_file(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             path = Path(temporary) / "recall.sock"
@@ -1032,6 +1049,26 @@ class AdminCliSafetyTest(unittest.TestCase):
                 ["read", "write"],
                 principal_id="synthetic-owner",
             )
+        store.connect.assert_not_called()
+
+    def test_canonical_credentials_bind_tenant_principal_source_and_write(self) -> None:
+        store = BrainStore("postgresql://synthetic.invalid/recall")
+        store.connect = mock.MagicMock()
+        invalid = (
+            ("tenant:one", None, "source:one", ["write"]),
+            ("tenant:one", "principal:owner", None, ["write"]),
+            ("tenant:one", "principal:owner", "source:one", ["read"]),
+            ("tenant with spaces", "principal:owner", "source:one", ["write"]),
+        )
+        for tenant_id, principal_id, source_id, scopes in invalid:
+            with self.subTest(tenant_id=tenant_id), self.assertRaises(ValueError):
+                store.create_collector_token(
+                    "synthetic-canonical",
+                    source_id,
+                    scopes,
+                    tenant_id=tenant_id,
+                    principal_id=principal_id,
+                )
         store.connect.assert_not_called()
 
     def test_webhook_credentials_require_source_principal_and_privacy(self) -> None:

--- a/recall/tests/test_collector.py
+++ b/recall/tests/test_collector.py
@@ -263,6 +263,70 @@ class CollectorTest(unittest.TestCase):
         self.assertNotIn(canary, json.dumps(AckServer.received))
         collector.close()
 
+    def test_canonical_runtime_archives_raw_before_safe_spool_and_ack(self) -> None:
+        canary = "synthetic-canonical-collector-canary-96"
+        (self.root / "session.jsonl").write_text(
+            claude_line(f"keep context api_key={canary} after")
+        )
+        archived = []
+        ingested = []
+
+        class Archive:
+            def put_raw(self, **kwargs):
+                archived.append(kwargs)
+                return {
+                    "contract": "recall.artifact-ref.v1",
+                    "schema_version": 1,
+                    "tenant_id": kwargs["tenant_id"],
+                    "source_id": kwargs["source_id"],
+                    "artifact_id": "art_" + "a" * 32,
+                    "storage_backend": "s3",
+                    "object_key": "objects/aa/" + "a" * 64,
+                    "content_sha256": hashlib.sha256(kwargs["payload"]).hexdigest(),
+                    "size_bytes": len(kwargs["payload"]),
+                    "media_type": kwargs["media_type"],
+                    "encryption": "sse-s3",
+                    "version_id": "synthetic-version",
+                    "created_at": kwargs["created_at"],
+                }
+
+        class Writer:
+            def ingest(self, events):
+                ingested.extend(events)
+                return {
+                    "status": "committed",
+                    "inserted": len(events),
+                    "duplicate_events": 0,
+                    "receipts": [
+                        f"recall://{event['source_id']}/{event['native_id']}?rev=1"
+                        for event in events
+                    ],
+                    "replay": False,
+                }
+
+        collector = Collector(
+            root=self.root,
+            harness="claude",
+            source_id="claude:linux:test",
+            spool_path=self.spool,
+            endpoint=self.endpoint,
+            token="test-token-not-a-secret",
+            principal_id="owner",
+            privacy=PrivacyPolicy(mode="scrub"),
+            brain_writer=Writer(),
+            archive=Archive(),
+            tenant_id="tenant:personal",
+        )
+        self.assertEqual(collector.scan()["records_queued"], 1)
+        self.assertEqual(collector.flush()["acked"], 1)
+        self.assertEqual(len(archived), 1)
+        self.assertIn(canary.encode(), archived[0]["payload"])
+        self.assertEqual(len(ingested), 1)
+        self.assertIn("artifact_ref", ingested[0]["provenance"])
+        self.assertNotIn(canary, json.dumps(ingested))
+        self.assertNotIn(canary.encode(), self.spool.read_bytes())
+        collector.close()
+
     def test_enabling_drop_compacts_sensitive_pending_bytes_from_legacy_spool(self) -> None:
         canary = "synthetic-legacy-spool-canary-95"
         (self.root / "session.jsonl").write_text(claude_line("legacy pending row"))

--- a/recall/tests/test_connector_host.py
+++ b/recall/tests/test_connector_host.py
@@ -170,6 +170,41 @@ class ClosedFactoryTest(unittest.TestCase):
         )
         host.close()
 
+    def test_canonical_mode_wires_one_tenant_scoped_writer_and_archive_client(self) -> None:
+        value = ConnectorHostConfig.from_mapping(
+            json.loads(CORPUS.read_text().splitlines()[0])["config"]
+        )
+        environment = {
+            "RECALL_CANONICAL_V2_ENABLED": "1",
+            "RECALL_TENANT_ID": "tenant:personal",
+            "RECALL_PRINCIPAL_ID": "principal:owner",
+        }
+        with tempfile.TemporaryDirectory() as directory, \
+             mock.patch.dict(os.environ, environment, clear=False), \
+             mock.patch("connectors.host.load_file_token", return_value="brain-token"), \
+             mock.patch("connectors.host.CanonicalBrainWriter") as writer_type, \
+             mock.patch("connectors.host.CanonicalArchiveClient") as archive_type, \
+             mock.patch("connectors.host.ExportInboxConnector") as connector_type, \
+             mock.patch("connectors.host.ConnectorRunner") as runner_type:
+            connector_type.return_value.connector_id = "openai.export-inbox"
+            connector_type.return_value.source_id = "synthetic:export:c8g"
+            runner_type.return_value = mock.Mock(
+                run_once=mock.Mock(return_value={"status": "committed"}),
+                close=mock.Mock(),
+            )
+            host = build_host(
+                value,
+                state_path=Path(directory) / "supervisor.db",
+            )
+        writer_type.assert_called_once()
+        archive_type.assert_called_once()
+        call = runner_type.call_args.kwargs
+        self.assertIs(call["brain"], writer_type.return_value)
+        self.assertIs(call["archive"], archive_type.return_value)
+        self.assertEqual(call["tenant_id"], "tenant:personal")
+        self.assertEqual(call["principal_id"], "principal:owner")
+        host.close()
+
 
 class HostCliTest(unittest.TestCase):
     def private_config(self, directory: str) -> Path:

--- a/recall/tests/test_mac_client.py
+++ b/recall/tests/test_mac_client.py
@@ -11,7 +11,16 @@ from pathlib import Path
 from unittest import mock
 from client import cli as client_cli
 
-from client.mac import BrainClient, ExportImporter, MemoryClient, PrivacyError, dry_run_manifest, load_file_token
+from client.mac import (
+    BrainClient,
+    CanonicalArchiveClient,
+    CanonicalBrainWriter,
+    ExportImporter,
+    MemoryClient,
+    PrivacyError,
+    dry_run_manifest,
+    load_file_token,
+)
 from privacy.policy import PrivacyPolicy
 
 
@@ -216,6 +225,113 @@ class BrainEndpointValidationTest(unittest.TestCase):
         ):
             with self.subTest(endpoint=endpoint), self.assertRaises(ValueError):
                 BrainClient(endpoint=endpoint, token="synthetic", source_id="test-source")
+
+
+class CanonicalV2ClientTest(unittest.TestCase):
+    def test_archive_then_canonical_writer_use_closed_tenant_scoped_routes(self) -> None:
+        requests = []
+        raw_payload = b'{"raw":"RAW_ARCHIVE_CANARY"}'
+        artifact = {
+            "contract": "recall.artifact-ref.v1",
+            "schema_version": 1,
+            "tenant_id": "tenant:personal",
+            "source_id": "source:personal",
+            "artifact_id": "art_" + "a" * 32,
+            "storage_backend": "s3",
+            "object_key": "objects/aa/" + "a" * 64,
+            "content_sha256": hashlib.sha256(raw_payload).hexdigest(),
+            "size_bytes": len(raw_payload),
+            "media_type": "application/json",
+            "encryption": "sse-s3",
+            "version_id": "r2-sha256-" + hashlib.sha256(raw_payload).hexdigest(),
+            "created_at": "2026-07-20T00:00:00Z",
+        }
+
+        def open_request(request, **_kwargs):
+            requests.append(request)
+            if request.full_url.endswith("/v2/archive/objects"):
+                return FakeResponse(201, artifact)
+            return FakeResponse(201, {
+                "status": "committed",
+                "inserted": 1,
+                "duplicate_events": 0,
+                "receipts": ["recall://source:personal/native:one?rev=1"],
+                "replay": False,
+            })
+
+        common = {
+            "endpoint": "https://brain.example.invalid",
+            "token": "CANONICAL_TOKEN_CANARY",
+            "source_id": "source:personal",
+            "tenant_id": "tenant:personal",
+            "principal_id": "principal:owner",
+        }
+        archive = CanonicalArchiveClient(**common)
+        writer = CanonicalBrainWriter(**common)
+        with mock.patch("client.mac.open_no_redirect", side_effect=open_request):
+            reference = archive.put_raw(
+                tenant_id="tenant:personal",
+                source_id="source:personal",
+                native_id="native:one",
+                payload=raw_payload,
+                media_type="application/json",
+                created_at="2026-07-20T00:00:00Z",
+            )
+            event = {
+                "schema_version": 1,
+                "source_id": "source:personal",
+                "native_id": "native:one",
+                "native_parent_id": "native:one",
+                "kind": "connector_record",
+                "occurred_at": "2026-07-20T00:00:00Z",
+                "observed_at": "2026-07-20T00:00:00Z",
+                "principal_id": "principal:owner",
+                "visibility": "private",
+                "content_type": "application/json",
+                "content": {"text": "safe"},
+                "provenance": {
+                    "connector_id": "synthetic.connector",
+                    "connector_schema_version": 1,
+                    "artifact_ref": reference,
+                },
+                "content_sha256": hashlib.sha256(b'{"text":"safe"}').hexdigest(),
+            }
+            acknowledgement = writer.ingest([event])
+
+        self.assertEqual(
+            [request.full_url.rsplit("/", 3)[-3:] for request in requests],
+            [["v2", "archive", "objects"], ["v2", "ingest", "canonical"]],
+        )
+        archive_body = json.loads(requests[0].data)
+        canonical_body = json.loads(requests[1].data)
+        self.assertEqual(archive_body["tenant_id"], "tenant:personal")
+        self.assertEqual(canonical_body["principal_id"], "principal:owner")
+        self.assertNotIn("RAW_ARCHIVE_CANARY", json.dumps(canonical_body))
+        self.assertNotIn(b"CANONICAL_TOKEN_CANARY", requests[0].data)
+        self.assertNotIn(b"CANONICAL_TOKEN_CANARY", requests[1].data)
+        self.assertEqual(acknowledgement["inserted"], 1)
+
+    def test_canonical_clients_reject_cross_scope_calls_before_network(self) -> None:
+        common = {
+            "endpoint": "https://brain.example.invalid",
+            "token": "synthetic",
+            "source_id": "source:personal",
+            "tenant_id": "tenant:personal",
+            "principal_id": "principal:owner",
+        }
+        archive = CanonicalArchiveClient(**common)
+        with mock.patch("client.mac.open_no_redirect") as opened, self.assertRaises(
+            PermissionError
+        ):
+            archive.put_raw(
+                tenant_id="tenant:other",
+                source_id="source:personal",
+                native_id="native:one",
+                payload=b"private",
+                media_type="application/json",
+                created_at="2026-07-20T00:00:00Z",
+            )
+        opened.assert_not_called()
 
 
 class ExplicitMemoryTest(unittest.TestCase):


### PR DESCRIPTION
Closes the canonical-writer portion of #139.

Adds tenant/source-bound canonical ingestion, private raw archive references, replay-safe ACK semantics, explicit tombstones/forget behavior, and canonical wiring for connector and local collectors.

Verification:
- 584 Python tests + 3 Node tests
- fresh pgvector E2E: revisions, tombstone, replay dedupe, cross-scope rejection, backup/restore, explicit forget, no resurrection
- real R2 write/replay/read/delete/absence lifecycle
- staged gitleaks clean
- changed-code Ruff clean; no high-severity Bandit findings

No transcripts, credentials, or cascade evidence are included.