### PR TITLE
feat(recall): run managed connectors from unified control plane

### DIFF
--- a/.github/workflows/recall-ci.yml
+++ b/.github/workflows/recall-ci.yml
@@ -76,6 +76,7 @@ jobs:
             e2e_public_mcp_principal.py \
             e2e_webhook_ingest.py \
             e2e_remote_worker.py \
+            e2e_managed_connector_worker.py \
             e2e_workspace_rail.py \
             e2e_retrieval_eval.py
           do

--- a/recall/.dockerignore
+++ b/recall/.dockerignore
@@ -18,3 +18,10 @@ spikes/
 README.md
 package.json
 package-lock.json
+!client/
+!client/**
+!collector/
+!collector/**
+!scripts/
+scripts/*
+!scripts/install_gws.py

--- a/recall/Dockerfile
+++ b/recall/Dockerfile
@@ -9,17 +9,26 @@ WORKDIR /opt/recall
 COPY server/requirements.txt /opt/recall/requirements.txt
 RUN python -m pip install --no-cache-dir --disable-pip-version-check --no-compile -r requirements.txt \
     && groupadd --gid 10001 recall \
-    && useradd --uid 10001 --gid 10001 --no-create-home --shell /usr/sbin/nologin recall
+    && useradd --uid 10001 --gid 10001 --no-create-home --shell /usr/sbin/nologin recall \
+    && install -d -m 0700 -o 10001 -g 10001 /var/lib/recall
 
 COPY --chown=10001:10001 server/recall_server /opt/recall/recall_server
 COPY --chown=10001:10001 server/schema /opt/recall/schema
 COPY --chown=10001:10001 contracts /opt/contracts
 COPY --chown=10001:10001 connectors /opt/connectors
+COPY --chown=10001:10001 client /opt/recall/client
+COPY --chown=10001:10001 collector /opt/recall/collector
 COPY --chown=10001:10001 privacy /opt/recall/privacy
+COPY --chown=10001:10001 scripts/install_gws.py /opt/recall/scripts/install_gws.py
 COPY --chown=10001:10001 skills/recall/scripts/recall.py /opt/skills/recall/scripts/recall.py
+
+RUN python /opt/recall/scripts/install_gws.py \
+      --target x86_64-unknown-linux-gnu \
+      --prefix /opt/recall/vendor/gws/0.22.5
 
 USER 10001:10001
 EXPOSE 8788
+VOLUME ["/var/lib/recall"]
 
 HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
     CMD ["python", "-c", "import http.client; connection=http.client.HTTPConnection('127.0.0.1',8788,timeout=2); connection.request('GET','/readyz'); response=connection.getresponse(); raise SystemExit(0 if response.status==200 else 1)"]

--- a/recall/collector/collector.py
+++ b/recall/collector/collector.py
@@ -8,6 +8,7 @@ import sqlite3
 import time
 import urllib.error
 import urllib.request
+from concurrent.futures import Future, ThreadPoolExecutor
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -77,7 +78,8 @@ class Collector:
                  endpoint: str, token: str, principal_id: str = "owner",
                  visibility: str = "private", batch_size: int = 500,
                  privacy: PrivacyPolicy | None = None, brain_writer: Any = None,
-                 archive: Any = None, tenant_id: str | None = None):
+                 archive: Any = None, tenant_id: str | None = None,
+                 archive_workers: int = 8):
         if harness not in {"claude", "codex"}:
             raise ValueError("harness must be claude or codex")
         if visibility not in {"private", "shared"}:
@@ -86,6 +88,11 @@ class Collector:
             archive is not None and not tenant_id
         ):
             raise ValueError("canonical collector runtime is incomplete")
+        if (
+            type(archive_workers) is not int
+            or not 1 <= archive_workers <= 16
+        ):
+            raise ValueError("archive_workers must be between 1 and 16")
         self.root = Path(root).expanduser().resolve()
         self.harness = harness
         self.source_id = source_id
@@ -99,6 +106,7 @@ class Collector:
         self.brain_writer = brain_writer
         self.archive = archive
         self.tenant_id = tenant_id
+        self.archive_workers = archive_workers
         self.shard_count = 1
         self.shard_index = 0
         self.spool_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
@@ -276,114 +284,188 @@ class Collector:
         summary = {"files_seen": 0, "records_queued": 0, "tombstones_queued": 0,
                    "parse_errors": 0, "partial_files": 0}
         privacy_receipts = []
-        for path in self.discover():
-            summary["files_seen"] += 1
-            stat = path.stat()
-            path_text = str(path)
-            row = self.db.execute("SELECT * FROM files WHERE path=?", (path_text,)).fetchone()
-            current_fingerprint = fingerprint(path, stat.st_size)
-            if row and not row["status"].startswith("scanning-") and row["size"] == stat.st_size and row["mtime_ns"] == stat.st_mtime_ns and row["fingerprint"] == current_fingerprint:
-                self.db.execute("UPDATE files SET last_scan_id=? WHERE path=?", (scan_id, path_text))
-                continue
-            resume_mode = row["status"].removeprefix("scanning-") if row and row["status"].startswith("scanning-") else None
-            if resume_mode:
-                mode = resume_mode
-                file_scan_id = row["last_scan_id"]
-            else:
-                mode = "append" if row and stat.st_size > row["size"] and fingerprint(path, row["size"]) == row["fingerprint"] else ("full" if row else "new")
-                file_scan_id = scan_id
-                if mode != "append":
-                    self.db.execute("DELETE FROM scan_members WHERE path=?", (path_text,))
-            append = mode == "append"
-            start_offset = int(row["scanned_offset"]) if append or resume_mode else 0
-            old_active = {item["native_id"]: item for item in self.db.execute("SELECT * FROM active_records WHERE path=?", (path_text,))}
-            seen_native: set[str] = set(old_active) if append else {item["native_id"] for item in self.db.execute("SELECT native_id FROM scan_members WHERE path=?", (path_text,))}
-            complete_end = start_offset
-            complete_records = 0
-            with path.open("rb") as source:
-                source.seek(start_offset)
-                while True:
-                    line_start = source.tell()
-                    line = source.readline()
-                    if not line:
-                        break
-                    if not line.endswith(b"\n"):
-                        summary["partial_files"] += 1
-                        break
-                    complete_end = source.tell()
-                    complete_records += 1
-                    native_id = f"{self._file_key(path)}-{line_start:016x}"
-                    try:
-                        content = json.loads(line)
-                        if not isinstance(content, dict):
-                            raise ValueError("record is not an object")
-                    except (json.JSONDecodeError, UnicodeDecodeError, ValueError) as exc:
-                        summary["parse_errors"] += 1
-                        self.db.execute(
-                            "INSERT OR IGNORE INTO dead_letters(path,byte_offset,error_code,error_summary,created_at) VALUES (?,?,?,?,?)",
-                            (path_text, line_start, type(exc).__name__, "record rejected", time.time()),
-                        )
-                        continue
-                    occurred_at = normalized_timestamp(content.get("timestamp"), stat.st_mtime)
-                    privacy = self.privacy.apply(content)
-                    privacy_receipts.append(privacy.receipt())
-                    if privacy.action == "drop":
-                        seen_native.add(native_id)
-                        if not append:
-                            self.db.execute("INSERT OR IGNORE INTO scan_members(path,native_id) VALUES (?,?)", (path_text, native_id))
-                        continue
-                    content = privacy.value
-                    artifact_ref = self._archive_raw(
-                        native_id=native_id,
-                        payload=line,
-                        occurred_at=occurred_at,
+        executor = (
+            ThreadPoolExecutor(max_workers=self.archive_workers)
+            if self.archive is not None and self.archive_workers > 1
+            else None
+        )
+        try:
+            for path in self.discover():
+                summary["files_seen"] += 1
+                stat = path.stat()
+                path_text = str(path)
+                row = self.db.execute("SELECT * FROM files WHERE path=?", (path_text,)).fetchone()
+                current_fingerprint = fingerprint(path, stat.st_size)
+                if row and not row["status"].startswith("scanning-") and row["size"] == stat.st_size and row["mtime_ns"] == stat.st_mtime_ns and row["fingerprint"] == current_fingerprint:
+                    self.db.execute("UPDATE files SET last_scan_id=? WHERE path=?", (scan_id, path_text))
+                    continue
+                resume_mode = row["status"].removeprefix("scanning-") if row and row["status"].startswith("scanning-") else None
+                if resume_mode:
+                    mode = resume_mode
+                    file_scan_id = row["last_scan_id"]
+                else:
+                    mode = "append" if row and stat.st_size > row["size"] and fingerprint(path, row["size"]) == row["fingerprint"] else ("full" if row else "new")
+                    file_scan_id = scan_id
+                    if mode != "append":
+                        self.db.execute("DELETE FROM scan_members WHERE path=?", (path_text,))
+                append = mode == "append"
+                start_offset = int(row["scanned_offset"]) if append or resume_mode else 0
+                old_active = {item["native_id"]: item for item in self.db.execute("SELECT * FROM active_records WHERE path=?", (path_text,))}
+                seen_native: set[str] = set(old_active) if append else {item["native_id"] for item in self.db.execute("SELECT native_id FROM scan_members WHERE path=?", (path_text,))}
+                complete_end = start_offset
+                complete_records = 0
+                pending: list[tuple[
+                    str, dict[str, Any], str, int, int,
+                    Future[dict[str, Any] | None] | None,
+                    dict[str, Any] | None,
+                ]] = []
+
+                def commit_pending() -> None:
+                    (
+                        native_id,
+                        content,
+                        occurred_at,
+                        line_start,
+                        line_end,
+                        future,
+                        artifact_ref,
+                    ) = pending.pop(0)
+                    if future is not None:
+                        artifact_ref = future.result()
+                    versioned_content = self._versioned_record_content(
+                        native_id,
+                        content,
+                        was_active=native_id in old_active,
                     )
-                    versioned_content = self._versioned_record_content(native_id, content, was_active=native_id in old_active)
                     envelope = self._envelope(
-                        path, native_id, "transcript_record", versioned_content,
-                        occurred_at, line_start, complete_end, artifact_ref,
+                        path,
+                        native_id,
+                        "transcript_record",
+                        versioned_content,
+                        occurred_at,
+                        line_start,
+                        line_end,
+                        artifact_ref,
                     )
-                    if self._queue(path, envelope, complete_end):
+                    if self._queue(path, envelope, line_end):
                         summary["records_queued"] += 1
                     self.db.execute(
                         "INSERT INTO active_records(path,native_id,content_sha256,start_offset,end_offset) VALUES (?,?,?,?,?) "
                         "ON CONFLICT(path,native_id) DO UPDATE SET content_sha256=excluded.content_sha256,start_offset=excluded.start_offset,end_offset=excluded.end_offset",
-                        (path_text, native_id, envelope["content_sha256"], line_start, complete_end),
+                        (
+                            path_text,
+                            native_id,
+                            envelope["content_sha256"],
+                            line_start,
+                            line_end,
+                        ),
                     )
                     seen_native.add(native_id)
                     if not append:
-                        self.db.execute("INSERT OR IGNORE INTO scan_members(path,native_id) VALUES (?,?)", (path_text, native_id))
-                    if complete_records % 1000 == 0:
-                        self._save_file_progress(path_text, stat, current_fingerprint, complete_end, "scanning-" + mode, file_scan_id)
-                        self.db.commit()
-            if not append:
-                for native_id, old in old_active.items():
-                    if native_id in seen_native:
-                        continue
-                    content = {"target_native_id": native_id, "deletion_id": scan_id}
-                    occurred_at = iso_now()
-                    artifact_ref = self._archive_raw(
-                        native_id=native_id,
-                        payload=canonical_json({
-                            "deleted": True,
-                            "native_id": native_id,
-                        }),
-                        occurred_at=occurred_at,
-                    )
-                    envelope = self._envelope(
-                        path, native_id, "tombstone", content, occurred_at,
-                        old["start_offset"], old["end_offset"], artifact_ref,
-                    )
-                    if self._queue(path, envelope, complete_end):
-                        summary["tombstones_queued"] += 1
-                    self.db.execute("DELETE FROM active_records WHERE path=? AND native_id=?", (path_text, native_id))
-            status = "partial" if complete_end < stat.st_size else "ok"
-            self._save_file_progress(path_text, stat, current_fingerprint, complete_end, status, scan_id)
-            if not self.db.execute("SELECT 1 FROM outbox WHERE path=? AND state='pending' LIMIT 1", (path_text,)).fetchone():
-                self.db.execute("UPDATE files SET committed_offset=scanned_offset WHERE path=?", (path_text,))
-            self.db.execute("DELETE FROM scan_members WHERE path=?", (path_text,))
-            # Bound crash recovery to one source file; acknowledged offsets still move only in flush().
-            self.db.commit()
+                        self.db.execute(
+                            "INSERT OR IGNORE INTO scan_members(path,native_id) VALUES (?,?)",
+                            (path_text, native_id),
+                        )
+
+                with path.open("rb") as source:
+                    source.seek(start_offset)
+                    while True:
+                        line_start = source.tell()
+                        line = source.readline()
+                        if not line:
+                            break
+                        if not line.endswith(b"\n"):
+                            summary["partial_files"] += 1
+                            break
+                        complete_end = source.tell()
+                        complete_records += 1
+                        native_id = f"{self._file_key(path)}-{line_start:016x}"
+                        try:
+                            content = json.loads(line)
+                            if not isinstance(content, dict):
+                                raise ValueError("record is not an object")
+                        except (json.JSONDecodeError, UnicodeDecodeError, ValueError) as exc:
+                            summary["parse_errors"] += 1
+                            self.db.execute(
+                                "INSERT OR IGNORE INTO dead_letters(path,byte_offset,error_code,error_summary,created_at) VALUES (?,?,?,?,?)",
+                                (path_text, line_start, type(exc).__name__, "record rejected", time.time()),
+                            )
+                            continue
+                        occurred_at = normalized_timestamp(content.get("timestamp"), stat.st_mtime)
+                        privacy = self.privacy.apply(content)
+                        privacy_receipts.append(privacy.receipt())
+                        if privacy.action == "drop":
+                            seen_native.add(native_id)
+                            if not append:
+                                self.db.execute("INSERT OR IGNORE INTO scan_members(path,native_id) VALUES (?,?)", (path_text, native_id))
+                            continue
+                        content = privacy.value
+                        if executor is None:
+                            future = None
+                            artifact_ref = self._archive_raw(
+                                native_id=native_id,
+                                payload=line,
+                                occurred_at=occurred_at,
+                            )
+                        else:
+                            future = executor.submit(
+                                self._archive_raw,
+                                native_id=native_id,
+                                payload=line,
+                                occurred_at=occurred_at,
+                            )
+                            artifact_ref = None
+                        pending.append(
+                            (
+                                native_id,
+                                content,
+                                occurred_at,
+                                line_start,
+                                complete_end,
+                                future,
+                                artifact_ref,
+                            )
+                        )
+                        if len(pending) >= self.archive_workers * 2:
+                            commit_pending()
+                        if complete_records % 1000 == 0:
+                            while pending:
+                                commit_pending()
+                            self._save_file_progress(path_text, stat, current_fingerprint, complete_end, "scanning-" + mode, file_scan_id)
+                            self.db.commit()
+                while pending:
+                    commit_pending()
+                if not append:
+                    for native_id, old in old_active.items():
+                        if native_id in seen_native:
+                            continue
+                        content = {"target_native_id": native_id, "deletion_id": scan_id}
+                        occurred_at = iso_now()
+                        artifact_ref = self._archive_raw(
+                            native_id=native_id,
+                            payload=canonical_json({
+                                "deleted": True,
+                                "native_id": native_id,
+                            }),
+                            occurred_at=occurred_at,
+                        )
+                        envelope = self._envelope(
+                            path, native_id, "tombstone", content, occurred_at,
+                            old["start_offset"], old["end_offset"], artifact_ref,
+                        )
+                        if self._queue(path, envelope, complete_end):
+                            summary["tombstones_queued"] += 1
+                        self.db.execute("DELETE FROM active_records WHERE path=? AND native_id=?", (path_text, native_id))
+                status = "partial" if complete_end < stat.st_size else "ok"
+                self._save_file_progress(path_text, stat, current_fingerprint, complete_end, status, scan_id)
+                if not self.db.execute("SELECT 1 FROM outbox WHERE path=? AND state='pending' LIMIT 1", (path_text,)).fetchone():
+                    self.db.execute("UPDATE files SET committed_offset=scanned_offset WHERE path=?", (path_text,))
+                self.db.execute("DELETE FROM scan_members WHERE path=?", (path_text,))
+                # Bound crash recovery to one source file; acknowledged offsets still move only in flush().
+                self.db.commit()
+        finally:
+            if executor is not None:
+                executor.shutdown(wait=True, cancel_futures=True)
         missing = list(self.db.execute("SELECT path FROM files WHERE last_scan_id != ? AND status != 'tombstone'", (scan_id,)))
         for item in missing:
             for old in self.db.execute("SELECT * FROM active_records WHERE path=?", (item["path"],)):

--- a/recall/connectors/sdk.py
+++ b/recall/connectors/sdk.py
@@ -685,7 +685,7 @@ class ConnectorRunner:
         return {
             "privacy": privacy, "staged": len(events), "dropped": dropped,
             "deduplicated": deduplicated, "archived": archived,
-            "forgotten": forgotten,
+            "forgotten": forgotten, "has_more": page.has_more,
         }
 
     def _commit_page(self, page_id: int, cursor: str | None) -> None:
@@ -741,9 +741,16 @@ class ConnectorRunner:
     def run_once(self) -> dict[str, Any]:
         if not self.enabled:
             return {"status": "disabled", "error_code": "connector_disabled"}
-        if self.db.execute("SELECT 1 FROM pages LIMIT 1").fetchone():
+        pending = self.db.execute(
+            "SELECT has_more FROM pages ORDER BY id LIMIT 1"
+        ).fetchone()
+        if pending:
             flushed = self.flush()
-            return {"status": "committed", **flushed}
+            return {
+                "status": "committed",
+                "has_more": bool(pending["has_more"]),
+                **flushed,
+            }
         cursor = self._cursor()
         try:
             page = self.connector.pull(cursor)

--- a/recall/server/deploy/README.md
+++ b/recall/server/deploy/README.md
@@ -63,7 +63,7 @@ infrastructure. The example is synthetic; a live manifest belongs in a private m
 location and contains references, never credential values.
 
 The production database gate requires a standard PostgreSQL URL with
-`sslmode=verify-full` and an explicit trust root, schema migrations 1 through 30,
+`sslmode=verify-full` and an explicit trust root, schema migrations 1 through 31,
 pgvector 0.8.0 or newer, and a runtime role without superuser, database/role creation,
 replication, or RLS-bypass privilege:
 
@@ -211,7 +211,7 @@ grant on the exact source.
 
 ## Unified connector administration
 
-Schemas 029–030 add one tenant-aware connector control plane for the web
+Schemas 029–031 add one tenant-aware connector control plane for the web
 switchboard and native utilities. A connector installation is always bound to one principal,
 one destination brain, and one opaque source ID. Connecting the same provider to
 personal and company memory creates separate installations; it never implies a
@@ -266,6 +266,25 @@ Native clients use the same versioned `/admin/api/v1` session, state, OAuth, and
 lifecycle contract. They must store the bootstrap or browser-session authority
 in the operating-system credential store and must not copy provider tokens out
 of Recall.
+
+Run one or more managed workers from the same immutable Recall Core image:
+
+```bash
+python -m recall_server.cli managed-worker \
+  --state-root /var/lib/recall --interval-seconds 60
+```
+
+The worker claims only due, enabled `remote_worker` installations with a
+database lease. It decrypts one provider capability in memory, materializes any
+short-lived CLI authority beneath an owner-private worker directory, archives
+raw records before projection, commits through the tenant-scoped canonical
+plane, advances the connector cursor only after acknowledgement, and updates
+the same installation row shown in the web UI. Pause, revoke, tenant selection,
+and provider disconnect therefore affect execution without a second config
+surface. Mount `/var/lib/recall` on persistent encrypted storage so ACK-gated
+spools survive image restarts. Every worker replica must receive the same
+database, R2, embedding, and control-encryption settings as the API service; it
+does not listen on a network port.
 
 `RECALL_DATABASE_URL` must be a PlanetScale application role URL with
 `sslmode=verify-full` and an explicit trust root. Prefer

--- a/recall/server/recall_server/__init__.py
+++ b/recall/server/recall_server/__init__.py
@@ -1,4 +1,4 @@
 """Recall central BrainStore service."""
 
-SCHEMA_VERSION = 30
+SCHEMA_VERSION = 31
 PROJECTOR_VERSION = 3

--- a/recall/server/recall_server/cli.py
+++ b/recall/server/recall_server/cli.py
@@ -27,6 +27,7 @@ from .managed_apply import (
     load_approvals,
     reconcile_infrastructure,
 )
+from .managed_worker import run_managed_worker
 from .mcp_conformance import (
     ConformanceError,
     McpConformanceConfig,
@@ -143,6 +144,18 @@ def main() -> None:
     create_admin_token.add_argument("--output", required=True)
     revoke_admin_token = sub.add_parser("admin-token-revoke")
     revoke_admin_token.add_argument("name")
+    managed_worker = sub.add_parser("managed-worker")
+    managed_worker.add_argument(
+        "--state-root",
+        type=Path,
+        default=Path("/var/lib/recall"),
+    )
+    managed_worker.add_argument("--once", action="store_true")
+    managed_worker.add_argument(
+        "--interval-seconds",
+        type=int,
+        default=60,
+    )
     source_profile = sub.add_parser("source-profile-set")
     source_profile.add_argument("source_id")
     source_profile.add_argument(
@@ -284,6 +297,18 @@ def main() -> None:
         print(json.dumps({"status": "ok", "schema_version": SCHEMA_VERSION}))
     elif args.command == "rebuild":
         print(json.dumps(store.rebuild(), sort_keys=True))
+    elif args.command == "managed-worker":
+        print(
+            json.dumps(
+                run_managed_worker(
+                    store,
+                    state_root=args.state_root,
+                    once=args.once,
+                    interval_seconds=args.interval_seconds,
+                ),
+                sort_keys=True,
+            )
+        )
     elif args.command == "backfill-entities":
         print(
             json.dumps(

--- a/recall/server/recall_server/control.py
+++ b/recall/server/recall_server/control.py
@@ -356,6 +356,10 @@ class GoogleOAuthProvider:
         ):
             raise ControlError("google_oauth_scope_invalid", 502)
         credentials = {
+            "type": "authorized_user",
+            "client_id": self.client_id,
+            "client_secret": self.client_secret,
+            "token_uri": self.token_endpoint,
             "access_token": access_token,
             "refresh_token": refresh_token,
             "token_type": token.get("token_type", "Bearer"),
@@ -569,6 +573,9 @@ class ControlPlane:
                           installation.privacy_mode,installation.selectors,
                           installation.revision,installation.last_error_code,
                           installation.last_success_at,
+                          installation.last_started_at,
+                          installation.run_after,
+                          installation.failure_count,
                           connection.provider,connection.status AS connection_status
                    FROM connector_installations installation
                    LEFT JOIN provider_connections connection

--- a/recall/server/recall_server/managed_worker.py
+++ b/recall/server/recall_server/managed_worker.py
@@ -1,0 +1,481 @@
+"""Database-driven remote connector execution for the unified control plane."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import stat
+import tempfile
+import time
+from typing import Any, Callable, Mapping
+
+from connectors.host import (
+    HOSTED_FACTORIES,
+    RemoteOptions,
+)
+from connectors.registry import (
+    ConnectorDefinitionV3,
+    RUNTIME_ERROR_CODES,
+    definition,
+)
+from connectors.sdk import (
+    ConnectorContractError,
+    ConnectorRunner,
+)
+from privacy.policy import PrivacyPolicy
+
+from .archive_runtime import build_archive_store
+from .canonical import CanonicalArchiveGateway, CanonicalPlane
+from .canonical_retrieval import CanonicalRetrieval
+from .control import ControlError, SecretBox
+from .db import BrainStore
+
+
+SAFE_WORKER = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.:-]{2,127}\Z")
+DEFAULT_INTERVAL_SECONDS = 60
+DEFAULT_LEASE_SECONDS = 300
+MAX_CREDENTIAL_BYTES = 64_000
+
+
+def _worker_identity(value: str | None = None) -> str:
+    candidate = value or (
+        f"worker:{os.uname().nodename}:{os.getpid()}"
+    )
+    if SAFE_WORKER.fullmatch(candidate):
+        return candidate
+    return "worker:" + hashlib.sha256(candidate.encode()).hexdigest()[:24]
+
+
+def _private_root(path: Path) -> Path:
+    path = Path(path)
+    path.mkdir(parents=True, exist_ok=True, mode=0o700)
+    metadata = path.lstat()
+    if (
+        stat.S_ISLNK(metadata.st_mode)
+        or not stat.S_ISDIR(metadata.st_mode)
+        or stat.S_IMODE(metadata.st_mode) != 0o700
+    ):
+        raise ValueError("managed worker state root is not private")
+    return path
+
+
+def _selector_defaults(connector_id: str) -> dict[str, Any]:
+    return {
+        "google.gmail": {
+            "include_spam_trash": False,
+            "label_ids": [],
+            "own_addresses": [],
+            "query": None,
+        },
+        "google.calendar": {
+            "calendar_id": "primary",
+            "time_max": None,
+            "time_min": None,
+        },
+        "google.contacts": {},
+        "google.drive": {
+            "drive_id": None,
+            "include_document_text": False,
+            "mime_types": [],
+        },
+        "github.activity": {"owner": "", "repository": ""},
+        "linear.activity": {"team_id": ""},
+        "slack.messages": {"channel_id": ""},
+        "notion.workspace": {},
+        "x.activity": {"streams": ["authored"], "user_id": ""},
+    }.get(connector_id, {})
+
+
+def _selectors(connector_id: str, selected: Mapping[str, Any]) -> dict[str, Any]:
+    values = _selector_defaults(connector_id)
+    values.update(dict(selected))
+    return values
+
+
+class _DirectCanonicalWriter:
+    def __init__(
+        self,
+        plane: CanonicalPlane,
+        *,
+        tenant_id: str,
+        principal_id: str,
+    ):
+        self.plane = plane
+        self.tenant_id = tenant_id
+        self.principal_id = principal_id
+
+    def ingest(self, events: list[dict[str, Any]]) -> dict[str, Any]:
+        return self.plane.ingest_batch(
+            tenant_id=self.tenant_id,
+            principal_id=self.principal_id,
+            events=events,
+        )
+
+
+class ManagedConnectorWorker:
+    """Claim enabled installations and execute one ACK-gated page per lease."""
+
+    def __init__(
+        self,
+        store: BrainStore,
+        archive: Any,
+        secret_box: SecretBox,
+        *,
+        state_root: Path,
+        worker_id: str | None = None,
+        connector_factory: Callable[
+            [dict[str, Any], dict[str, Any], Path], tuple[Any, Path]
+        ]
+        | None = None,
+        remote_rails: Mapping[str, Any] | None = None,
+        interval_seconds: int = DEFAULT_INTERVAL_SECONDS,
+        lease_seconds: int = DEFAULT_LEASE_SECONDS,
+    ):
+        if (
+            type(interval_seconds) is not int
+            or not 1 <= interval_seconds <= 3600
+            or type(lease_seconds) is not int
+            or not 30 <= lease_seconds <= 3600
+        ):
+            raise ValueError("managed worker timing is invalid")
+        self.store = store
+        self.archive = archive
+        self.secret_box = secret_box
+        self.state_root = _private_root(state_root)
+        self.spool_root = _private_root(self.state_root / "spools")
+        self.authority_root = _private_root(self.state_root / "authorities")
+        self.worker_id = _worker_identity(worker_id)
+        self.connector_factory = connector_factory
+        self.remote_rails = dict(remote_rails or {})
+        self.interval_seconds = interval_seconds
+        self.lease_seconds = lease_seconds
+        self.plane = CanonicalPlane(store, archive)
+        self.retrieval = CanonicalRetrieval(store, archive)
+
+    def _claim(self) -> dict[str, Any] | None:
+        with self.store.connect() as connection:
+            with connection.transaction():
+                row = connection.execute(
+                    """SELECT installation.id,installation.tenant_id,
+                              installation.principal_id,
+                              installation.connector_id,
+                              installation.source_id,
+                              installation.connection_id,
+                              installation.privacy_mode,
+                              installation.selectors,
+                              connection.provider,
+                              connection.status AS connection_status,
+                              connection.encrypted_credentials,
+                              connection.encryption_key_id
+                       FROM connector_installations installation
+                       LEFT JOIN provider_connections connection
+                         ON connection.id=installation.connection_id
+                       WHERE installation.execution='remote_worker'
+                         AND installation.state='enabled'
+                         AND installation.run_after<=now()
+                         AND (
+                           installation.lease_expires_at IS NULL
+                           OR installation.lease_expires_at<=now()
+                         )
+                       ORDER BY installation.run_after,installation.id
+                       FOR UPDATE OF installation SKIP LOCKED
+                       LIMIT 1"""
+                ).fetchone()
+                if row is None:
+                    return None
+                connection.execute(
+                    """UPDATE connector_installations
+                       SET lease_owner=%s,
+                           lease_expires_at=now()+(%s * interval '1 second'),
+                           last_started_at=now(),updated_at=now()
+                       WHERE id=%s""",
+                    (self.worker_id, self.lease_seconds, row["id"]),
+                )
+        return dict(row)
+
+    def _credentials(self, row: dict[str, Any]) -> dict[str, Any]:
+        if (
+            row.get("connection_id") is None
+            or row.get("connection_status") != "connected"
+            or row.get("encrypted_credentials") is None
+            or row.get("encryption_key_id") != self.secret_box.key_id
+        ):
+            raise ControlError("connector_authority_revoked")
+        return self.secret_box.open(
+            bytes(row["encrypted_credentials"]),
+            purpose=f"provider-connection:{row['connection_id']}",
+        )
+
+    def _credential_payload(
+        self,
+        connector_id: str,
+        credentials: dict[str, Any],
+    ) -> bytes:
+        if connector_id.startswith("google."):
+            required = {
+                "client_id",
+                "client_secret",
+                "refresh_token",
+                "token_uri",
+                "type",
+            }
+            if not required.issubset(credentials):
+                raise ControlError("connector_authority_revoked")
+            payload = json.dumps(
+                credentials,
+                sort_keys=True,
+                separators=(",", ":"),
+                allow_nan=False,
+            ).encode()
+        else:
+            token = credentials.get("access_token") or credentials.get("token")
+            if not isinstance(token, str) or not token:
+                raise ControlError("connector_authority_revoked")
+            payload = token.encode()
+        if not payload or len(payload) > MAX_CREDENTIAL_BYTES:
+            raise ControlError("connector_authority_revoked")
+        return payload
+
+    def _build_default(
+        self,
+        row: dict[str, Any],
+        credentials: dict[str, Any],
+        private_directory: Path,
+    ) -> tuple[Any, Path]:
+        connector_id = row["connector_id"]
+        connector_definition = definition(connector_id)
+        if (
+            not isinstance(connector_definition, ConnectorDefinitionV3)
+            or connector_definition.execution_placement != "remote_worker"
+        ):
+            raise ControlError("connector_schema_drift")
+        authority_path = private_directory / "source-authority"
+        descriptor = os.open(
+            authority_path,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+            0o600,
+        )
+        try:
+            payload = self._credential_payload(connector_id, credentials)
+            os.write(descriptor, payload)
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+        options = RemoteOptions.from_mapping(
+            connector_id,
+            {
+                "source_authority": {
+                    "kind": "file",
+                    "path": str(authority_path),
+                },
+                "spool": str(self.spool_root / f"{row['id']}.db"),
+                "page_size": 25 if connector_id == "x.activity" else 100,
+                "timeout_seconds": 60,
+                "selectors": _selectors(
+                    connector_id,
+                    row.get("selectors") or {},
+                ),
+            },
+        )
+        factory = HOSTED_FACTORIES[connector_id]
+        connector, spool = factory.build(
+            options,
+            row["source_id"],
+            row["privacy_mode"],
+            self.remote_rails,
+        )
+        return connector, spool
+
+    @staticmethod
+    def _safe_error(error: Exception) -> str:
+        code = getattr(error, "error_code", None) or getattr(error, "code", None)
+        if code in RUNTIME_ERROR_CODES:
+            return code
+        if isinstance(error, ConnectorContractError):
+            return "connector_invalid_page"
+        return "connector_unavailable"
+
+    def _finish(
+        self,
+        installation_id: Any,
+        *,
+        success: bool,
+        error_code: str | None = None,
+        retry_after_seconds: int | None = None,
+    ) -> None:
+        delay = (
+            max(1, min(3600, retry_after_seconds))
+            if retry_after_seconds is not None
+            else self.interval_seconds
+        )
+        with self.store.connect() as connection:
+            if success:
+                connection.execute(
+                    """UPDATE connector_installations
+                       SET lease_owner=NULL,lease_expires_at=NULL,
+                           run_after=now()+(%s * interval '1 second'),
+                           last_success_at=now(),last_error_code=NULL,
+                           failure_count=0,updated_at=now()
+                       WHERE id=%s AND lease_owner=%s""",
+                    (delay, installation_id, self.worker_id),
+                )
+            else:
+                connection.execute(
+                    """UPDATE connector_installations
+                       SET lease_owner=NULL,lease_expires_at=NULL,
+                           run_after=now()+(%s * interval '1 second'),
+                           last_error_code=%s,failure_count=failure_count+1,
+                           updated_at=now()
+                       WHERE id=%s AND lease_owner=%s""",
+                    (delay, error_code, installation_id, self.worker_id),
+                )
+
+    def run_once(self) -> dict[str, Any]:
+        row = self._claim()
+        if row is None:
+            return {
+                "schema_version": 1,
+                "status": "idle",
+                "processed": 0,
+                "committed": 0,
+                "failed": 0,
+            }
+        connector = None
+        runner = None
+        try:
+            credentials = self._credentials(row)
+            with tempfile.TemporaryDirectory(
+                prefix="authority-",
+                dir=self.authority_root,
+            ) as directory:
+                private_directory = Path(directory)
+                os.chmod(private_directory, 0o700)
+                builder = self.connector_factory or self._build_default
+                connector, spool = builder(
+                    row,
+                    credentials,
+                    private_directory,
+                )
+                runner = ConnectorRunner(
+                    connector=connector,
+                    brain=_DirectCanonicalWriter(
+                        self.plane,
+                        tenant_id=row["tenant_id"],
+                        principal_id=row["principal_id"],
+                    ),
+                    archive=CanonicalArchiveGateway(
+                        self.store,
+                        self.archive,
+                        tenant_id=row["tenant_id"],
+                        principal_id=row["principal_id"],
+                    ),
+                    tenant_id=row["tenant_id"],
+                    principal_id=row["principal_id"],
+                    spool_path=spool,
+                    privacy=PrivacyPolicy(mode=row["privacy_mode"]),
+                )
+                result = runner.run_once()
+            if result.get("status") == "backoff":
+                code = result.get("error_code", "connector_rate_limited")
+                self._finish(
+                    row["id"],
+                    success=False,
+                    error_code=code,
+                    retry_after_seconds=result.get("retry_after_seconds"),
+                )
+                return {
+                    "schema_version": 1,
+                    "status": "backoff",
+                    "processed": 1,
+                    "committed": 0,
+                    "failed": 1,
+                    "error_code": code,
+                }
+            embedding = self.retrieval.embed_pending(
+                tenant_id=row["tenant_id"],
+                batch_size=100,
+                max_batches=1,
+            )
+            has_more = bool(result.get("has_more", False))
+            self._finish(
+                row["id"],
+                success=True,
+                retry_after_seconds=1 if has_more else None,
+            )
+            return {
+                "schema_version": 1,
+                "status": "committed",
+                "processed": 1,
+                "committed": 1,
+                "failed": 0,
+                "acked": int(result.get("acked", 0)),
+                "staged": int(result.get("staged", 0)),
+                "embedded": int(embedding.get("processed", 0)),
+                "has_more": has_more,
+            }
+        except Exception as error:
+            code = self._safe_error(error)
+            self._finish(
+                row["id"],
+                success=False,
+                error_code=code,
+                retry_after_seconds=min(
+                    3600,
+                    self.interval_seconds * 2,
+                ),
+            )
+            return {
+                "schema_version": 1,
+                "status": "failed",
+                "processed": 1,
+                "committed": 0,
+                "failed": 1,
+                "error_code": code,
+            }
+        finally:
+            if runner is not None:
+                runner.close()
+            if connector is not None:
+                close = getattr(connector, "close", None)
+                if callable(close):
+                    close()
+
+
+def run_managed_worker(
+    store: BrainStore,
+    *,
+    state_root: Path,
+    once: bool,
+    interval_seconds: int,
+) -> dict[str, Any]:
+    worker = ManagedConnectorWorker(
+        store,
+        build_archive_store(),
+        SecretBox.from_env(),
+        state_root=state_root,
+        interval_seconds=interval_seconds,
+    )
+    cycles = committed = failed = 0
+    while True:
+        result = worker.run_once()
+        cycles += 1
+        committed += int(result["committed"])
+        failed += int(result["failed"])
+        if once:
+            return {
+                "schema_version": 1,
+                "status": result["status"],
+                "cycles": cycles,
+                "committed": committed,
+                "failed": failed,
+            }
+        time.sleep(1 if result["processed"] else min(interval_seconds, 30))
+
+
+__all__ = [
+    "ManagedConnectorWorker",
+    "run_managed_worker",
+]

--- a/recall/server/recall_server/static/admin.js
+++ b/recall/server/recall_server/static/admin.js
@@ -132,10 +132,17 @@ function renderInstallations() {
     const revoke = item.state === "revoked"
       ? ""
       : `<button data-action="revoke" data-id="${item.id}">revoke</button>`;
+    const runtime = item.last_error_code
+      ? `attention · ${item.last_error_code}`
+      : item.last_success_at
+        ? "synced"
+        : item.execution === "remote_worker" && item.state === "enabled"
+          ? "waiting for first sync"
+          : item.state;
     row.innerHTML = `
       <strong>${escapeText(item.connector_id)}</strong>
       <span>${escapeText(brains.get(item.tenant_id) || item.tenant_id)}</span>
-      <span class="state">${escapeText(item.state)}</span>
+      <span class="state">${escapeText(runtime)}</span>
       <div class="installation-actions">
         <button data-action="${action}" data-id="${item.id}">${action}</button>
         ${revoke}

--- a/recall/server/schema/031_managed_connector_worker.sql
+++ b/recall/server/schema/031_managed_connector_worker.sql
@@ -1,0 +1,31 @@
+BEGIN;
+
+ALTER TABLE connector_installations
+    ADD COLUMN IF NOT EXISTS run_after timestamptz NOT NULL DEFAULT now(),
+    ADD COLUMN IF NOT EXISTS lease_owner text,
+    ADD COLUMN IF NOT EXISTS lease_expires_at timestamptz,
+    ADD COLUMN IF NOT EXISTS last_started_at timestamptz,
+    ADD COLUMN IF NOT EXISTS failure_count integer NOT NULL DEFAULT 0;
+
+ALTER TABLE connector_installations
+    DROP CONSTRAINT IF EXISTS connector_installations_worker_lease_check;
+
+ALTER TABLE connector_installations
+    ADD CONSTRAINT connector_installations_worker_lease_check CHECK (
+        failure_count >= 0
+        AND (
+            (lease_owner IS NULL AND lease_expires_at IS NULL)
+            OR (
+                lease_owner ~ '^[A-Za-z0-9][A-Za-z0-9_.:-]{2,127}$'
+                AND lease_expires_at IS NOT NULL
+            )
+        )
+    );
+
+CREATE INDEX IF NOT EXISTS connector_installations_worker_due_idx
+    ON connector_installations(run_after, lease_expires_at, id)
+    WHERE execution = 'remote_worker' AND state = 'enabled';
+
+INSERT INTO schema_migrations(version) VALUES (31) ON CONFLICT DO NOTHING;
+
+COMMIT;

--- a/recall/server/tests/e2e_managed_connector_worker.py
+++ b/recall/server/tests/e2e_managed_connector_worker.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+"""Fresh-PostgreSQL E2E for web-controlled managed remote ingestion."""
+
+from __future__ import annotations
+
+import base64
+from datetime import datetime, timedelta, timezone
+import json
+import os
+from pathlib import Path
+import sys
+import tempfile
+import uuid
+
+
+ROOT = Path(__file__).resolve().parents[3]
+sys.path[:0] = [str(ROOT / "recall"), str(ROOT / "recall/server")]
+
+from recall_server.archive import FilesystemArchiveStore
+from recall_server.control import SecretBox
+from recall_server.db import BrainStore
+from recall_server.managed_worker import ManagedConnectorWorker
+
+
+OWNER = "principal:owner:managed-worker-e2e"
+PERSONAL = "tenant:personal:managed-worker-e2e"
+COMPANY = "tenant:company:managed-worker-e2e"
+COMPANY_SOURCE = "google-gmail:company:managed-worker-e2e"
+PERSONAL_SOURCE = "google-gmail:personal:managed-worker-e2e"
+SECRET = "synthetic-managed-worker-refresh-secret"
+
+
+class FakeSemanticRuntime:
+    dimensions = 512
+    model = "synthetic-managed-worker-embedding"
+    fingerprint = "synthetic-managed-worker-runtime"
+
+    def embed_documents(self, texts):
+        return [[1.0] + [0.0] * 511 for _text in texts]
+
+    def embed_query(self, _query):
+        return [1.0] + [0.0] * 511
+
+
+class GmailRail:
+    def run(self, operation, params):
+        if operation == "gmail.messages.list":
+            if params.get("pageToken") == "page-2":
+                return {"messages": [{"id": "managed-message-2"}]}
+            return {
+                "messages": [{"id": "managed-message-1"}],
+                "nextPageToken": "page-2",
+            }
+        if operation == "gmail.messages.get":
+            message_id = params["id"]
+            body = base64.urlsafe_b64encode(
+                b"managed company launch marker "
+                b"api_key=synthetic-managed-content-secret"
+            ).decode().rstrip("=")
+            return {
+                "id": message_id,
+                "threadId": "managed-thread-1",
+                "historyId": "700",
+                "internalDate": "1784505600000",
+                "payload": {
+                    "mimeType": "text/plain",
+                    "headers": [
+                        {
+                            "name": "From",
+                            "value": "teammate@example.invalid",
+                        },
+                        {
+                            "name": "To",
+                            "value": "owner@example.invalid",
+                        },
+                        {
+                            "name": "Subject",
+                            "value": "managed company launch marker",
+                        },
+                    ],
+                    "body": {"data": body},
+                },
+            }
+        if operation == "gmail.history.list":
+            return {"history": [], "historyId": "700"}
+        raise AssertionError("unexpected synthetic Google operation")
+
+    def export_document(self, *, file_id, mime_type="text/plain"):
+        raise AssertionError("Gmail fixture does not export documents")
+
+
+def provision(store):
+    store.provision_brain(
+        organization_id="org:personal:managed-worker-e2e",
+        organization_kind="personal",
+        display_name="Synthetic Personal",
+        tenant_id=PERSONAL,
+        brain_kind="personal",
+        slug="personal-managed-worker",
+        owner_principal_id=OWNER,
+    )
+    store.provision_brain(
+        organization_id="org:company:managed-worker-e2e",
+        organization_kind="company",
+        display_name="Synthetic Company",
+        tenant_id=COMPANY,
+        brain_kind="company",
+        slug="company-managed-worker",
+        owner_principal_id=OWNER,
+    )
+
+
+def connection(store, box):
+    connection_id = uuid.uuid4()
+    credentials = {
+        "type": "authorized_user",
+        "client_id": "synthetic-client-id",
+        "client_secret": "synthetic-client-secret",
+        "refresh_token": SECRET,
+        "token_uri": "https://oauth2.googleapis.com/token",
+        "access_token": "synthetic-access-token",
+        "token_type": "Bearer",
+    }
+    encrypted = box.seal(
+        credentials,
+        purpose=f"provider-connection:{connection_id}",
+    )
+    assert SECRET.encode() not in encrypted
+    with store.connect() as database:
+        database.execute(
+            """INSERT INTO provider_connections(
+                   id,principal_id,provider,subject_id,status,granted_scopes,
+                   encrypted_credentials,encryption_key_id,expires_at
+               ) VALUES (%s,%s,'google','synthetic-subject','connected',
+                         ARRAY['https://www.googleapis.com/auth/gmail.readonly'],
+                         %s,%s,%s)""",
+            (
+                connection_id,
+                OWNER,
+                encrypted,
+                box.key_id,
+                datetime.now(timezone.utc) + timedelta(hours=1),
+            ),
+        )
+    return connection_id
+
+
+def install(
+    store,
+    connection_id,
+    *,
+    tenant_id,
+    source_id,
+    state,
+):
+    installation_id = uuid.uuid4()
+    with store.connect() as database:
+        database.execute(
+            """INSERT INTO connector_installations(
+                   id,tenant_id,principal_id,connector_id,source_id,
+                   connection_id,execution,state,privacy_mode,selectors
+               ) VALUES (%s,%s,%s,'google.gmail',%s,%s,'remote_worker',
+                         %s,'scrub',%s::jsonb)""",
+            (
+                installation_id,
+                tenant_id,
+                OWNER,
+                source_id,
+                connection_id,
+                state,
+                json.dumps(
+                    {
+                        "own_addresses": ["owner@example.invalid"],
+                    }
+                ),
+            ),
+        )
+    return installation_id
+
+
+def force_due(store, installation_id):
+    with store.connect() as database:
+        database.execute(
+            """UPDATE connector_installations
+               SET run_after=now()-interval '1 second',
+                   lease_owner=NULL,lease_expires_at=NULL
+               WHERE id=%s""",
+            (installation_id,),
+        )
+
+
+def main():
+    store = BrainStore(
+        os.environ["RECALL_DATABASE_URL"],
+        semantic_runtime=FakeSemanticRuntime(),
+    )
+    store.migrate()
+    with store.connect() as database:
+        database.execute(
+            """TRUNCATE brain_tenants,brain_organizations,
+                        provider_connections,control_audit_events
+               RESTART IDENTITY CASCADE"""
+        )
+    provision(store)
+    box = SecretBox(b"w" * 32)
+    connection_id = connection(store, box)
+    company_installation = install(
+        store,
+        connection_id,
+        tenant_id=COMPANY,
+        source_id=COMPANY_SOURCE,
+        state="enabled",
+    )
+    install(
+        store,
+        connection_id,
+        tenant_id=PERSONAL,
+        source_id=PERSONAL_SOURCE,
+        state="paused",
+    )
+
+    with tempfile.TemporaryDirectory(
+        prefix="recall-managed-worker-e2e-"
+    ) as directory:
+        root = Path(directory)
+        os.chmod(root, 0o700)
+        archive = FilesystemArchiveStore(
+            root / "archive",
+            namespace_key=b"a" * 32,
+        )
+        worker = ManagedConnectorWorker(
+            store,
+            archive,
+            box,
+            state_root=root / "state",
+            worker_id="worker:managed-e2e",
+            remote_rails={"google.gmail": GmailRail()},
+            interval_seconds=60,
+        )
+        first = worker.run_once()
+        assert first == {
+            "schema_version": 1,
+            "status": "committed",
+            "processed": 1,
+            "committed": 1,
+            "failed": 0,
+            "acked": 1,
+            "staged": 1,
+            "embedded": 1,
+            "has_more": True,
+        }
+        assert SECRET not in json.dumps(first)
+
+        with store.connect() as database:
+            due_in = database.execute(
+                """SELECT extract(epoch FROM (run_after-now())) AS seconds
+                   FROM connector_installations WHERE id=%s""",
+                (company_installation,),
+            ).fetchone()["seconds"]
+        assert 0 <= float(due_in) <= 2
+
+        force_due(store, company_installation)
+        second = worker.run_once()
+        assert second["status"] == "committed"
+        assert second["acked"] == 1 and second["has_more"] is False
+
+        idle = worker.run_once()
+        assert idle["status"] == "idle" and idle["processed"] == 0
+
+        with store.connect() as database:
+            by_tenant = database.execute(
+                """SELECT tenant_id,count(*) AS count
+                   FROM canonical_events
+                   GROUP BY tenant_id ORDER BY tenant_id"""
+            ).fetchall()
+            embeddings = database.execute(
+                """SELECT tenant_id,count(*) AS count
+                   FROM canonical_chunk_embeddings
+                   GROUP BY tenant_id ORDER BY tenant_id"""
+            ).fetchall()
+            route = database.execute(
+                """SELECT last_success_at,last_error_code,failure_count,
+                          lease_owner,lease_expires_at
+                   FROM connector_installations WHERE id=%s""",
+                (company_installation,),
+            ).fetchone()
+            rendered = json.dumps(
+                database.execute(
+                    """SELECT canonical_redacted
+                       FROM canonical_events
+                       WHERE tenant_id=%s AND source_id=%s""",
+                    (COMPANY, COMPANY_SOURCE),
+                ).fetchone()["canonical_redacted"]
+            )
+        assert [(row["tenant_id"], row["count"]) for row in by_tenant] == [
+            (COMPANY, 2)
+        ]
+        assert [(row["tenant_id"], row["count"]) for row in embeddings] == [
+            (COMPANY, 2)
+        ]
+        assert (
+            route["last_success_at"] is not None
+            and route["last_error_code"] is None
+            and route["failure_count"] == 0
+            and route["lease_owner"] is None
+            and route["lease_expires_at"] is None
+        )
+        assert "synthetic-managed-content-secret" not in rendered
+
+        force_due(store, company_installation)
+        replay = worker.run_once()
+        assert replay["status"] == "committed"
+        with store.connect() as database:
+            assert database.execute(
+                """SELECT count(*) AS count FROM canonical_events
+                   WHERE tenant_id=%s AND source_id=%s""",
+                (COMPANY, COMPANY_SOURCE),
+            ).fetchone()["count"] == 2
+
+        with store.connect() as database:
+            database.execute(
+                """UPDATE connector_installations
+                   SET state='paused',run_after=now()-interval '1 second'
+                   WHERE id=%s""",
+                (company_installation,),
+            )
+        paused = worker.run_once()
+        assert paused["status"] == "idle"
+
+    print(
+        json.dumps(
+            {
+                "status": "pass",
+                "managed_jobs_committed": 3,
+                "canonical_company_events": 2,
+                "canonical_personal_events": 0,
+                "canonical_company_embeddings": 2,
+                "duplicate_events_after_replay": 0,
+                "paused_jobs_executed": 0,
+                "plaintext_provider_credentials_at_rest": 0,
+                "rendered_secret_canaries": 0,
+            },
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/recall/tests/test_collector.py
+++ b/recall/tests/test_collector.py
@@ -4,6 +4,7 @@ import json
 import hashlib
 import tempfile
 import threading
+import time
 import unittest
 from unittest import mock
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -325,6 +326,76 @@ class CollectorTest(unittest.TestCase):
         self.assertIn("artifact_ref", ingested[0]["provenance"])
         self.assertNotIn(canary, json.dumps(ingested))
         self.assertNotIn(canary.encode(), self.spool.read_bytes())
+        collector.close()
+
+    def test_canonical_scan_archives_concurrently_but_spools_in_source_order(self) -> None:
+        (self.root / "session.jsonl").write_text(
+            "".join(claude_line(f"record-{index}") for index in range(12))
+        )
+        lock = threading.Lock()
+        active = 0
+        peak = 0
+
+        class Archive:
+            def put_raw(inner, **kwargs):
+                nonlocal active, peak
+                with lock:
+                    active += 1
+                    peak = max(peak, active)
+                time.sleep(0.02)
+                with lock:
+                    active -= 1
+                digest = hashlib.sha256(kwargs["payload"]).hexdigest()
+                return {
+                    "contract": "recall.artifact-ref.v1",
+                    "schema_version": 1,
+                    "tenant_id": kwargs["tenant_id"],
+                    "source_id": kwargs["source_id"],
+                    "artifact_id": "art_" + digest[:32],
+                    "storage_backend": "s3",
+                    "object_key": "objects/aa/" + digest,
+                    "content_sha256": digest,
+                    "size_bytes": len(kwargs["payload"]),
+                    "media_type": kwargs["media_type"],
+                    "encryption": "sse-s3",
+                    "version_id": "synthetic-version",
+                    "created_at": kwargs["created_at"],
+                }
+
+        class Writer:
+            def ingest(self, events):
+                return {
+                    "status": "committed",
+                    "inserted": len(events),
+                    "duplicate_events": 0,
+                    "receipts": [
+                        f"recall://{event['source_id']}/{event['native_id']}?rev=1"
+                        for event in events
+                    ],
+                    "replay": False,
+                }
+
+        collector = Collector(
+            root=self.root,
+            harness="claude",
+            source_id="claude:linux:test",
+            spool_path=self.spool,
+            endpoint=self.endpoint,
+            token="test-token-not-a-secret",
+            principal_id="owner",
+            privacy=PrivacyPolicy(mode="scrub"),
+            brain_writer=Writer(),
+            archive=Archive(),
+            tenant_id="tenant:personal",
+            archive_workers=4,
+        )
+        self.assertEqual(collector.scan()["records_queued"], 12)
+        self.assertGreaterEqual(peak, 2)
+        starts = [
+            event["provenance"]["byte_start"]
+            for event in collector.pending_envelopes()
+        ]
+        self.assertEqual(starts, sorted(starts))
         collector.close()
 
     def test_enabling_drop_compacts_sensitive_pending_bytes_from_legacy_spool(self) -> None:


### PR DESCRIPTION
## Outcome

Adds the database-leased managed connector worker used by the unified personal/company control plane, preserves ACK-gated durable cursors, and accelerates Mac raw archival with bounded concurrency.

## Verification

- 596 Python tests and 3 launcher tests pass
- managed connector E2E proves personal/company isolation, two-page catch-up, dedupe, pause, encrypted provider credentials, and scrubbed projections
- immutable container E2E proves non-root/read-only startup, least-privilege PostgreSQL, fail-closed auth, ingest, and retrieval
- ruff E9/F/PLE clean; Bandit reports no high-severity findings
- repository diff audited: no transcripts, private evidence, or live credentials