### PR TITLE
docs(parable): publish Grok subscription route

### DIFF
--- a/parable/docs/CLIPROXYAPI_GPT_SUBSCRIPTION.md
+++ b/parable/docs/CLIPROXYAPI_GPT_SUBSCRIPTION.md
@@ -1,13 +1,15 @@
-# GPT subscription models in stock Claude Code
+# GPT and Grok subscription models in stock Claude Code
 
 This is the reproducible OSS path for running stock Claude Code with
-`gpt-5.6-sol`, `gpt-5.6-terra`, or `gpt-5.6-luna` through a local
-CLIProxyAPI process and the user's own ChatGPT subscription OAuth.
+`gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, and `grok-4.5` through a
+local CLIProxyAPI process and the user's own subscription OAuth.
 
 No broker or shared deployment is involved:
 
 ```text
-Claude Code → loopback CLIProxyAPI → ChatGPT subscription OAuth
+                                      ┌→ ChatGPT subscription OAuth
+Claude Code → loopback CLIProxyAPI ───┤
+                                      └→ xAI subscription OAuth
 ```
 
 ## Support state
@@ -20,8 +22,18 @@ all 15 combinations of:
 - model: `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`
 - effort: `low`, `medium`, `high`, `xhigh`, `max`
 
-The result was 15/15 exact effort pass-through and 3/3 tool canaries. The
-patch is **not** an upstream CLIProxyAPI release. It is pinned to:
+The result was 15/15 exact GPT effort pass-through and 3/3 tool canaries.
+The same build also completed all five Claude Code effort flags with Grok 4.5
+and 3/3 real Grok tool canaries through xAI OAuth:
+
+- Grok `low`, `medium`, and `high` are exact end to end.
+- Claude's `xhigh` and `max` reach CLIProxyAPI intact, then clamp to Grok's
+  supported `high`.
+- A Sol parent invoked exact named agent `parable-grok` at all five parent
+  efforts. Claude Code inherited each parent effort into the child; Grok
+  applied the same `xhigh|max → high` clamp.
+
+The patch is **not** an upstream CLIProxyAPI release. It is pinned to:
 
 | Item | Pin |
 |---|---|
@@ -34,8 +46,8 @@ patch is **not** an upstream CLIProxyAPI release. It is pinned to:
 ## Five-minute path
 
 Prerequisites: Git, Go `1.26.5`, Claude Code `2.1.215`, `openssl`, `curl`,
-`jq`, and a ChatGPT account with access to the target models. Install Go from
-the [official downloads](https://go.dev/dl/?mode=html).
+`jq`, and the subscription accounts whose models you intend to use. Install
+Go from the [official downloads](https://go.dev/dl/?mode=html).
 
 ### 1. Pin, patch, test, and build CLIProxyAPI
 
@@ -87,9 +99,9 @@ debug: false
 EOF
 ```
 
-### 3. Connect the user's ChatGPT subscription
+### 3. Connect the user's subscriptions
 
-Run the browser OAuth flow:
+Connect ChatGPT:
 
 ```bash
 ./cli-proxy-api \
@@ -104,6 +116,20 @@ printed device code once; stale or previously submitted codes produce
 This route uses ChatGPT subscription OAuth. Do not set `OPENAI_API_KEY` for
 this setup.
 
+To add Grok 4.5, connect the user's xAI subscription separately:
+
+```bash
+./cli-proxy-api \
+  --config "$HOME/.config/parable/cliproxy.yaml" \
+  --xai-login \
+  --no-browser
+```
+
+Complete the printed xAI device flow. CLIProxyAPI stores and refreshes each
+provider's OAuth record in its user-only auth directory. Do not set
+`XAI_API_KEY`; this recipe proves the subscription route, not metered API
+billing.
+
 ### 4. Start and verify the local proxy
 
 Start the server in one terminal:
@@ -115,7 +141,8 @@ source "$HOME/.config/parable/cliproxy.env"
   --local-model
 ```
 
