### PR TITLE
fix(recall): retry transient canonical archive writes

### DIFF
--- a/recall/client/mac.py
+++ b/recall/client/mac.py
@@ -8,6 +8,7 @@ import os
 import platform
 import re
 import stat
+import time
 import urllib.parse
 import urllib.error
 import urllib.request
@@ -39,6 +40,7 @@ V2_IDENTITY = re.compile(r"[A-Za-z0-9][A-Za-z0-9:._/@+-]{1,255}\Z")
 MAX_INGEST_BYTES = 8_000_000
 MAX_INGEST_EVENTS = 500
 MAX_CANONICAL_ARCHIVE_BYTES = 8_000_000
+MAX_CANONICAL_ARCHIVE_ATTEMPTS = 5
 MAX_EXPORT_BYTES = 256_000_000
 MAX_ARCHIVE_MEMBERS = 10_000
 
@@ -488,31 +490,39 @@ class CanonicalArchiveClient(_CanonicalClient):
             raise ValueError("canonical archive payload is invalid")
         if not isinstance(native_id, str) or not V2_IDENTITY.fullmatch(native_id):
             raise ValueError("canonical archive identity is invalid")
-        try:
-            return self._request(
-                "/v2/archive/objects",
-                body={
-                    "tenant_id": self.tenant_id,
-                    "principal_id": self.principal_id,
-                    "source_id": self.source_id,
-                    "native_id": native_id,
-                    "payload_base64": base64.b64encode(payload).decode(),
-                    "media_type": media_type,
-                    "created_at": created_at,
-                },
-            )
-        except urllib.error.HTTPError as error:
-            error_code = "archive_unavailable"
+        body = {
+            "tenant_id": self.tenant_id,
+            "principal_id": self.principal_id,
+            "source_id": self.source_id,
+            "native_id": native_id,
+            "payload_base64": base64.b64encode(payload).decode(),
+            "media_type": media_type,
+            "created_at": created_at,
+        }
+        for attempt in range(MAX_CANONICAL_ARCHIVE_ATTEMPTS):
+            retryable = False
             try:
-                response = json.loads(error.read(4096))
-            except (json.JSONDecodeError, UnicodeDecodeError):
-                response = {}
-            if (
-                error.code == 409
-                and response.get("error") == "archive_identity_forgotten"
-            ):
-                error_code = "archive_identity_forgotten"
-            raise CanonicalClientError(error_code) from None
+                return self._request("/v2/archive/objects", body=body)
+            except urllib.error.HTTPError as error:
+                if error.code == 409:
+                    try:
+                        response = json.loads(error.read(4096))
+                    except (json.JSONDecodeError, UnicodeDecodeError):
+                        response = {}
+                    if response.get("error") == "archive_identity_forgotten":
+                        raise CanonicalClientError(
+                            "archive_identity_forgotten"
+                        ) from None
+                retryable = (
+                    error.code in {408, 425, 429}
+                    or 500 <= error.code <= 599
+                )
+            except (OSError, urllib.error.URLError):
+                retryable = True
+            if not retryable or attempt + 1 == MAX_CANONICAL_ARCHIVE_ATTEMPTS:
+                raise CanonicalClientError("archive_unavailable") from None
+            time.sleep(min(2**attempt, 8))
+        raise AssertionError("unreachable")
 
 
 class CanonicalBrainWriter(_CanonicalClient):

--- a/recall/tests/test_mac_client.py
+++ b/recall/tests/test_mac_client.py
@@ -6,6 +6,7 @@ import io
 import json
 import tempfile
 import unittest
+import urllib.error
 import zipfile
 from pathlib import Path
 from unittest import mock
@@ -15,6 +16,7 @@ from client.mac import (
     BrainClient,
     CanonicalArchiveClient,
     CanonicalBrainWriter,
+    CanonicalClientError,
     ExportImporter,
     MemoryClient,
     PrivacyError,
@@ -332,6 +334,95 @@ class CanonicalV2ClientTest(unittest.TestCase):
                 created_at="2026-07-20T00:00:00Z",
             )
         opened.assert_not_called()
