### PR TITLE
feat(recall): tenant-aware canonical MCP

### DIFF
--- a/.github/workflows/recall-ci.yml
+++ b/.github/workflows/recall-ci.yml
@@ -52,6 +52,7 @@ jobs:
             e2e_v2_lifecycle.py \
             e2e_v2_isolation.py \
             e2e_v2_connector_writer.py \
+            e2e_v2_multitenant_mcp.py \
             e2e_session_source_l1.py \
             e2e_semantic_l2.py \
             e2e_capture_mcp.py \

--- a/recall/server/deploy/README.md
+++ b/recall/server/deploy/README.md
@@ -61,7 +61,7 @@ infrastructure. The example is synthetic; a live manifest belongs in a private m
 location and contains references, never credential values.
 
 The production database gate requires a standard PostgreSQL URL with
-`sslmode=verify-full` and an explicit trust root, schema migrations 1 through 27,
+`sslmode=verify-full` and an explicit trust root, schema migrations 1 through 28,
 pgvector 0.8.0 or newer, and a runtime role without superuser, database/role creation,
 replication, or RLS-bypass privilege:
 
@@ -184,6 +184,28 @@ runner archives raw bytes through the fenced archive route, applies privacy,
 writes only the redacted envelope to its private spool, and advances its cursor
 only after the canonical ACK. Do not enable this flag on an MCP-only service
 that has no collector ingress.
+
+After canonical ingestion is live, provision each personal or company brain and
+mint a separate audience-bound MCP credential:
+
+```bash
+python -m recall_server.cli brain-provision \
+  --organization org:owner --kind personal --display-name "Personal" \
+  --tenant tenant:personal --slug personal --owner-principal principal:owner
+python -m recall_server.cli mcp-token-create owner-personal \
+  --tenant tenant:personal --principal principal:owner \
+  --scopes read,forget \
+  --output /approved/private/owner-personal-mcp.json
+```
+
+Set `RECALL_CANONICAL_MCP_ENABLED=1` only after migration 28 and canonical
+embedding backfill pass. In this mode, public MCP accepts only unexpired
+`recall-mcp` credentials bound to one tenant. Retrieval intersects brain access
+with explicit canonical source grants and never reads the legacy evidence
+projection. A single principal can hold separate personal and company
+credentials without gaining an implicit cross-brain view. Omit the optional
+`forget` scope for read-only agents; canonical forget also requires an owner
+grant on the exact source.
 
 `RECALL_DATABASE_URL` must be a PlanetScale application role URL with
 `sslmode=verify-full` and an explicit trust root. Prefer

--- a/recall/server/deploy/service.env.example
+++ b/recall/server/deploy/service.env.example
@@ -15,6 +15,8 @@ RECALL_ALLOWED_TAILSCALE_USERS=owner@example.com
 # Canonical v2 cutover. Keep disabled until archive-check and migrations pass.
 # RECALL_CANONICAL_V2_ENABLED=1
 # RECALL_CANONICAL_INGEST_PUBLIC=1
+# Route authenticated MCP reads exclusively through canonical tenant/source grants.
+# RECALL_CANONICAL_MCP_ENABLED=1
 # RECALL_TENANT_ID=tenant:personal
 # RECALL_PRINCIPAL_ID=principal:owner
 # Browser MCP clients must match this exact comma-separated allow-list.

--- a/recall/server/recall_server/__init__.py
+++ b/recall/server/recall_server/__init__.py
@@ -1,4 +1,4 @@
 """Recall central BrainStore service."""
 
-SCHEMA_VERSION = 27
+SCHEMA_VERSION = 28
 PROJECTOR_VERSION = 3

--- a/recall/server/recall_server/app.py
+++ b/recall/server/recall_server/app.py
@@ -20,6 +20,7 @@ from .canonical import (
     CanonicalLifecycleError,
     CanonicalPlane,
 )