-Verify the authenticated catalog from another terminal:
+Verify the combined authenticated catalog from another terminal. Remove
+`grok-4.5` from the assertion if you intentionally configured only ChatGPT:
 
 ```bash
 source "$HOME/.config/parable/cliproxy.env"
@@ -125,7 +152,12 @@ curl -fsS \
   jq -e '
     [.data[].id] as $ids |
     all(
-      ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"][];
+      [
+        "gpt-5.6-sol",
+        "gpt-5.6-terra",
+        "gpt-5.6-luna",
+        "grok-4.5"
+      ][];
       . as $model | $ids | index($model)
     )
   '
@@ -146,15 +178,37 @@ version = 1
 base_url = "http://127.0.0.1:8317"
 auth_token_env = "CLIPROXY_API_KEY"
 brain_model = "gpt-5.6-sol"
+
+[providers.claude]
+type = "subagent"
+
+[executors.grok]
+provider = "claude"
+model = "grok-4.5"
+use_for = "A third-family implementation or adversarial review."
+avoid_for = "Reviewing its own diff."
 EOF
 
 source "$HOME/.config/parable/cliproxy.env"
 npx @parcha/parable doctor
+npx @parcha/parable agents sync
 npx @parcha/parable claude -- --effort high
 ```
 
 That launches the installed stock `claude` binary with Sol as the session
-model. Change the final effort to any of the five verified values.
+model and materializes exact project agent `parable-grok`. Change the final
+effort to any of the five verified values. In the session, explicitly ask Sol
+to use the `parable-grok` agent when that is the intended lane.
+
+The effort rule is observable, not advisory:
+
+| Sol parent effort | Grok child inbound | Grok upstream |
+|---|---|---|
+| `low` | `low` | `low` |
+| `medium` | `medium` | `medium` |
+| `high` | `high` | `high` |
+| `xhigh` | `xhigh` | `high` |
+| `max` | `max` | `high` |
 
 ## Optional GPT named subagents
 
