### PR TITLE
fix(recall): bind Mac routes to canonical tenants

### DIFF
--- a/recall/client/README.md
+++ b/recall/client/README.md
@@ -78,6 +78,9 @@ content, or exception:
 ```bash
 recall-brain mac-status
 recall-brain mac-pause --source cowork
+recall-brain mac-route-info --source cowork
+recall-brain mac-route-apply --source cowork \
+  --tenant-id tenant:personal --principal-id principal:owner
 recall-brain mac-resume --source cowork
 recall-brain mac-disable --source cowork
 recall-brain mac-support
@@ -93,6 +96,10 @@ not claim to delete—evidence already committed to the central Brain; central
 deletion requires an authenticated server-side receipt/source operation.
 `mac-support` reports only closed health and package-integrity aggregates: no
 paths, credentials, content, cursors, or exception text.
+`mac-route-apply` is normally driven by the native switchboard after the server
+creates a source-scoped route. It atomically retains the LaunchAgent while
+binding that collector to the canonical tenant writer; the next resume writes
+raw objects through the configured archive and ACKs only after canonical ingest.
 
 The bundle also carries a SwiftUI owner utility. Build it on an Apple Silicon
 Mac with Xcode 16 or newer:
@@ -105,8 +112,9 @@ open "macos_admin/dist/Recall Brain.app"
 The Mac switchboard uses the same `/admin/api/v1` contract as the web UI. It
 stores the owner key and source credentials only in Keychain. Pausing retains
 the exact LaunchAgent and checkpoint. Changing a destination atomically revokes
-the prior device route, installs a new write-only source credential, and sends
-subsequent ingestion to the chosen personal or company brain.
+the prior device route, installs a new write-only source credential, binds the
+retained LaunchAgent to that canonical tenant/principal, and sends subsequent
+ingestion to the chosen personal or company brain.
 
 Only already configured collectors are actionable. Selecting source paths,
 granting Full Disk Access, and importing archives remain explicit install-time

--- a/recall/client/cli.py
+++ b/recall/client/cli.py
@@ -24,6 +24,7 @@ from client.mcp import McpServer, serve as serve_mcp
 from client.macos_utility import (
     SOURCE_SPECS,
     MacUtilityError,
+    apply_route,
     disable_source,
     mac_status,
     pause_source,
@@ -463,6 +464,15 @@ def parser() -> argparse.ArgumentParser:
     mac_route.add_argument(
         "--launch-agents", default=str(Path.home() / "Library" / "LaunchAgents")
     )
+    mac_route_apply = commands.add_parser("mac-route-apply")
+    mac_route_apply.add_argument(
+        "--source", choices=tuple(SOURCE_SPECS), required=True
+    )
+    mac_route_apply.add_argument("--tenant-id", required=True)
+    mac_route_apply.add_argument("--principal-id", required=True)
+    mac_route_apply.add_argument(
+        "--launch-agents", default=str(Path.home() / "Library" / "LaunchAgents")
+    )
 
     mac_revoke = commands.add_parser("mac-revoke")
     mac_revoke.add_argument("--source", choices=tuple(SOURCE_SPECS), required=True)
@@ -608,6 +618,18 @@ def main() -> None:
         try:
             result = route_info(
                 args.source, launch_agents=Path(args.launch_agents)
+            )
+        except MacUtilityError as error:
+            raise SystemExit(str(error)) from None
+        print(json.dumps(result, sort_keys=True))
+        return
+    if args.command == "mac-route-apply":
+        try:
+            result = apply_route(
+                args.source,
+                launch_agents=Path(args.launch_agents),
+                tenant_id=args.tenant_id,
+                principal_id=args.principal_id,
             )
         except MacUtilityError as error:
             raise SystemExit(str(error)) from None

--- a/recall/client/macos_admin/RecallBrainAdmin.swift
+++ b/recall/client/macos_admin/RecallBrainAdmin.swift
@@ -26,7 +26,12 @@ struct ProviderState: Codable, Identifiable {
     let status: String
 }
 
+struct Principal: Codable {
+    let id: String
+}
+
 struct ControlState: Codable {
+    let principal: Principal
     let brains: [Brain]
     let providers: [ProviderState]
     let installations: [Installation]
@@ -66,6 +71,10 @@ struct TransitionResponse: Codable {
 
 struct LifecycleResponse: Codable {
     let enabled: Bool
+}
+
+struct RouteApplyResponse: Codable {
+    let canonical_v2: Bool
 }
 
 enum AdminFailure: LocalizedError {
@@ -206,15 +215,20 @@ final class RecallAdminModel: ObservableObject {
             $0.device_id == deviceID && $0.connector_id == source.connector_id
                 && !["revoked", "uninstalled"].contains($0.state)
         })
+        let route: RouteInfo = try await runRecall([
+            "mac-route-info", "--source", name,
+        ])
+        if source.enabled {
+            let _: LifecycleResponse = try await runRecall([
+                "mac-pause", "--source", name,
+            ])
+        }
         if active?.tenant_id == tenant && active?.state == "paused" {
             try await transition(active!.id, action: "resume")
         } else if active?.tenant_id == tenant && active?.state == "enabled"
                     && source.enabled {
-            return
+            // Restart below so retained LaunchAgent authority changes take effect.
         } else if active?.tenant_id != tenant || active == nil {
-            let route: RouteInfo = try await runRecall([
-                "mac-route-info", "--source", name,
-            ])
             let payload: [String: Any] = [
                 "connector_id": route.connector_id,
                 "tenant_id": tenant,
@@ -237,11 +251,16 @@ final class RecallAdminModel: ObservableObject {
                 service: route.keychain_service,
                 account: route.keychain_account
             )
-            if source.enabled {
-                let _: LifecycleResponse = try await runRecall([
-                    "mac-pause", "--source", name,
-                ])
-            }
+        }
+        guard let principal = control?.principal.id else {
+            throw AdminFailure.closed("brain_principal_missing")
+        }
+        let applied: RouteApplyResponse = try await runRecall([
+            "mac-route-apply", "--source", name,
+            "--tenant-id", tenant, "--principal-id", principal,
+        ])
+        guard applied.canonical_v2 else {
+            throw AdminFailure.closed("canonical_route_apply_failed")
         }
         let _: LifecycleResponse = try await runRecall([
             "mac-resume", "--source", name,
@@ -533,7 +552,7 @@ enum RecallBrainAdminMain {
     static func main() {
         if CommandLine.arguments == [CommandLine.arguments[0], "--self-test"] {
             let controlJSON = """
-            {"brains":[
+            {"principal":{"id":"principal:synthetic"},"brains":[
               {"tenant_id":"tenant:personal:synthetic","slug":"personal","brain_kind":"personal","display_name":"Personal","permission":"owner"},
               {"tenant_id":"tenant:company:synthetic","slug":"company","brain_kind":"company","display_name":"Company","permission":"owner"}
             ],"providers":[],"installations":[]}

--- a/recall/client/macos_utility.py
+++ b/recall/client/macos_utility.py
@@ -7,9 +7,11 @@ import json
 import os
 import math
 import plistlib
+import re
 import sqlite3
 import stat
 import subprocess
+import tempfile
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -75,6 +77,9 @@ SOURCE_SPECS = {
 
 class MacUtilityError(ValueError):
     """A closed error that never includes a local path or private database value."""
+
+
+ROUTE_IDENTITY = re.compile(r"[A-Za-z0-9][A-Za-z0-9:._/@+-]{1,255}\Z")
 
 
 def _regular(path: Path) -> bool:
@@ -347,6 +352,90 @@ def route_info(name: str, *, launch_agents: Path) -> dict[str, Any]:
         "keychain_service": _option(arguments, "--keychain-service"),
         "keychain_account": _option(arguments, "--keychain-account"),
         "privacy_mode": _option(arguments, "--privacy-mode"),
+    }
+
+
+def apply_route(
+    name: str,
+    *,
+    launch_agents: Path,
+    tenant_id: str,
+    principal_id: str,
+) -> dict[str, Any]:
+    """Atomically bind one retained LaunchAgent to the canonical tenant writer."""
+
+    if (
+        name not in SOURCE_SPECS
+        or not isinstance(tenant_id, str)
+        or not ROUTE_IDENTITY.fullmatch(tenant_id)
+        or not isinstance(principal_id, str)
+        or not ROUTE_IDENTITY.fullmatch(principal_id)
+    ):
+        raise MacUtilityError("canonical_route_invalid")
+    path = Path(launch_agents) / f"{SOURCE_SPECS[name].label}.plist"
+    arguments = _plist_arguments(path)
+    _option(arguments, "--source-id")
+    try:
+        principal_index = arguments.index("--principal-id") + 1
+        if principal_index >= len(arguments):
+            raise ValueError
+    except ValueError:
+        raise MacUtilityError("canonical_route_apply_failed") from None
+    try:
+        parent = path.parent
+        parent_details = parent.lstat()
+        if stat.S_ISLNK(parent_details.st_mode) or not stat.S_ISDIR(
+            parent_details.st_mode
+        ):
+            raise OSError
+        with path.open("rb") as source:
+            value = plistlib.load(source)
+        environment = value.get("EnvironmentVariables")
+        if (
+            not isinstance(value, dict)
+            or not isinstance(environment, dict)
+            or len(environment) > 64
+            or not all(
+                isinstance(key, str) and isinstance(item, str)
+                for key, item in environment.items()
+            )
+        ):
+            raise ValueError
+        environment = dict(environment)
+        environment.update(
+            {
+                "RECALL_CANONICAL_V2_ENABLED": "1",
+                "RECALL_TENANT_ID": tenant_id,
+                "RECALL_PRINCIPAL_ID": principal_id,
+            }
+        )
+        arguments = list(arguments)
+        arguments[principal_index] = principal_id
+        value["ProgramArguments"] = arguments
+        value["EnvironmentVariables"] = environment
+        descriptor, temporary_name = tempfile.mkstemp(
+            prefix=".recall-route-", suffix=".plist", dir=parent
+        )
+        temporary = Path(temporary_name)
+        try:
+            os.fchmod(descriptor, 0o600)
+            with os.fdopen(descriptor, "wb") as output:
+                plistlib.dump(value, output, sort_keys=True)
+                output.flush()
+                os.fsync(output.fileno())
+            os.replace(temporary, path)
+        finally:
+            temporary.unlink(missing_ok=True)
+    except MacUtilityError:
+        raise
+    except (OSError, ValueError, plistlib.InvalidFileException):
+        raise MacUtilityError("canonical_route_apply_failed") from None
+    return {
+        "schema_version": 1,
+        "mode": "mac-route-apply",
+        "source": name,
+        "canonical_v2": True,
+        "configuration_retained": True,
     }
 
 

--- a/recall/server/tests/e2e_macos_connector_registry_c8e.py
+++ b/recall/server/tests/e2e_macos_connector_registry_c8e.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import plistlib
 import shutil
 import sqlite3
 import subprocess
@@ -27,6 +28,8 @@ def main() -> None:
     prefix = args.workspace / "installed"
     launch_agents = args.workspace / "launch-agents"
     spool = args.workspace / "synthetic-registry-state.db"
+    source_root = args.workspace / "synthetic-codex-root"
+    source_root.mkdir(parents=True)
     wrapper = prefix / "bin" / "recall-brain"
     installed = False
     result = None
@@ -38,7 +41,7 @@ def main() -> None:
             "--host-id", "synthetic-c8e-live-host",
             "--keychain-service", "synthetic.c8e.reference",
             "--visibility", "private", "--privacy-mode", "drop",
-            "--disable-export-inbox", "--no-load",
+            "--sources", "codex", "--codex-root", str(source_root), "--no-load",
         ], check=True, text=True, capture_output=True)
         installed = True
         assert install.stderr == "" and wrapper.is_file()
@@ -47,6 +50,25 @@ def main() -> None:
         assert len(preview["connectors"]) == 32
         for field in ("credential_reads", "source_reads", "network_requests", "writes"):
             assert preview[field] == 0
+        routed = run_json([
+            str(wrapper), "mac-route-apply", "--source", "codex",
+            "--tenant-id", "tenant:personal:synthetic",
+            "--principal-id", "principal:owner:synthetic",
+            "--launch-agents", str(launch_agents),
+        ])
+        assert routed["canonical_v2"] is True
+        with (
+            launch_agents / "ai.parcha.recall.codex.plist"
+        ).open("rb") as source:
+            configured = plistlib.load(source)
+        environment = configured["EnvironmentVariables"]
+        arguments = configured["ProgramArguments"]
+        assert arguments[arguments.index("--principal-id") + 1] == (
+            "principal:owner:synthetic"
+        )
+        assert environment["RECALL_CANONICAL_V2_ENABLED"] == "1"
+        assert environment["RECALL_TENANT_ID"] == "tenant:personal:synthetic"
+        assert environment["RECALL_PRINCIPAL_ID"] == "principal:owner:synthetic"
 
         connection = sqlite3.connect(spool)
         connection.executescript("""
@@ -96,6 +118,7 @@ def main() -> None:
                 "preview_network_requests": 0,
                 "preview_writes": 0,
                 "status_state_mutations": 0,
+                "canonical_route_bindings": 1,
                 "private_cursor_rendered": False,
                 "health_states_proved": 4,
             },

--- a/recall/tests/test_macos_utility.py
+++ b/recall/tests/test_macos_utility.py
@@ -11,6 +11,8 @@ from unittest import mock
 from client.cli import parser
 from client.macos_utility import (
     SOURCE_SPECS,
+    MacUtilityError,
+    apply_route,
     disable_source,
     mac_status,
     pause_source,
@@ -156,13 +158,17 @@ class MacUtilityLifecycleTest(unittest.TestCase):
         spec = SOURCE_SPECS["codex"]
         path = self.agents / f"{spec.label}.plist"
         with path.open("wb") as output:
-            plistlib.dump({"ProgramArguments": [
-                "runtime", "-m", "client.cli", "collect",
-                "--source-id", "codex:mac:synthetic",
-                "--keychain-service", "ai.parcha.recall",
-                "--keychain-account", "codex:mac:synthetic",
-                "--privacy-mode", "scrub",
-            ]}, output)
+            plistlib.dump({
+                "ProgramArguments": [
+                    "runtime", "-m", "client.cli", "collect",
+                    "--source-id", "codex:mac:synthetic",
+                    "--principal-id", "owner",
+                    "--keychain-service", "ai.parcha.recall",
+                    "--keychain-account", "codex:mac:synthetic",
+                    "--privacy-mode", "scrub",
+                ],
+                "EnvironmentVariables": {},
+            }, output)
         original = path.read_bytes()
 
         paused = pause_source(
@@ -189,12 +195,55 @@ class MacUtilityLifecycleTest(unittest.TestCase):
             "keychain_account": "codex:mac:synthetic",
             "privacy_mode": "scrub",
         })
+        applied = apply_route(
+            "codex",
+            launch_agents=self.agents,
+            tenant_id="tenant:personal",
+            principal_id="principal:owner",
+        )
+        self.assertTrue(applied["canonical_v2"])
+        configured = plistlib.loads(path.read_bytes())
+        expected_arguments = plistlib.loads(original)["ProgramArguments"]
+        expected_arguments[
+            expected_arguments.index("--principal-id") + 1
+        ] = "principal:owner"
+        self.assertEqual(configured["ProgramArguments"], expected_arguments)
+        self.assertEqual(
+            configured["EnvironmentVariables"],
+            {
+                "RECALL_CANONICAL_V2_ENABLED": "1",
+                "RECALL_TENANT_ID": "tenant:personal",
+                "RECALL_PRINCIPAL_ID": "principal:owner",
+            },
+        )
+        self.assertEqual(path.stat().st_mode & 0o777, 0o600)
+        routed = path.read_bytes()
         resumed = resume_source(
             "codex", prefix=self.prefix, launch_agents=self.agents, no_load=True,
         )
         self.assertTrue(resumed["enabled"])
         self.assertFalse(marker.exists())
-        self.assertEqual(path.read_bytes(), original)
+        self.assertEqual(path.read_bytes(), routed)
+
+    def test_route_apply_rejects_invalid_authority_and_symlink(self) -> None:
+        self._enable("codex")
+        with self.assertRaisesRegex(MacUtilityError, "canonical_route_invalid"):
+            apply_route(
+                "codex",
+                launch_agents=self.agents,
+                tenant_id="../personal",
+                principal_id="principal:owner",
+            )
+        path = self.agents / f"{SOURCE_SPECS['codex'].label}.plist"
+        path.unlink()
+        path.symlink_to(self.home / "outside.plist")
+        with self.assertRaisesRegex(MacUtilityError, "invalid_launch_agent"):
+            apply_route(
+                "codex",
+                launch_agents=self.agents,
+                tenant_id="tenant:personal",
+                principal_id="principal:owner",
+            )
 
     def test_revoke_disables_source_deletes_only_its_keychain_reference(self) -> None:
         self._enable("cowork")


### PR DESCRIPTION
## Outcome
- atomically binds each routed Mac LaunchAgent to canonical v2 tenant and principal authority
- restarts native-switchboard routes so the new authority takes effect
- preserves source paths, Keychain references, privacy mode, and checkpoints
- adds an exact Darwin/arm64 package gate for canonical route binding

## Verification
- 595 Python tests and 3 Node tests pass
- Mac lifecycle and package unit suites pass
- exact packaged Apple Silicon install, route bind, preview, status, and uninstall pass with zero residue
- native Swift app compiles, signs, and passes its binary self-test
- Ruff, diff checks, and staged gitleaks pass

## Live finding addressed
The production cutover proved device credentials were valid but the retained LaunchAgents still selected the legacy writer. This patch makes the selected personal/company destination drive the canonical R2-backed writer explicitly. No private records were committed during the failed attempt.