+
+    def test_archive_retries_transient_transport_failure_idempotently(self) -> None:
+        payload = b'{"raw":"synthetic-retry"}'
+        artifact = {
+            "contract": "recall.artifact-ref.v1",
+            "schema_version": 1,
+            "tenant_id": "tenant:personal",
+            "source_id": "source:personal",
+            "artifact_id": "art_" + "b" * 32,
+            "storage_backend": "s3",
+            "object_key": "objects/bb/" + "b" * 64,
+            "content_sha256": hashlib.sha256(payload).hexdigest(),
+            "size_bytes": len(payload),
+            "media_type": "application/json",
+            "encryption": "sse-s3",
+            "version_id": "synthetic-version",
+            "created_at": "2026-07-20T00:00:00Z",
+        }
+        archive = CanonicalArchiveClient(
+            endpoint="https://brain.example.invalid",
+            token="synthetic",
+            source_id="source:personal",
+            tenant_id="tenant:personal",
+            principal_id="principal:owner",
+        )
+        attempts = [
+            urllib.error.URLError("synthetic-timeout"),
+            OSError("synthetic-reset"),
+            FakeResponse(201, artifact),
+        ]
+        with (
+            mock.patch(
+                "client.mac.open_no_redirect",
+                side_effect=attempts,
+            ) as opened,
+            mock.patch("client.mac.time.sleep") as slept,
+        ):
+            result = archive.put_raw(
+                tenant_id="tenant:personal",
+                source_id="source:personal",
+                native_id="native:retry",
+                payload=payload,
+                media_type="application/json",
+                created_at="2026-07-20T00:00:00Z",
+            )
+        self.assertEqual(result, artifact)
+        self.assertEqual(opened.call_count, 3)
+        self.assertEqual(
+            [call.args[0] for call in slept.call_args_list],
+            [1, 2],
+        )
+        bodies = [
+            json.loads(call.args[0].data)
+            for call in opened.call_args_list
+        ]
+        self.assertEqual(bodies[0], bodies[1])
+        self.assertEqual(bodies[1], bodies[2])
+
+    def test_archive_retry_budget_is_bounded_and_content_free(self) -> None:
+        archive = CanonicalArchiveClient(
+            endpoint="https://brain.example.invalid",
+            token="synthetic",
+            source_id="source:personal",
+            tenant_id="tenant:personal",
+            principal_id="principal:owner",
+        )
+        with (
+            mock.patch(
+                "client.mac.open_no_redirect",
+                side_effect=OSError("synthetic-private-upstream-detail"),
+            ) as opened,
+            mock.patch("client.mac.time.sleep") as slept,
+            self.assertRaises(CanonicalClientError) as raised,
+        ):
+            archive.put_raw(
+                tenant_id="tenant:personal",
+                source_id="source:personal",
+                native_id="native:retry-budget",
+                payload=b"synthetic",
+                media_type="application/json",
+                created_at="2026-07-20T00:00:00Z",
+            )
+        self.assertEqual(raised.exception.error_code, "archive_unavailable")
+        self.assertNotIn("upstream", str(raised.exception))
+        self.assertEqual(opened.call_count, 5)
+        self.assertEqual(
+            [call.args[0] for call in slept.call_args_list],
+            [1, 2, 4, 8],
+        )
 
 
 class ExplicitMemoryTest(unittest.TestCase):


### PR DESCRIPTION
## Outcome

Retries only idempotent canonical archive writes on bounded transport, rate-limit, and 5xx failures. Identity-forgotten and other closed client errors still fail immediately.

## Live failure reproduced

Mac backfill advanced through thousands of successful archive writes, then both collectors exited on a transient archive timeout. Durable scan checkpoints remained intact.

## Verification

- 598 Python tests and 3 launcher tests pass
- retry success eval proves byte-identical request bodies and 1s/2s bounded backoff
- retry exhaustion eval proves exactly 5 attempts, 1/2/4/8s delays, and a content-free terminal error
- ruff E9/F/PLE and diff checks pass
- no transcripts, credentials, or live evidence added