@@ -194,8 +248,11 @@ Kimi remains paused and is intentionally absent from this setup.
 - [Released-binary diagnosis](https://github.com/miguelrios/unc-skills/blob/main/parable/docs/evidence/g1-gpt-model-effort-live/EXIT.md)
 - [Patched source proof](https://github.com/miguelrios/unc-skills/blob/main/parable/docs/evidence/e1-cliproxy-effort-fix/EXIT.md)
 - [Patched live matrix](https://github.com/miguelrios/unc-skills/blob/main/parable/docs/evidence/e2-cliproxy-effort-live/EXIT.md)
+- [xAI OAuth and catalog proof](https://github.com/miguelrios/unc-skills/blob/main/parable/docs/evidence/x1-grok45-catalog/EXIT.md)
+- [Grok main-model matrix](https://github.com/miguelrios/unc-skills/blob/main/parable/docs/evidence/x2-grok45-main-permutations/EXIT.md)
+- [Sol to named Grok matrix](https://github.com/miguelrios/unc-skills/blob/main/parable/docs/evidence/x3-sol-grok-named-subagent/EXIT.md)
 
 This is a per-user localhost setup. CLIProxyAPI owns OAuth storage and token
 refresh; Parable stores neither provider credentials nor OAuth state. ChatGPT
-plan limits, model entitlements, and provider terms still apply. Do not expose
-the proxy port outside loopback.
+and xAI plan limits, model entitlements, and provider terms still apply. Do
+not expose the proxy port outside loopback.

--- a/parable/docs/evidence/x4-grok45-oss-delivery/EXIT.md
+++ b/parable/docs/evidence/x4-grok45-oss-delivery/EXIT.md
@@ -1,0 +1,76 @@
+# X4 — OSS GROK DELIVERY · EXIT (2026-07-20)
+
+## Status: COMPLETE
+
+## The headline evidence
+
+The packaged five-minute localhost guide now covers both ChatGPT and xAI
+subscription OAuth, exact `grok-4.5` as main model or generated
+`parable-grok` child, authenticated combined-catalog verification, and the
+live-measured effort rule. The provider reference and distributable example
+carry the same contract.
+
+## What shipped
+
+| Piece | Where |
+|---|---|
+| Combined GPT/Grok five-minute recipe | `docs/CLIPROXYAPI_GPT_SUBSCRIPTION.md` |
+| Verified Grok provider contract | `skills/parable/references/providers.md` |
+| Subscription-backed cast example | `examples/parable.claude-subscriptions.toml` |
+| Sanitized delivery receipt | `docs/evidence/x4-grok45-oss-delivery/receipt.json` |
+
+## Bound accounting (honest)
+
+- Documentation proofs: 1/2; passed.
+- Evidence failures: 0.
+- Instrument failures: 2. Two content-boundary shell expressions were too
+  broad or incorrectly quoted; both stopped before affecting package content
+  and the corrected scan passed.
+- Review rounds: 1. Commands, links, effort claims, example merge behavior,
+  package contents, credential boundaries, and Cursor/Kimi distinctions were
+  checked.
+
+ZEN check: one localhost endpoint and declarative exact model ids unify the
+two proved subscriptions. Provider OAuth remains provider-owned; Parable adds
+no broker, credential format, model alias, or hidden routing rule.
+
+## Acceptance criteria → evidence
+
+1. Exact xAI OAuth and named-Grok path — ✅ the guide gives the xAI device
+   command, combined catalog assertion, exact TOML executor, agent sync, and
+   Sol launch.
+2. Claims match live receipts — ✅ the guide/reference distinguish exact
+   `low|medium|high`, `xhigh|max → high`, and five nested parent cells.
+3. Content boundary — ✅ corrected scan found no credential values, OAuth
+   state, raw trace, account identifier, or private runtime path.
+4. Verification — ✅ example config validation, 81/81 tests, and package
+   dry-run pass.
+5. Focused merge — ✅ the focused PR and verified `main` are recorded below.
+
+## The running delta table
+
+| Loop | xAI auth | Grok main | Sol → Grok | Public OSS recipe | Kimi |
+|---|---|---:|---:|---:|---|
+| X1 | valid | catalog only | 0 | GPT only | PAUSED |
+| X2 | valid | 5/5 + 3/3 tools | 0 | GPT only | PAUSED |
+| X3 | valid | retained | 5/5 | GPT only | PAUSED |
+| X4 | documented | retained | retained | GPT + Grok | PAUSED |
+
+MEASURE is reproducibility surface: proved Grok subscription routing moved
+from private evidence to all three packaged public entry points.
+
+## Merge verification
+
+- Example configuration: PASS.
+- Complete Parable suite: PASS, 81/81.
+- Package dry-run: PASS, 32 files.
+- Local Claudio-Michel review: 5/5.
+- Focused PR: pending.
+- Verified merged `main`: pending.
+
+## exit → X5
+
+The operator has already selected the successor: keep Kimi paused and extend
+the same Sol-parent proof to every available named subscription subagent,
+including Sonnet and Opus. X5 therefore records the verdict and opens that
+successor chain without waiting for another choice.

--- a/parable/docs/evidence/x4-grok45-oss-delivery/receipt.json
+++ b/parable/docs/evidence/x4-grok45-oss-delivery/receipt.json
@@ -1,0 +1,56 @@
+{
+  "schema_version": 1,
+  "loop": "X4",
+  "captured_at_utc": "2026-07-20T06:43:00Z",
+  "parable_baseline_head": "703949accbaf649b3286719a43dbffdb024e195d",
+  "delivery": {
+    "five_minute_guide": "docs/CLIPROXYAPI_GPT_SUBSCRIPTION.md",
+    "provider_reference": "skills/parable/references/providers.md",
+    "subscription_example": "examples/parable.claude-subscriptions.toml",
+    "xai_device_login_documented": true,
+    "combined_catalog_check_documented": true,
+    "exact_grok_agent_documented": true,
+    "sol_parent_effort_table_documented": true,
+    "grok_effort_clamp_documented": true,
+    "cursor_route_distinguished": true,
+    "kimi_state": "PAUSED"
+  },
+  "proved_claims": {
+    "gpt_text_effort_cells": "15/15",
+    "gpt_tool_canaries": "3/3",
+    "grok_main_text_cells": "5/5",
+    "grok_main_tool_canaries": "3/3",
+    "sol_to_named_grok_cells": "5/5",
+    "grok_supported_efforts_exact": [
+      "low",
+      "medium",
+      "high"
+    ],
+    "grok_clamped_efforts": {
+      "xhigh": "high",
+      "max": "high"
+    }
+  },
+  "verification": {
+    "example_config_valid": true,
+    "example_generated_executors": [
+      "parable-grok",
+      "parable-luna",
+      "parable-terra"
+    ],
+    "complete_parable_tests": "81/81",
+    "package_dry_run": "PASS",
+    "diff_check": "PASS",
+    "content_boundary_scan": "PASS"
+  },
+  "safety": {
+    "local_proxy_key_committed": false,
+    "credential_material_committed": false,
+    "oauth_state_committed": false,
+    "account_identifier_committed": false,
+    "raw_prompt_committed": false,
+    "raw_response_committed": false,
+    "raw_proxy_log_committed": false,
+    "private_path_committed": false
+  }
+}

--- a/parable/examples/parable.claude-subscriptions.toml
+++ b/parable/examples/parable.claude-subscriptions.toml
@@ -1,11 +1,12 @@
-# Subscription-backed models in one stock Claude Code session through a local
-# Claude-compatible proxy. This file contains no OAuth/provider credentials:
-# only the NAME of the environment variable holding the proxy's localhost
-# client token. Configure and authenticate the local proxy separately.
+# ChatGPT- and xAI-subscription-backed models in one stock Claude Code session
+# through a local Claude-compatible proxy. This file contains no
+# OAuth/provider credentials: only the NAME of the environment variable
+# holding the proxy's localhost client token. Configure and authenticate the
+# local proxy separately.
 
 [parable]
 version = 1
-default_executor = "kimi"
+default_executor = "terra"
 default_reviewer = "opus"
 
 [claude]
@@ -16,18 +17,30 @@ brain_model = "gpt-5.6-sol"
 [providers.claude]
 type = "subagent"
 
-[executors.kimi]
+[executors.grok]
 provider = "claude"
-model = "kimi-k3"
-tags = ["implementer", "third-party", "subscription"]
-use_for = "Independent implementation through the Kimi Code subscription."
+model = "grok-4.5"
+tags = ["implementer", "third-family", "subscription"]
+use_for = "Independent implementation or adversarial review through the xAI subscription."
 avoid_for = "Reviewing its own diff."
 
+[executors.terra]
+provider = "claude"
+model = "gpt-5.6-terra"
+tags = ["implementer", "subscription"]
+use_for = "Independent GPT implementation or debugging."
+
+[executors.luna]
+provider = "claude"
+model = "gpt-5.6-luna"
+tags = ["reviewer", "subscription"]
+use_for = "Independent GPT review or a second implementation."
+
 [routing]
-mechanical    = ["kimi", "sonnet"]
-feature       = ["kimi", "sonnet"]
-refactor_wide = ["kimi", "sonnet"]
+mechanical    = ["luna", "sonnet"]
+feature       = ["terra", "sonnet", "grok"]
+refactor_wide = ["terra", "sonnet", "grok"]
 gnarly        = ["opus"]
-review        = ["opus", "sonnet"]
+review        = ["opus", "luna", "grok"]
 smoke_test    = ["opus"]
-escalation    = ["kimi", "sonnet", "opus"]
+escalation    = ["terra", "sonnet", "grok", "opus"]

--- a/parable/skills/parable/references/providers.md
+++ b/parable/skills/parable/references/providers.md
@@ -204,6 +204,35 @@ accepted-but-not-effective. Follow the
 [pinned five-minute patched-source path](../../../docs/CLIPROXYAPI_GPT_SUBSCRIPTION.md)
 for the exact build, OAuth, proxy, and Parable commands.
 
+### Verified Grok 4.5 subscription support
+
+The same patched localhost build exposes exact `grok-4.5` through per-user
+xAI OAuth; no `XAI_API_KEY`, broker, or shared deployment is involved. With
+stock Claude Code `2.1.215`, Grok completed 5/5 main-model text cells and 3/3
+real Bash canaries. `low|medium|high` are exact. Claude's `xhigh|max` reach
+CLIProxyAPI intact and clamp to Grok's supported `high`.
+
+A generated custom executor routes exact named agent `parable-grok`:
+
+```toml
+[executors.grok]
+provider = "claude"
+model = "grok-4.5"
+use_for = "Third-family implementation or adversarial review."
+```
+
+Sol invoked that agent successfully at all five parent effort values. Claude
+Code inherited the parent effort into every child request; Grok preserved the
+three supported values and clamped `xhigh|max` to `high`. The
+[main-model receipt](../../../docs/evidence/x2-grok45-main-permutations/receipt.json)
+and [named-child receipt](../../../docs/evidence/x3-sol-grok-named-subagent/receipt.json)
+record exact model attribution, real tool use, deterministic artifacts, and
+separate ChatGPT/xAI OAuth routes.
+
+This xAI OAuth route is distinct from Parable's Cursor executor. Cursor uses a
+Cursor plan and `cursor-agent`; it is not the Grok child route inside Claude
+Code.
+
 ## Reading subscription headroom (parable-usage.sh)
 
 Each subscription pool publishes its own remaining headroom over an authenticated endpoint the


### PR DESCRIPTION
## Summary
- extend the five-minute localhost recipe to xAI subscription OAuth and Grok 4.5
- document exact named parable-grok routing and measured effort inheritance/clamps
- update the provider reference and packaged subscription example
- record X4 delivery evidence and content boundaries

## Verification
- example configuration validation
- 81/81 Parable tests
- npm package dry-run (32 files)
- corrected content-boundary scan and local review 5/5