+from .canonical_retrieval import CanonicalRetrieval
 from .db import BrainStore, IdempotencyConflict
 from .mcp import (
     SUPPORTED_PROTOCOL_VERSIONS,
@@ -49,6 +50,7 @@ class Handler(BaseHTTPRequestHandler):
     store: BrainStore
     archive_store = None
     canonical_plane: CanonicalPlane | None = None
+    canonical_retrieval: CanonicalRetrieval | None = None
 
     def log_message(self, fmt: str, *args) -> None:
         LOG.info(
@@ -153,20 +155,37 @@ class Handler(BaseHTTPRequestHandler):
             )
             if not credential:
                 return None
+            credential_kind = credential.get("credential_kind", "collector")
+            if (
+                scope == "read"
+                and os.environ.get("RECALL_CANONICAL_MCP_ENABLED") == "1"
+                and credential_kind != "mcp"
+            ):
+                return None
             principal = {
-                "kind": "collector",
+                "kind": credential_kind,
+                "credential_kind": credential_kind,
                 "name": credential["name"],
                 "tenant_id": credential.get("tenant_id"),
                 "source_id": credential["source_id"],
                 "principal_id": credential.get("principal_id"),
+                "audience": credential.get("audience"),
                 "capture_origin": credential.get("capture_origin"),
                 "webhook_privacy_mode": credential.get("webhook_privacy_mode"),
                 "scopes": list(credential.get("scopes", [])),
             }
             if credential.get("principal_id") and scope == "read":
-                principal["authorized_sources"] = self.store.authorized_source_ids(
-                    credential["principal_id"]
-                )
+                if credential_kind == "mcp":
+                    principal["authorized_sources"] = (
+                        self.store.authorized_canonical_source_ids(
+                            credential.get("tenant_id"),
+                            credential["principal_id"],
+                        )
+                    )
+                else:
+                    principal["authorized_sources"] = self.store.authorized_source_ids(
+                        credential["principal_id"]
+                    )
             return principal
         if (
             os.environ.get("RECALL_TRUST_TAILSCALE_HEADERS", "0") == "1"
@@ -473,6 +492,18 @@ class Handler(BaseHTTPRequestHandler):
                     principal_id=principal_id,
                     events=events,
                 )
+                if self.canonical_retrieval is not None:
+                    try:
+                        self.canonical_retrieval.embed_pending(
+                            tenant_id=tenant_id,
+                            batch_size=min(500, max(1, len(events))),
+                            max_batches=1,
+                        )
+                    except Exception as exc:
+                        LOG.warning(
+                            "canonical embedding deferred type=%s",
+                            type(exc).__name__,
+                        )
                 with COUNTER_LOCK:
                     COUNTERS[
                         "ingest_replays"
@@ -581,7 +612,12 @@ class Handler(BaseHTTPRequestHandler):
                 body = json.loads(self.rfile.read(length))
                 if isinstance(body, dict):
                     request_id = body.get("id")
-                response = dispatch_mcp(self.store, principal, body)
+                mcp_store = self.store
+                if os.environ.get("RECALL_CANONICAL_MCP_ENABLED") == "1":
+                    if self.canonical_retrieval is None:
+                        raise RuntimeError("canonical retrieval unavailable")
+                    mcp_store = self.canonical_retrieval.bind(principal)
+                response = dispatch_mcp(mcp_store, principal, body)
             except json.JSONDecodeError:
                 self.send_json(
                     400,
@@ -749,6 +785,13 @@ def validate_http_profile() -> None:
         raise RuntimeError(
             "public canonical ingest requires authentication and canonical v2"
         )
+    if os.environ.get("RECALL_CANONICAL_MCP_ENABLED") == "1" and (
+        os.environ.get("RECALL_AUTH_REQUIRED", "0") != "1"
+        or os.environ.get("RECALL_CANONICAL_V2_ENABLED") != "1"
+    ):
+        raise RuntimeError(
+            "canonical MCP requires authentication and canonical v2"
+        )
     if profile in {"public-edge", "public-mcp"}:
         if os.environ.get("RECALL_AUTH_REQUIRED", "0") != "1":
             raise RuntimeError("public HTTP profile requires authentication")
@@ -764,9 +807,15 @@ def configure_runtime(dsn: str) -> None:
             Handler.store,
             Handler.archive_store,
         )
+        Handler.canonical_retrieval = (
+            CanonicalRetrieval(Handler.store, Handler.archive_store)
+            if os.environ.get("RECALL_CANONICAL_MCP_ENABLED") == "1"
+            else None
+        )
     else:
         Handler.archive_store = None
         Handler.canonical_plane = None
+        Handler.canonical_retrieval = None
 
 
 def serve(dsn: str, host: str = "127.0.0.1", port: int = 8788) -> None:

--- a/recall/server/recall_server/canonical.py
+++ b/recall/server/recall_server/canonical.py
@@ -180,6 +180,14 @@ class CanonicalPlane:
         ).fetchone()
         if owner is None or owner["owner_principal_id"] != principal_id:
             raise CanonicalLifecycleError("canonical_authority_forbidden")
+        conn.execute(
+            """INSERT INTO canonical_source_grants(
+                   tenant_id,principal_id,source_id,permission
+               ) VALUES (%s,%s,%s,'owner')
+               ON CONFLICT(tenant_id,principal_id,source_id)
+               DO UPDATE SET permission='owner'""",
+            (tenant_id, principal_id, source_id),
+        )
 
     def ingest_document(
         self,

--- a/recall/server/recall_server/canonical_retrieval.py
+++ b/recall/server/recall_server/canonical_retrieval.py
@@ -1,0 +1,489 @@
+from __future__ import annotations
+
+import hashlib
+import re
+from datetime import datetime, timezone
+from typing import Any
+from urllib.parse import urlsplit
+
+from .canonical import CanonicalPlane
+from .db import BrainStore, bounded_search_text
+
+
+AUTHORITY_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9:._/@+-]{1,255}\Z")
+ALLOWED_FILTERS = frozenset({"since", "until", "source_id"})
+
+
+def _timestamp(value: Any) -> str:
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return str(value)
+
+
+class CanonicalRetrieval:
+    """Tenant-keyed hybrid retrieval over only the canonical v2 projection."""
+
+    def __init__(self, store: BrainStore, archive: Any = None):
+        self.store = store
+        self.archive = archive
+
+    def bind(self, principal: dict[str, Any]) -> BoundCanonicalRetrieval:
+        tenant_id = principal.get("tenant_id")
+        principal_id = principal.get("principal_id")
+        audience = principal.get("audience")
+        if (
+            principal.get("credential_kind") != "mcp"
+            or audience != "recall-mcp"
+            or not isinstance(tenant_id, str)
+            or not AUTHORITY_RE.fullmatch(tenant_id)
+            or not isinstance(principal_id, str)
+            or not AUTHORITY_RE.fullmatch(principal_id)
+        ):
+            raise PermissionError("canonical MCP authority required")
+        sources = tuple(principal.get("authorized_sources") or ())
+        if any(
+            not isinstance(source, str) or not AUTHORITY_RE.fullmatch(source)
+            for source in sources
+        ):
+            raise PermissionError("canonical MCP source grants invalid")
+        return BoundCanonicalRetrieval(
+            self.store,
+            tenant_id=tenant_id,
+            principal_id=principal_id,
+            authorized_sources=sources,
+            archive=self.archive,
+        )
+
+    def embed_pending(
+        self,
+        *,
+        tenant_id: str | None = None,
+        batch_size: int = 100,
+        max_batches: int = 10,
+    ) -> dict[str, int | str]:
+        runtime = self.store.semantic_runtime
+        if runtime is None:
+            return {"status": "disabled", "processed": 0, "batches": 0}
+        if runtime.dimensions != 512:
+            raise ValueError("canonical embeddings require 512 dimensions")
+        if not 1 <= batch_size <= 500 or not 1 <= max_batches <= 100:
+            raise ValueError("invalid canonical embedding batch")
+        processed = batches = 0
+        for _ in range(max_batches):
+            with self.store.connect() as connection:
+                rows = connection.execute(
+                    """SELECT chunk.tenant_id,chunk.source_id,chunk.chunk_id,
+                              chunk.text_redacted,chunk.text_sha256
+                       FROM canonical_chunks chunk
+                       JOIN canonical_documents document
+                         USING(tenant_id,source_id,document_id)
+                       LEFT JOIN canonical_chunk_embeddings embedding
+                         ON embedding.tenant_id=chunk.tenant_id
+                        AND embedding.source_id=chunk.source_id
+                        AND embedding.chunk_id=chunk.chunk_id
+                        AND embedding.runtime_fingerprint=%s
+                       WHERE chunk.deleted_at IS NULL
+                         AND document.is_current
+                         AND document.deleted_at IS NULL
+                         AND embedding.chunk_id IS NULL
+                         AND (%s::text IS NULL OR chunk.tenant_id=%s)
+                       ORDER BY chunk.tenant_id,chunk.source_id,chunk.chunk_id
+                       LIMIT %s""",
+                    (runtime.fingerprint, tenant_id, tenant_id, batch_size),
+                ).fetchall()
+            if not rows:
+                break
+            vectors = runtime.embed_documents(
+                [row["text_redacted"] for row in rows]
+            )
+            with self.store.connect() as connection:
+                with connection.transaction():
+                    with connection.cursor() as cursor:
+                        cursor.executemany(
+                            """INSERT INTO canonical_chunk_embeddings(
+                                   tenant_id,source_id,chunk_id,model,dimensions,
+                                   content_sha256,runtime_fingerprint,embedding
+                               ) VALUES (%s,%s,%s,%s,512,%s,%s,%s::halfvec)
+                               ON CONFLICT(tenant_id,source_id,chunk_id)
+                               DO UPDATE SET
+                                 model=excluded.model,
+                                 dimensions=excluded.dimensions,
+                                 content_sha256=excluded.content_sha256,
+                                 runtime_fingerprint=excluded.runtime_fingerprint,
+                                 embedding=excluded.embedding,
+                                 embedded_at=now()""",
+                            [
+                                (
+                                    row["tenant_id"],
+                                    row["source_id"],
+                                    row["chunk_id"],
+                                    runtime.model,
+                                    row["text_sha256"],
+                                    runtime.fingerprint,
+                                    vector,
+                                )
+                                for row, vector in zip(rows, vectors, strict=True)
+                            ],
+                        )
+            processed += len(rows)
+            batches += 1
+        return {"status": "complete", "processed": processed, "batches": batches}
+
+
+class BoundCanonicalRetrieval:
+    """A canonical retrieval view whose tenant and grants cannot be overridden."""
+
+    def __init__(
+        self,
+        store: BrainStore,
+        *,
+        tenant_id: str,
+        principal_id: str,
+        authorized_sources: tuple[str, ...],
+        archive: Any = None,
+    ):
+        self.store = store
+        self.tenant_id = tenant_id
+        self.principal_id = principal_id
+        self.authorized_sources = authorized_sources
+        self.archive = archive
+
+    @staticmethod
+    def _filters(filters: dict[str, Any]) -> tuple[str | None, str | None, str | None]:
+        if not isinstance(filters, dict) or set(filters) - ALLOWED_FILTERS:
+            raise ValueError("unsupported canonical search filter")
+        source_id = filters.get("source_id")
+        if source_id is not None and (
+            not isinstance(source_id, str) or not AUTHORITY_RE.fullmatch(source_id)
+        ):
+            raise ValueError("invalid source_id filter")
+        values: list[str | None] = []
+        for name in ("since", "until"):
+            value = filters.get(name)
+            if value is not None:
+                if not isinstance(value, str):
+                    raise ValueError("invalid temporal filter")
+                parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+                if parsed.tzinfo is None:
+                    raise ValueError("invalid temporal filter")
+            values.append(value)
+        return source_id, values[0], values[1]
+
+    @staticmethod
+    def _row(row: dict[str, Any], score: float) -> dict[str, Any]:
+        text, clipped = bounded_search_text(row["text_redacted"])
+        return {
+            "source_id": row["source_id"],
+            "native_id": row["native_id"],
+            "revision": row["revision"],
+            "occurred_at": _timestamp(row["occurred_at"]),
+            "text": text,
+            "text_clipped": clipped,
+            "receipt": row["receipt"],
+            "rank": round(score, 8),
+        }
+
+    def search(
+        self,
+        query: str,
+        filters: dict[str, Any] | None = None,
+        limit: int = 10,
+        _authorized_source: Any = None,
+    ) -> dict[str, Any]:
+        if not isinstance(query, str) or not query.strip() or len(query) > 8192:
+            raise ValueError("invalid canonical search query")
+        if isinstance(limit, bool) or not isinstance(limit, int) or not 1 <= limit <= 20:
+            raise ValueError("invalid canonical search limit")
+        source_id, since, until = self._filters(filters or {})
+        sources = list(self.authorized_sources)
+        if source_id is not None:
+            sources = [source_id] if source_id in sources else []
+        if not sources:
+            return {
+                "results": [],
+                "diagnostics": {
+                    "engine": "canonical-v2",
+                    "lexical_candidates": 0,
+                    "semantic_candidates": 0,
+                },
+            }
+        candidate_limit = min(100, max(20, limit * 5))
+        with self.store.connect() as connection:
+            lexical = connection.execute(
+                """SELECT chunk.source_id,document.native_id,document.revision,
+                          event.occurred_at,chunk.text_redacted,chunk.receipt,
+                          ts_rank_cd(
+                            chunk.search_vector,
+                            websearch_to_tsquery('simple',%s),
+                            32
+                          ) AS score
+                   FROM canonical_chunks chunk
+                   JOIN canonical_documents document
+                     USING(tenant_id,source_id,document_id)
+                   JOIN canonical_events event
+                     USING(tenant_id,source_id,event_id)
+                   WHERE chunk.tenant_id=%s
+                     AND chunk.source_id=ANY(%s)
+                     AND chunk.deleted_at IS NULL
+                     AND document.is_current
+                     AND document.deleted_at IS NULL
+                     AND chunk.search_vector @@
+                         websearch_to_tsquery('simple',%s)
+                     AND (%s::timestamptz IS NULL OR event.occurred_at>=%s)
+                     AND (%s::timestamptz IS NULL OR event.occurred_at<=%s)
+                   ORDER BY score DESC,event.occurred_at DESC,chunk.chunk_id
+                   LIMIT %s""",
+                (
+                    query,
+                    self.tenant_id,
+                    sources,
+                    query,
+                    since,
+                    since,
+                    until,
+                    until,
+                    candidate_limit,
+                ),
+            ).fetchall()
+        semantic: list[dict[str, Any]] = []
+        runtime = self.store.semantic_runtime
+        if runtime is not None:
+            vector = runtime.embed_query(query)
+            with self.store.connect() as connection:
+                semantic = connection.execute(
+                    """SELECT chunk.source_id,document.native_id,document.revision,
+                              event.occurred_at,chunk.text_redacted,chunk.receipt,
+                              1-(embedding.embedding <=> %s::halfvec) AS score
+                       FROM canonical_chunk_embeddings embedding
+                       JOIN canonical_chunks chunk
+                         USING(tenant_id,source_id,chunk_id)
+                       JOIN canonical_documents document
+                         USING(tenant_id,source_id,document_id)
+                       JOIN canonical_events event
+                         USING(tenant_id,source_id,event_id)
+                       WHERE chunk.tenant_id=%s
+                         AND chunk.source_id=ANY(%s)
+                         AND embedding.runtime_fingerprint=%s
+                         AND chunk.deleted_at IS NULL
+                         AND document.is_current
+                         AND document.deleted_at IS NULL
+                         AND (%s::timestamptz IS NULL OR event.occurred_at>=%s)
+                         AND (%s::timestamptz IS NULL OR event.occurred_at<=%s)
+                       ORDER BY embedding.embedding <=> %s::halfvec,
+                                event.occurred_at DESC,chunk.chunk_id
+                       LIMIT %s""",
+                    (
+                        vector,
+                        self.tenant_id,
+                        sources,
+                        runtime.fingerprint,
+                        since,
+                        since,
+                        until,
+                        until,
+                        vector,
+                        candidate_limit,
+                    ),
+                ).fetchall()
+        combined: dict[str, tuple[dict[str, Any], float]] = {}
+        for weight, rows in ((0.6, lexical), (0.4, semantic)):
+            for rank, row in enumerate(rows, start=1):
+                score = weight / (60 + rank)
+                prior = combined.get(row["receipt"])
+                combined[row["receipt"]] = (
+                    row,
+                    score + (prior[1] if prior else 0.0),
+                )
+        ranked = sorted(
+            combined.values(),
+            key=lambda value: (value[1], value[0]["occurred_at"], value[0]["receipt"]),
+            reverse=True,
+        )[:limit]
+        return {
+            "results": [self._row(row, score) for row, score in ranked],
+            "diagnostics": {
+                "engine": "canonical-v2",
+                "lexical_candidates": len(lexical),
+                "semantic_candidates": len(semantic),
+            },
+        }
+
+    def show(
+        self,
+        target: str,
+        *,
+        around: str | None = None,
+        tail: int = 0,
+        prompts: bool = False,
+        authorized_source: Any = None,
+    ) -> dict[str, Any] | None:
+        if (
+            not isinstance(target, str)
+            or not target.startswith("recall://")
+            or around is not None
+            or tail not in {0}
+            or prompts
+        ):
+            raise ValueError("unsupported canonical show request")
+        if not self.authorized_sources:
+            return None
+        with self.store.connect() as connection:
+            redirect = connection.execute(
+                """SELECT new_receipt FROM receipt_redirects
+                   WHERE tenant_id=%s AND old_receipt=%s""",
+                (self.tenant_id, target),
+            ).fetchone()
+            if redirect:
+                target = redirect["new_receipt"]
+            row = connection.execute(
+                """SELECT chunk.source_id,chunk.document_id,document.native_id,
+                          document.revision,event.kind,event.occurred_at,
+                          event.observed_at,event.canonical_redacted
+                   FROM canonical_chunks chunk
+                   JOIN canonical_documents document
+                     USING(tenant_id,source_id,document_id)
+                   JOIN canonical_events event
+                     USING(tenant_id,source_id,event_id)
+                   WHERE chunk.tenant_id=%s
+                     AND chunk.source_id=ANY(%s)
+                     AND chunk.receipt=%s
+                     AND chunk.deleted_at IS NULL
+                     AND document.deleted_at IS NULL
+                     AND NOT EXISTS (
+                       SELECT 1 FROM canonical_events later
+                       WHERE later.tenant_id=document.tenant_id
+                         AND later.source_id=document.source_id
+                         AND later.native_id=document.native_id
+                         AND later.revision>document.revision
+                         AND later.is_tombstone
+                     )""",
+                (self.tenant_id, list(self.authorized_sources), target),
+            ).fetchone()
+            if row is None:
+                return None
+            chunks = connection.execute(
+                """SELECT ordinal,text_redacted AS text,receipt
+                   FROM canonical_chunks
+                   WHERE tenant_id=%s AND source_id=%s AND document_id=%s
+                     AND deleted_at IS NULL
+                   ORDER BY ordinal""",
+                (self.tenant_id, row["source_id"], row["document_id"]),
+            ).fetchall()
+        return {
+            "event": {
+                "source_id": row["source_id"],
+                "native_id": row["native_id"],
+                "revision": row["revision"],
+                "kind": row["kind"],
+                "occurred_at": _timestamp(row["occurred_at"]),
+                "observed_at": _timestamp(row["observed_at"]),
+                "canonical_redacted": row["canonical_redacted"],
+            },
+            "chunks": chunks,
+        }
+
+    def related(
+        self,
+        *,
+        cwd: str | None = None,
+        branch: str | None = None,
+        limit: int = 10,
+        mains_only: bool = False,
+        fast: bool = False,
+        authorized_source: Any = None,
+    ) -> dict[str, Any]:
+        if (
+            (cwd is not None and (not isinstance(cwd, str) or len(cwd) > 4096))
+            or (branch is not None and (not isinstance(branch, str) or len(branch) > 512))
+            or isinstance(limit, bool)
+            or not isinstance(limit, int)
+            or not 1 <= limit <= 20
+            or mains_only
+        ):
+            raise ValueError("unsupported canonical related request")
+        if not self.authorized_sources:
+            return {"results": [], "diagnostics": {"engine": "canonical-v2"}}
+        with self.store.connect() as connection:
+            rows = connection.execute(
+                """SELECT chunk.source_id,document.native_id,document.revision,
+                          event.occurred_at,chunk.text_redacted,chunk.receipt,
+                          event.canonical_redacted #>> '{provenance,cwd}' AS path,
+                          event.canonical_redacted #>> '{provenance,branch}' AS branch
+                   FROM canonical_chunks chunk
+                   JOIN canonical_documents document
+                     USING(tenant_id,source_id,document_id)
+                   JOIN canonical_events event
+                     USING(tenant_id,source_id,event_id)
+                   WHERE chunk.tenant_id=%s
+                     AND chunk.source_id=ANY(%s)
+                     AND chunk.deleted_at IS NULL
+                     AND document.is_current
+                     AND document.deleted_at IS NULL
+                     AND (%s::text IS NULL OR
+                          event.canonical_redacted #>> '{provenance,cwd}'=%s)
+                     AND (%s::text IS NULL OR
+                          event.canonical_redacted #>> '{provenance,branch}'=%s)
+                   ORDER BY event.occurred_at DESC,chunk.chunk_id
+                   LIMIT %s""",
+                (
+                    self.tenant_id,
+                    list(self.authorized_sources),
+                    cwd,
+                    cwd,
+                    branch,
+                    branch,
+                    limit,
+                ),
+            ).fetchall()
+        return {
+            "results": [
+                {
+                    **self._row(row, 1.0 / (60 + rank)),
+                    "path": row["path"],
+                    "branch": row["branch"],
+                }
+                for rank, row in enumerate(rows, start=1)
+            ],
+            "diagnostics": {"engine": "canonical-v2", "fast": bool(fast)},
+        }
+
+    def forget(self, receipt: str) -> dict[str, Any]:
+        if self.archive is None or not isinstance(receipt, str):
+            raise ValueError("canonical forget unavailable")
+        parsed = urlsplit(receipt)
+        source_id = parsed.netloc
+        if (
+            parsed.scheme != "recall"
+            or source_id not in self.authorized_sources
+            or not AUTHORITY_RE.fullmatch(source_id)
+        ):
+            raise ValueError("canonical forget receipt not found")
+        with self.store.connect() as connection:
+            owner = connection.execute(
+                """SELECT 1 FROM canonical_source_grants
+                   WHERE tenant_id=%s AND principal_id=%s AND source_id=%s
+                     AND permission='owner'""",
+                (self.tenant_id, self.principal_id, source_id),
+            ).fetchone()
+        if not owner:
+            raise ValueError("canonical forget receipt not found")
+        now = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+        return CanonicalPlane(self.store, self.archive).forget(
+            {
+                "contract": "recall.forget-request.v1",
+                "schema_version": 1,
+                "tenant_id": self.tenant_id,
+                "principal_id": self.principal_id,
+                "source_id": source_id,
+                "target_receipt": receipt,
+                "mode": "explicit_forget",
+                "reason": "owner_requested",
+                "requested_at": now,
+                "idempotency_key": "mcp-forget-v1-"
+                + hashlib.sha256(
+                    "\x1f".join(
+                        (self.tenant_id, self.principal_id, receipt)
+                    ).encode()
+                ).hexdigest(),
+            }
+        )

--- a/recall/server/recall_server/capabilities.py
+++ b/recall/server/recall_server/capabilities.py
@@ -26,7 +26,10 @@ WITH expected_tables(name) AS (
         ('brain_tenants'), ('brain_principals'), ('canonical_sources'),
         ('raw_artifacts'), ('canonical_events'), ('canonical_documents'),
         ('canonical_chunks'), ('canonical_ingest_jobs'), ('receipt_redirects'),
-        ('forget_tombstones'), ('canonical_audit_events')
+        ('forget_tombstones'), ('canonical_audit_events'),
+        ('brain_organizations'), ('brain_spaces'), ('brain_memberships'),
+        ('brain_access_grants'), ('canonical_source_grants'),
+        ('mcp_credentials'), ('canonical_chunk_embeddings')
 ), runtime_tables(name) AS (
     SELECT name FROM expected_tables WHERE name <> 'schema_migrations'
 ), expected_sequences(name) AS (
@@ -51,13 +54,13 @@ SELECT
     role.rolbypassrls AS bypass_rls,
     pg_catalog.has_database_privilege(current_database(), 'CONNECT') AS can_connect,
     pg_catalog.has_schema_privilege(current_user, 'public', 'USAGE') AS can_use_schema,
-    (SELECT count(*) = 34 AND COALESCE(bool_and(
+    (SELECT count(*) = 41 AND COALESCE(bool_and(
         pg_catalog.to_regclass(pg_catalog.format('public.%I', name)) IS NOT NULL
         AND pg_catalog.has_table_privilege(
             current_user, pg_catalog.to_regclass(pg_catalog.format('public.%I', name)), 'SELECT'
         )
     ), false) FROM expected_tables) AS can_read_runtime_tables,
-    (SELECT count(*) = 33 AND COALESCE(bool_and(
+    (SELECT count(*) = 40 AND COALESCE(bool_and(
         pg_catalog.to_regclass(pg_catalog.format('public.%I', name)) IS NOT NULL
         AND pg_catalog.has_table_privilege(
             current_user, pg_catalog.to_regclass(pg_catalog.format('public.%I', name)),

--- a/recall/server/recall_server/cli.py
+++ b/recall/server/recall_server/cli.py
@@ -12,6 +12,7 @@ from .app import serve, serve_unix
 from .archive import ArchiveError
 from .archive_runtime import build_archive_store, probe_archive
 from .capabilities import CapabilityError, probe_database
+from .canonical_retrieval import CanonicalRetrieval
 from .db import BrainStore
 from .deployment import DeploymentManifestError, load_manifest, preview
 from .federation import QUALITY_SCORES, SOURCE_FAMILIES
@@ -81,6 +82,10 @@ def main() -> None:
     backfill_turn_embeddings.add_argument("--batch-size", type=int, default=128)
     backfill_turn_embeddings.add_argument("--max-batches", type=int)
     backfill_turn_embeddings.add_argument("--source-id")
+    canonical_embeddings = sub.add_parser("backfill-canonical-embeddings")
+    canonical_embeddings.add_argument("--tenant")
+    canonical_embeddings.add_argument("--batch-size", type=int, default=100)
+    canonical_embeddings.add_argument("--max-batches", type=int, default=10)
     sub.add_parser("export")
     conformance = sub.add_parser("mcp-conformance")
     conformance.add_argument("--config", type=Path, required=True)
@@ -112,6 +117,24 @@ def main() -> None:
     )
     revoke_token = sub.add_parser("token-revoke")
     revoke_token.add_argument("name")
+    brain = sub.add_parser("brain-provision")
+    brain.add_argument("--organization", required=True)
+    brain.add_argument(
+        "--kind", choices=("personal", "company"), required=True
+    )
+    brain.add_argument("--display-name", required=True)
+    brain.add_argument("--tenant", required=True)
+    brain.add_argument("--slug", required=True)
+    brain.add_argument("--owner-principal", required=True)
+    create_mcp_token = sub.add_parser("mcp-token-create")
+    create_mcp_token.add_argument("name")
+    create_mcp_token.add_argument("--tenant", required=True)
+    create_mcp_token.add_argument("--principal", required=True)
+    create_mcp_token.add_argument("--scopes", default="read")
+    create_mcp_token.add_argument("--expires-in-days", type=int, default=30)
+    create_mcp_token.add_argument("--output", required=True)
+    revoke_mcp_token = sub.add_parser("mcp-token-revoke")
+    revoke_mcp_token.add_argument("name")
     source_profile = sub.add_parser("source-profile-set")
     source_profile.add_argument("source_id")
     source_profile.add_argument(
@@ -304,6 +327,17 @@ def main() -> None:
                 sort_keys=True,
             )
         )
+    elif args.command == "backfill-canonical-embeddings":
+        print(
+            json.dumps(
+                CanonicalRetrieval(store).embed_pending(
+                    tenant_id=args.tenant,
+                    batch_size=args.batch_size,
+                    max_batches=args.max_batches,
+                ),
+                sort_keys=True,
+            )
+        )
     elif args.command == "export":
         for envelope in store.export_raw():
             print(json.dumps(envelope, sort_keys=True))
@@ -329,6 +363,49 @@ def main() -> None:
         )
     elif args.command == "token-revoke":
         print(json.dumps({"revoked": store.revoke_collector_token(args.name)}))
+    elif args.command == "brain-provision":
+        print(
+            json.dumps(
+                store.provision_brain(
+                    organization_id=args.organization,
+                    organization_kind=args.kind,
+                    display_name=args.display_name,
+                    tenant_id=args.tenant,
+                    brain_kind=args.kind,
+                    slug=args.slug,
+                    owner_principal_id=args.owner_principal,
+                ),
+                sort_keys=True,
+            )
+        )
+    elif args.command == "mcp-token-create":
+        credential = store.create_mcp_token(
+            args.name,
+            tenant_id=args.tenant,
+            principal_id=args.principal,
+            scopes=[
+                scope.strip()
+                for scope in args.scopes.split(",")
+                if scope.strip()
+            ],
+            expires_in_days=args.expires_in_days,
+        )
+        payload = (json.dumps(credential, sort_keys=True) + "\n").encode()
+        descriptor = os.open(
+            args.output,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+            0o600,
+        )
+        with os.fdopen(descriptor, "wb") as output:
+            output.write(payload)
+        print(
+            json.dumps(
+                {key: value for key, value in credential.items() if key != "token"},
+                sort_keys=True,
+            )
+        )
+    elif args.command == "mcp-token-revoke":
+        print(json.dumps({"revoked": store.revoke_mcp_token(args.name)}))
     elif args.command == "source-profile-set":
         print(
             json.dumps(

--- a/recall/server/recall_server/db.py
+++ b/recall/server/recall_server/db.py
@@ -9,7 +9,7 @@ import threading
 import time
 import uuid
 from concurrent.futures import ProcessPoolExecutor
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Iterable
 
@@ -267,6 +267,215 @@ class BrainStore:
             )
             return bool(row)
 
+    def provision_brain(
+        self,
+        *,
+        organization_id: str,
+        organization_kind: str,
+        display_name: str,
+        tenant_id: str,
+        brain_kind: str,
+        slug: str,
+        owner_principal_id: str,
+    ) -> dict[str, str]:
+        values = (organization_id, tenant_id, owner_principal_id)
+        if (
+            any(not isinstance(value, str) or not V2_AUTHORITY_RE.fullmatch(value)
+                for value in values)
+            or organization_kind not in {"personal", "company"}
+            or brain_kind != organization_kind
+            or not isinstance(display_name, str)
+            or not 1 <= len(display_name) <= 200
+            or not isinstance(slug, str)
+            or not re.fullmatch(r"[a-z0-9][a-z0-9-]{0,62}", slug)
+        ):
+            raise ValueError("invalid brain provisioning request")
+        with self.connect() as conn:
+            with conn.transaction():
+                conn.execute(
+                    """INSERT INTO brain_organizations(
+                           organization_id,organization_kind,display_name
+                       ) VALUES (%s,%s,%s)
+                       ON CONFLICT(organization_id) DO UPDATE SET
+                         display_name=excluded.display_name
+                       WHERE brain_organizations.organization_kind=
+                             excluded.organization_kind""",
+                    (organization_id, organization_kind, display_name),
+                )
+                conn.execute(
+                    """INSERT INTO brain_tenants(tenant_id)
+                       VALUES (%s) ON CONFLICT DO NOTHING""",
+                    (tenant_id,),
+                )
+                conn.execute(
+                    """INSERT INTO brain_principals(tenant_id,principal_id)
+                       VALUES (%s,%s) ON CONFLICT DO NOTHING""",
+                    (tenant_id, owner_principal_id),
+                )
+                conn.execute(
+                    """INSERT INTO brain_spaces(
+                           tenant_id,organization_id,brain_kind,slug
+                       ) VALUES (%s,%s,%s,%s)
+                       ON CONFLICT(tenant_id) DO NOTHING""",
+                    (tenant_id, organization_id, brain_kind, slug),
+                )
+                conn.execute(
+                    """INSERT INTO brain_memberships(
+                           organization_id,principal_id,role
+                       ) VALUES (%s,%s,'owner')
+                       ON CONFLICT(organization_id,principal_id)
+                       DO UPDATE SET role='owner'""",
+                    (organization_id, owner_principal_id),
+                )
+                conn.execute(
+                    """INSERT INTO brain_access_grants(
+                           tenant_id,principal_id,permission
+                       ) VALUES (%s,%s,'owner')
+                       ON CONFLICT(tenant_id,principal_id)
+                       DO UPDATE SET permission='owner'""",
+                    (tenant_id, owner_principal_id),
+                )
+                configured = conn.execute(
+                    """SELECT organization.organization_kind,space.brain_kind,
+                              space.organization_id,space.slug
+                       FROM brain_spaces space
+                       JOIN brain_organizations organization
+                         USING(organization_id)
+                       WHERE space.tenant_id=%s""",
+                    (tenant_id,),
+                ).fetchone()
+                if (
+                    configured is None
+                    or configured["organization_id"] != organization_id
+                    or configured["organization_kind"] != organization_kind
+                    or configured["brain_kind"] != brain_kind
+                    or configured["slug"] != slug
+                ):
+                    raise ValueError("brain provisioning conflict")
+        return {
+            "organization_id": organization_id,
+            "organization_kind": organization_kind,
+            "tenant_id": tenant_id,
+            "brain_kind": brain_kind,
+            "slug": slug,
+            "owner_principal_id": owner_principal_id,
+        }
+
+    def grant_canonical_source(
+        self,
+        *,
+        tenant_id: str,
+        principal_id: str,
+        source_id: str,
+        permission: str = "read",
+    ) -> None:
+        if (
+            any(
+                not isinstance(value, str)
+                or not V2_AUTHORITY_RE.fullmatch(value)
+                for value in (tenant_id, principal_id, source_id)
+            )
+            or permission not in {"owner", "read"}
+        ):
+            raise ValueError("invalid canonical source grant")
+        with self.connect() as conn:
+            with conn.transaction():
+                brain_access = conn.execute(
+                    """SELECT 1 FROM brain_access_grants
+                       WHERE tenant_id=%s AND principal_id=%s
+                         AND permission IN ('owner','admin','read')""",
+                    (tenant_id, principal_id),
+                ).fetchone()
+                source = conn.execute(
+                    """SELECT 1 FROM canonical_sources
+                       WHERE tenant_id=%s AND source_id=%s""",
+                    (tenant_id, source_id),
+                ).fetchone()
+                if not brain_access or not source:
+                    raise ValueError("canonical source grant authority missing")
+                conn.execute(
+                    """INSERT INTO canonical_source_grants(
+                           tenant_id,principal_id,source_id,permission
+                       ) VALUES (%s,%s,%s,%s)
+                       ON CONFLICT(tenant_id,principal_id,source_id)
+                       DO UPDATE SET permission=excluded.permission""",
+                    (tenant_id, principal_id, source_id, permission),
+                )
+
+    def create_mcp_token(
+        self,
+        name: str,
+        *,
+        tenant_id: str,
+        principal_id: str,
+        scopes: list[str] | None = None,
+        expires_in_days: int = 30,
+    ) -> dict[str, Any]:
+        scopes = list(scopes or ["read"])
+        if (
+            not isinstance(name, str)
+            or not name
+            or not isinstance(tenant_id, str)
+            or not V2_AUTHORITY_RE.fullmatch(tenant_id)
+            or not isinstance(principal_id, str)
+            or not V2_AUTHORITY_RE.fullmatch(principal_id)
+            or not isinstance(expires_in_days, int)
+            or isinstance(expires_in_days, bool)
+            or not 1 <= expires_in_days <= 365
+            or not scopes
+            or len(scopes) != len(set(scopes))
+            or "read" not in scopes
+            or set(scopes) - {"read", "forget"}
+        ):
+            raise ValueError("invalid MCP credential")
+        plaintext = "rcl_" + secrets.token_urlsafe(32)
+        digest = hashlib.sha256(plaintext.encode()).hexdigest()
+        credential_id = uuid.uuid4()
+        expires_at = datetime.now(timezone.utc) + timedelta(days=expires_in_days)
+        with self.connect() as conn:
+            access = conn.execute(
+                """SELECT 1 FROM brain_access_grants
+                   WHERE tenant_id=%s AND principal_id=%s
+                     AND permission IN ('owner','admin','read')""",
+                (tenant_id, principal_id),
+            ).fetchone()
+            if not access:
+                raise ValueError("MCP brain access missing")
+            conn.execute(
+                """INSERT INTO mcp_credentials(
+                       id,name,token_sha256,tenant_id,principal_id,
+                       audience,scopes,expires_at
+                   ) VALUES (%s,%s,%s,%s,%s,'recall-mcp',%s,%s)""",
+                (
+                    credential_id,
+                    name,
+                    digest,
+                    tenant_id,
+                    principal_id,
+                    scopes,
+                    expires_at,
+                ),
+            )
+        return {
+            "id": str(credential_id),
+            "name": name,
+            "token": plaintext,
+            "tenant_id": tenant_id,
+            "principal_id": principal_id,
+            "audience": "recall-mcp",
+            "scopes": scopes,
+            "expires_at": expires_at.isoformat(),
+        }
+
+    def revoke_mcp_token(self, name: str) -> bool:
+        with self.connect() as conn:
+            row = conn.execute(
+                """UPDATE mcp_credentials SET revoked_at=now()
+                   WHERE name=%s AND revoked_at IS NULL RETURNING id""",
+                (name,),
+            ).fetchone()
+        return bool(row)
+
     def set_source_profile(self, value: SourceProfile | dict[str, Any]) -> dict[str, Any]:
         profile = value if isinstance(value, SourceProfile) else SourceProfile.from_mapping(value)
         with self.connect() as conn:
@@ -372,11 +581,24 @@ class BrainStore:
                    WHERE token_sha256=%s AND revoked_at IS NULL""",
                 (digest,),
             ).fetchone()
-            if not row or required_scope not in row["scopes"]:
+            if row:
+                if required_scope not in row["scopes"]:
+                    return None
+                if required_scope == "webhook" and set(row["scopes"]) != {"webhook"}:
+                    return None
+                return {**row, "credential_kind": "collector", "audience": None}
+            mcp = conn.execute(
+                """SELECT id,name,tenant_id,NULL::text AS source_id,
+                          principal_id,NULL::text AS capture_origin,
+                          NULL::text AS webhook_privacy_mode,scopes,audience
+                   FROM mcp_credentials
+                   WHERE token_sha256=%s AND revoked_at IS NULL
+                     AND expires_at>now() AND audience='recall-mcp'""",
+                (digest,),
+            ).fetchone()
+            if not mcp or required_scope not in mcp["scopes"]:
                 return None
-            if required_scope == "webhook" and set(row["scopes"]) != {"webhook"}:
-                return None
-            return row
+            return {**mcp, "credential_kind": "mcp"}
 
     def authorized_source_ids(self, principal_id: str) -> list[str]:
         if not isinstance(principal_id, str) or not principal_id:
@@ -388,6 +610,36 @@ class BrainStore:
                    WHERE principal_id=%s AND permission IN ('owner','read')
                    ORDER BY source_id""",
                 (principal_id,),
+            ).fetchall()
+        return [row["source_id"] for row in rows]
+
+    def authorized_canonical_source_ids(
+        self,
+        tenant_id: str,
+        principal_id: str,
+    ) -> list[str]:
+        if (
+            not isinstance(tenant_id, str)
+            or not V2_AUTHORITY_RE.fullmatch(tenant_id)
+            or not isinstance(principal_id, str)
+            or not V2_AUTHORITY_RE.fullmatch(principal_id)
+        ):
+            return []
+        with self.connect() as conn:
+            brain_access = conn.execute(
+                """SELECT 1 FROM brain_access_grants
+                   WHERE tenant_id=%s AND principal_id=%s
+                     AND permission IN ('owner','admin','read')""",
+                (tenant_id, principal_id),
+            ).fetchone()
+            if not brain_access:
+                return []
+            rows = conn.execute(
+                """SELECT source_id FROM canonical_source_grants
+                   WHERE tenant_id=%s AND principal_id=%s
+                     AND permission IN ('owner','read')
+                   ORDER BY source_id""",
+                (tenant_id, principal_id),
             ).fetchall()
         return [row["source_id"] for row in rows]
 

--- a/recall/server/recall_server/mcp.py
+++ b/recall/server/recall_server/mcp.py
@@ -107,7 +107,7 @@ READ_TOOLS = (
     {
         "name": "recall_search",
         "description": (
-            "Search the owner's authorized Recall evidence using a natural-language "
+            "Search the authorized Recall brain using a natural-language "
             "question. Results include stable recall:// receipts for follow-up."
         ),
         "inputSchema": {
@@ -242,8 +242,20 @@ def _write_enabled(principal: dict) -> bool:
     )
 
 
+def _canonical_forget_enabled(principal: dict) -> bool:
+    return (
+        principal.get("credential_kind") == "mcp"
+        and principal.get("audience") == "recall-mcp"
+        and "forget" in principal.get("scopes", ())
+    )
+
+
 def _tools_for(principal: dict) -> tuple[dict, ...]:
-    return READ_TOOLS + (WRITE_TOOLS if _write_enabled(principal) else ())
+    if _write_enabled(principal):
+        return READ_TOOLS + WRITE_TOOLS
+    if _canonical_forget_enabled(principal):
+        return READ_TOOLS + (WRITE_TOOLS[1],)
+    return READ_TOOLS
 
 
 def _reject_extra(arguments: dict, allowed: frozenset[str]) -> None:
@@ -336,11 +348,13 @@ def _call_tool(store, principal: dict, name: str, arguments: dict) -> dict:
         )
         return store.capture(principal, arguments)
     if name == "recall_forget":
-        if not _write_enabled(principal):
-            raise McpProtocolError(-32602, "unknown tool")
         _reject_extra(arguments, frozenset({"receipt"}))
         receipt = _string(arguments.get("receipt"), "receipt")
-        return store.forget_capture(principal, receipt)
+        if _canonical_forget_enabled(principal):
+            return store.forget(receipt)
+        if _write_enabled(principal):
+            return store.forget_capture(principal, receipt)
+        raise McpProtocolError(-32602, "unknown tool")
     raise McpProtocolError(-32602, "unknown tool")
 
 
@@ -393,7 +407,7 @@ def dispatch(store, principal: dict, message: Any) -> dict | None:
             "serverInfo": {
                 "name": "recall",
                 "version": "1",
-                "description": "Private, source-scoped personal evidence retrieval.",
+                "description": "Private, tenant- and source-scoped evidence retrieval.",
             },
         }
     elif method == "ping":

--- a/recall/server/schema/028_unified_brain_access.sql
+++ b/recall/server/schema/028_unified_brain_access.sql
@@ -1,0 +1,114 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS brain_organizations (
+    organization_id text PRIMARY KEY,
+    organization_kind text NOT NULL
+        CHECK (organization_kind IN ('personal', 'company')),
+    display_name text NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    CHECK (length(organization_id) BETWEEN 2 AND 256),
+    CHECK (length(display_name) BETWEEN 1 AND 200)
+);
+
+CREATE TABLE IF NOT EXISTS brain_spaces (
+    tenant_id text PRIMARY KEY REFERENCES brain_tenants(tenant_id),
+    organization_id text NOT NULL
+        REFERENCES brain_organizations(organization_id),
+    brain_kind text NOT NULL CHECK (brain_kind IN ('personal', 'company')),
+    slug text NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    UNIQUE(organization_id, slug),
+    CHECK (slug ~ '^[a-z0-9][a-z0-9-]{0,62}$')
+);
+
+CREATE TABLE IF NOT EXISTS brain_memberships (
+    organization_id text NOT NULL
+        REFERENCES brain_organizations(organization_id),
+    principal_id text NOT NULL,
+    role text NOT NULL CHECK (role IN ('owner', 'admin', 'member')),
+    created_at timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY(organization_id, principal_id)
+);
+
+CREATE TABLE IF NOT EXISTS brain_access_grants (
+    tenant_id text NOT NULL REFERENCES brain_spaces(tenant_id),
+    principal_id text NOT NULL,
+    permission text NOT NULL CHECK (permission IN ('owner', 'admin', 'read')),
+    created_at timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY(tenant_id, principal_id),
+    FOREIGN KEY(tenant_id, principal_id)
+        REFERENCES brain_principals(tenant_id, principal_id)
+);
+
+CREATE TABLE IF NOT EXISTS canonical_source_grants (
+    tenant_id text NOT NULL,
+    principal_id text NOT NULL,
+    source_id text NOT NULL,
+    permission text NOT NULL CHECK (permission IN ('owner', 'read')),
+    created_at timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY(tenant_id, principal_id, source_id),
+    FOREIGN KEY(tenant_id, principal_id)
+        REFERENCES brain_principals(tenant_id, principal_id),
+    FOREIGN KEY(tenant_id, source_id)
+        REFERENCES canonical_sources(tenant_id, source_id)
+);
+
+CREATE INDEX IF NOT EXISTS canonical_source_grants_lookup_idx
+    ON canonical_source_grants(tenant_id, principal_id, permission, source_id);
+
+CREATE TABLE IF NOT EXISTS mcp_credentials (
+    id uuid PRIMARY KEY,
+    name text NOT NULL UNIQUE,
+    token_sha256 char(64) NOT NULL UNIQUE,
+    tenant_id text NOT NULL REFERENCES brain_spaces(tenant_id),
+    principal_id text NOT NULL,
+    audience text NOT NULL CHECK (audience = 'recall-mcp'),
+    scopes text[] NOT NULL
+        CHECK (scopes <@ ARRAY['read','forget']::text[] AND scopes @> ARRAY['read']::text[]),
+    expires_at timestamptz NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    revoked_at timestamptz,
+    CHECK (expires_at > created_at),
+    FOREIGN KEY(tenant_id, principal_id)
+        REFERENCES brain_principals(tenant_id, principal_id)
+);
+
+CREATE INDEX IF NOT EXISTS mcp_credentials_active_idx
+    ON mcp_credentials(token_sha256, audience, expires_at)
+    WHERE revoked_at IS NULL;
+
+ALTER TABLE canonical_chunks
+    ADD COLUMN IF NOT EXISTS search_vector tsvector
+    GENERATED ALWAYS AS (to_tsvector('simple', text_redacted)) STORED;
+
+CREATE INDEX IF NOT EXISTS canonical_chunks_search_idx
+    ON canonical_chunks USING gin(search_vector)
+    WHERE deleted_at IS NULL;
+
+CREATE TABLE IF NOT EXISTS canonical_chunk_embeddings (
+    tenant_id text NOT NULL,
+    source_id text NOT NULL,
+    chunk_id text NOT NULL,
+    model text NOT NULL,
+    dimensions smallint NOT NULL CHECK (dimensions = 512),
+    content_sha256 char(64) NOT NULL,
+    runtime_fingerprint text NOT NULL,
+    embedding halfvec(512) NOT NULL,
+    embedded_at timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY(tenant_id, source_id, chunk_id),
+    FOREIGN KEY(tenant_id, source_id, chunk_id)
+        REFERENCES canonical_chunks(tenant_id, source_id, chunk_id)
+        ON DELETE CASCADE,
+    CHECK (content_sha256 ~ '^[0-9a-f]{64}$')
+);
+
+CREATE INDEX IF NOT EXISTS canonical_chunk_embeddings_scope_idx
+    ON canonical_chunk_embeddings(tenant_id, source_id, chunk_id);
+
+CREATE INDEX IF NOT EXISTS canonical_chunk_embeddings_hnsw_idx
+    ON canonical_chunk_embeddings USING hnsw (embedding halfvec_cosine_ops)
+    WITH (m = 16, ef_construction = 64);
+
+INSERT INTO schema_migrations(version) VALUES (28) ON CONFLICT DO NOTHING;
+
+COMMIT;

--- a/recall/server/scripts/backup_restore.sh
+++ b/recall/server/scripts/backup_restore.sh
@@ -38,12 +38,19 @@ FROM (VALUES
   ('source_events','id'),
   ('brain_tenants','tenant_id'),
   ('brain_principals','tenant_id,principal_id'),
+  ('brain_organizations','organization_id'),
+  ('brain_spaces','tenant_id'),
+  ('brain_memberships','organization_id,principal_id'),
+  ('brain_access_grants','tenant_id,principal_id'),
   ('canonical_sources','tenant_id,source_id'),
+  ('canonical_source_grants','tenant_id,principal_id,source_id'),
+  ('mcp_credentials','id'),
   ('raw_artifacts','tenant_id,source_id,artifact_id'),
   ('canonical_ingest_jobs','tenant_id,source_id,job_id'),
   ('canonical_events','tenant_id,source_id,event_id'),
   ('canonical_documents','tenant_id,source_id,document_id'),
   ('canonical_chunks','tenant_id,source_id,chunk_id'),
+  ('canonical_chunk_embeddings','tenant_id,source_id,chunk_id'),
   ('receipt_redirects','tenant_id,old_receipt'),
   ('forget_tombstones','tenant_id,source_id,target_identity_sha256'),
   ('canonical_audit_events','tenant_id,source_id,audit_id')
@@ -61,8 +68,11 @@ import re
 
 approved = {
     "schema_migrations", "source_events", "brain_tenants", "brain_principals",
-    "canonical_sources", "raw_artifacts", "canonical_ingest_jobs",
+    "brain_organizations", "brain_spaces", "brain_memberships",
+    "brain_access_grants", "canonical_sources", "canonical_source_grants",
+    "mcp_credentials", "raw_artifacts", "canonical_ingest_jobs",
     "canonical_events", "canonical_documents", "canonical_chunks",
+    "canonical_chunk_embeddings",
     "receipt_redirects", "forget_tombstones", "canonical_audit_events",
 }
 rows = []

--- a/recall/server/tests/e2e_v2_multitenant_mcp.py
+++ b/recall/server/tests/e2e_v2_multitenant_mcp.py
@@ -1,0 +1,469 @@
+#!/usr/bin/env python3
+"""Fresh-PostgreSQL proof for canonical-only personal/company MCP retrieval."""
+
+from __future__ import annotations
+
+import hashlib
+import http.client
+import json
+import os
+import sys
+import tempfile
+import threading
+import time
+from http.server import ThreadingHTTPServer
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+sys.path[:0] = [str(ROOT / "recall"), str(ROOT / "recall/server")]
+
+from client.mac import canonical_envelope
+from recall_server.app import Handler
+from recall_server.archive import FilesystemArchiveStore
+from recall_server.canonical import CanonicalArchiveGateway, CanonicalPlane
+from recall_server.canonical_retrieval import CanonicalRetrieval
+from recall_server.db import BrainStore
+
+
+OWNER = "principal:owner:e2e"
+OUTSIDER = "principal:outsider:e2e"
+VIEWER = "principal:viewer:e2e"
+PERSONAL = "tenant:personal:e2e"
+COMPANY = "tenant:company:e2e"
+PERSONAL_SOURCE = "source:personal:e2e"
+COMPANY_SOURCE = "source:company:e2e"
+OUTSIDER_SOURCE = "source:company:outsider:e2e"
+OCCURRED = "2026-07-20T07:00:00Z"
+
+
+class FakeSemanticRuntime:
+    dimensions = 512
+    model = "synthetic-embedding-v1"
+    fingerprint = "synthetic-canonical-runtime-v1"
+
+    @staticmethod
+    def _vector(text: str) -> list[float]:
+        vector = [0.0] * 512
+        lowered = text.casefold()
+        vector[0] = 1.0 if "personal" in lowered else 0.01
+        vector[1] = 1.0 if "company" in lowered else 0.01
+        vector[2] = 1.0 if "outsider" in lowered else 0.01
+        return vector
+
+    def embed_documents(self, texts: list[str]) -> list[list[float]]:
+        return [self._vector(text) for text in texts]
+
+    def embed_query(self, query: str) -> list[float]:
+        return self._vector(query)
+
+
+def rpc(server: ThreadingHTTPServer, token: str, name: str, arguments: dict) -> dict:
+    body = json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {"name": name, "arguments": arguments},
+        }
+    ).encode()
+    connection = http.client.HTTPConnection(
+        "127.0.0.1", server.server_port, timeout=10
+    )
+    connection.request(
+        "POST",
+        "/mcp",
+        body=body,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/json, text/event-stream",
+            "Content-Type": "application/json",
+            "Content-Length": str(len(body)),
+            "MCP-Protocol-Version": "2025-11-25",
+        },
+    )
+    response = connection.getresponse()
+    payload = json.loads(response.read())
+    connection.close()
+    assert response.status == 200, payload
+    return payload
+
+
+def ingest(
+    store: BrainStore,
+    archive: FilesystemArchiveStore,
+    *,
+    tenant_id: str,
+    principal_id: str,
+    source_id: str,
+    native_id: str,
+    text: str,
+    tombstone: bool = False,
+) -> str:
+    raw = json.dumps(
+        {"text": text, "deleted": tombstone},
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode()
+    reference = CanonicalArchiveGateway(
+        store,
+        archive,
+        tenant_id=tenant_id,
+        principal_id=principal_id,
+    ).put_raw(
+        tenant_id=tenant_id,
+        source_id=source_id,
+        native_id=native_id,
+        payload=raw,
+        media_type="application/json",
+        created_at=OCCURRED,
+    )
+    content = {"target_native_id": native_id} if tombstone else {"text": text}
+    event = canonical_envelope(
+        source_id=source_id,
+        native_id=native_id,
+        kind="tombstone" if tombstone else "connector_record",
+        content=content,
+        principal_id=principal_id,
+        visibility="private",
+        occurred_at=OCCURRED,
+        provenance={
+            "uri": f"connector://synthetic/{hashlib.sha256(source_id.encode()).hexdigest()[:8]}",
+            "cwd": "/synthetic/unified-brain",
+            "branch": "test/multitenant-mcp",
+            "connector_id": "synthetic.v2",
+            "artifact_ref": reference,
+        },
+    )
+    result = CanonicalPlane(store, archive).ingest_batch(
+        tenant_id=tenant_id,
+        principal_id=principal_id,
+        events=[event],
+    )
+    assert result["inserted"] == 1
+    return result["receipts"][0]
+
+
+def main() -> None:
+    store = BrainStore(
+        os.environ["RECALL_DATABASE_URL"],
+        semantic_runtime=FakeSemanticRuntime(),
+    )
+    store.migrate()
+    tables = (
+        "mcp_credentials,canonical_chunk_embeddings,canonical_source_grants,"
+        "brain_access_grants,brain_memberships,brain_spaces,brain_organizations,"
+        "forget_tombstones,receipt_redirects,canonical_audit_events,"
+        "canonical_chunks,canonical_documents,canonical_events,"
+        "canonical_ingest_jobs,raw_artifacts,canonical_sources,"
+        "brain_principals,brain_tenants,collector_credentials"
+    )
+    with store.connect() as connection:
+        connection.execute(f"TRUNCATE {tables} RESTART IDENTITY CASCADE")
+    store.provision_brain(
+        organization_id="org:personal:e2e",
+        organization_kind="personal",
+        display_name="Synthetic Personal",
+        tenant_id=PERSONAL,
+        brain_kind="personal",
+        slug="personal",
+        owner_principal_id=OWNER,
+    )
+    store.provision_brain(
+        organization_id="org:company:e2e",
+        organization_kind="company",
+        display_name="Synthetic Company",
+        tenant_id=COMPANY,
+        brain_kind="company",
+        slug="company",
+        owner_principal_id=OWNER,
+    )
+    with tempfile.TemporaryDirectory() as temporary:
+        archive = FilesystemArchiveStore(
+            Path(temporary) / "archive",
+            namespace_key=b"m" * 32,
+        )
+        personal_receipt = ingest(
+            store,
+            archive,
+            tenant_id=PERSONAL,
+            principal_id=OWNER,
+            source_id=PERSONAL_SOURCE,
+            native_id="native:personal:e2e",
+            text="shared launch marker personal semantic decision",
+        )
+        company_receipt = ingest(
+            store,
+            archive,
+            tenant_id=COMPANY,
+            principal_id=OWNER,
+            source_id=COMPANY_SOURCE,
+            native_id="native:company:e2e",
+            text="shared launch marker company semantic roadmap",
+        )
+        ingest(
+            store,
+            archive,
+            tenant_id=COMPANY,
+            principal_id=OUTSIDER,
+            source_id=OUTSIDER_SOURCE,
+            native_id="native:outsider:e2e",
+            text="shared launch marker outsider confidential plan",
+        )
+        forget_receipt = ingest(
+            store,
+            archive,
+            tenant_id=PERSONAL,
+            principal_id=OWNER,
+            source_id=PERSONAL_SOURCE,
+            native_id="native:personal:forgettable:e2e",
+            text="synthetic forgettable personal note",
+        )
+        with store.connect() as connection:
+            connection.execute(
+                """INSERT INTO brain_principals(tenant_id,principal_id)
+                   VALUES (%s,%s) ON CONFLICT DO NOTHING""",
+                (COMPANY, VIEWER),
+            )
+            connection.execute(
+                """INSERT INTO brain_access_grants(
+                       tenant_id,principal_id,permission
+                   ) VALUES (%s,%s,'read')""",
+                (COMPANY, VIEWER),
+            )
+        personal_token = store.create_mcp_token(
+            "personal-mcp-e2e",
+            tenant_id=PERSONAL,
+            principal_id=OWNER,
+            scopes=["read", "forget"],
+        )
+        company_token = store.create_mcp_token(
+            "company-mcp-e2e",
+            tenant_id=COMPANY,
+            principal_id=OWNER,
+        )
+        empty_token = store.create_mcp_token(
+            "empty-company-mcp-e2e",
+            tenant_id=COMPANY,
+            principal_id=VIEWER,
+        )
+        retrieval = CanonicalRetrieval(store, archive)
+        embedding = retrieval.embed_pending()
+        assert embedding["processed"] == 4
+
+        def legacy_read_forbidden(*_args, **_kwargs):
+            raise AssertionError("legacy retrieval was called")
+
+        store.search = legacy_read_forbidden
+        store.show = legacy_read_forbidden
+        store.related = legacy_read_forbidden
+        previous = {
+            name: os.environ.get(name)
+            for name in (
+                "RECALL_AUTH_REQUIRED",
+                "RECALL_HTTP_PROFILE",
+                "RECALL_TRUST_TAILSCALE_HEADERS",
+                "RECALL_CANONICAL_V2_ENABLED",
+                "RECALL_CANONICAL_MCP_ENABLED",
+            )
+        }
+        os.environ.update(
+            {
+                "RECALL_AUTH_REQUIRED": "1",
+                "RECALL_HTTP_PROFILE": "public-mcp",
+                "RECALL_TRUST_TAILSCALE_HEADERS": "0",
+                "RECALL_CANONICAL_V2_ENABLED": "1",
+                "RECALL_CANONICAL_MCP_ENABLED": "1",
+            }
+        )
+        Handler.store = store
+        Handler.archive_store = archive
+        Handler.canonical_plane = CanonicalPlane(store, archive)
+        Handler.canonical_retrieval = retrieval
+        server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            personal = rpc(
+                server,
+                personal_token["token"],
+                "recall_search",
+                {"query": "shared launch marker"},
+            )
+            personal_results = personal["result"]["structuredContent"]["results"]
+            assert {row["source_id"] for row in personal_results} == {PERSONAL_SOURCE}
+            assert COMPANY_SOURCE not in json.dumps(personal)
+            assert OUTSIDER_SOURCE not in json.dumps(personal)
+
+            company = rpc(
+                server,
+                company_token["token"],
+                "recall_search",
+                {"query": "shared launch marker"},
+            )
+            company_results = company["result"]["structuredContent"]["results"]
+            assert {row["source_id"] for row in company_results} == {COMPANY_SOURCE}
+            assert PERSONAL_SOURCE not in json.dumps(company)
+            assert OUTSIDER_SOURCE not in json.dumps(company)
+
+            semantic = rpc(
+                server,
+                personal_token["token"],
+                "recall_search",
+                {"query": "personal semantic"},
+            )["result"]["structuredContent"]
+            assert semantic["results"][0]["receipt"] == personal_receipt
+            assert semantic["diagnostics"]["semantic_candidates"] >= 1
+
+            shown = rpc(
+                server,
+                company_token["token"],
+                "recall_show",
+                {"target": company_receipt},
+            )
+            assert (
+                shown["result"]["structuredContent"]["event"]["source_id"]
+                == COMPANY_SOURCE
+            )
+            denied_show = rpc(
+                server,
+                personal_token["token"],
+                "recall_show",
+                {"target": company_receipt},
+            )
+            assert denied_show["error"]["message"] == "receipt not found"
+
+            related = rpc(
+                server,
+                company_token["token"],
+                "recall_related",
+                {
+                    "cwd": "/synthetic/unified-brain",
+                    "branch": "test/multitenant-mcp",
+                },
+            )
+            assert {
+                row["source_id"]
+                for row in related["result"]["structuredContent"]["results"]
+            } == {COMPANY_SOURCE}
+
+            empty = rpc(
+                server,
+                empty_token["token"],
+                "recall_search",
+                {"query": "shared launch marker"},
+            )
+            assert empty["result"]["structuredContent"]["results"] == []
+
+            eval_cases = (
+                (personal_token["token"], "shared launch marker", personal_receipt),
+                (
+                    personal_token["token"],
+                    "personal semantic decision",
+                    personal_receipt,
+                ),
+                (company_token["token"], "shared launch marker", company_receipt),
+                (
+                    company_token["token"],
+                    "company semantic roadmap",
+                    company_receipt,
+                ),
+            ) * 3
+            latencies = []
+            recalled = useful = 0
+            for token, query, expected in eval_cases:
+                started = time.perf_counter()
+                evaluated = rpc(
+                    server,
+                    token,
+                    "recall_search",
+                    {"query": query, "limit": 5},
+                )["result"]["structuredContent"]["results"]
+                latencies.append((time.perf_counter() - started) * 1000)
+                receipts = [row["receipt"] for row in evaluated]
+                recalled += expected in receipts
+                useful += bool(receipts and receipts[0] == expected)
+            recall_at_5 = recalled / len(eval_cases)
+            usefulness = useful / len(eval_cases)
+            p95_ms = sorted(latencies)[
+                max(0, int(0.95 * len(latencies) + 0.999999) - 1)
+            ]
+            assert recall_at_5 >= 0.91
+            assert usefulness >= 0.80
+            assert p95_ms < 8000
+
+            forgotten = rpc(
+                server,
+                personal_token["token"],
+                "recall_forget",
+                {"receipt": forget_receipt},
+            )["result"]["structuredContent"]
+            assert forgotten["raw_deleted"] == 1
+            forgotten_show = rpc(
+                server,
+                personal_token["token"],
+                "recall_show",
+                {"target": forget_receipt},
+            )
+            assert forgotten_show["error"]["message"] == "receipt not found"
+
+            ingest(
+                store,
+                archive,
+                tenant_id=PERSONAL,
+                principal_id=OWNER,
+                source_id=PERSONAL_SOURCE,
+                native_id="native:personal:e2e",
+                text="",
+                tombstone=True,
+            )
+            deleted = rpc(
+                server,
+                personal_token["token"],
+                "recall_search",
+                {"query": "shared launch marker"},
+            )
+            assert deleted["result"]["structuredContent"]["results"] == []
+            deleted_show = rpc(
+                server,
+                personal_token["token"],
+                "recall_show",
+                {"target": personal_receipt},
+            )
+            assert deleted_show["error"]["message"] == "receipt not found"
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=5)
+            for name, value in previous.items():
+                if value is None:
+                    os.environ.pop(name, None)
+                else:
+                    os.environ[name] = value
+    store.close()
+    print(
+        json.dumps(
+            {
+                "status": "pass",
+                "brains": 2,
+                "cross_tenant_hits": 0,
+                "cross_principal_hits": 0,
+                "empty_grant_hits": 0,
+                "legacy_reads": 0,
+                "lexical_candidates": 2,
+                "semantic_candidates": semantic["diagnostics"][
+                    "semantic_candidates"
+                ],
+                "tombstoned_search_hits": 0,
+                "tombstoned_show_hits": 0,
+                "forgotten_show_hits": 0,
+                "recall_at_5": recall_at_5,
+                "usefulness": usefulness,
+                "p95_ms": round(p95_ms, 3),
+            },
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Advances #139 and closes Loop A of #157.

Adds organization/brain provisioning, audience-bound expiring MCP credentials, tenant/source grants, canonical lexical/vector/temporal retrieval, exact show/related, owner-scoped canonical forget, continuous embedding convergence, schema/capability/backup coverage, and canonical-only MCP routing.

Hard-gate evidence (synthetic/content-free):
- adversarial two-brain E2E: zero cross-tenant, cross-principal, and empty-grant hits
- zero legacy search/show/related calls in canonical MCP profile
- Recall@5 1.00, usefulness 1.00, local p95 under 8 seconds
- tombstone and forget hide both search and exact show
- 584 Python tests + 3 Node tests
- staged gitleaks clean; changed-code Ruff clean; no high-severity Bandit findings

No transcripts, credentials, private traces, or cascade evidence are included.