### PR TITLE
fix(recall): publish image for every runtime input

### DIFF
--- a/.github/workflows/recall-image.yml
+++ b/.github/workflows/recall-image.yml
@@ -13,7 +13,10 @@ on:
       - "recall/server/**"
       - "recall/contracts/**"
       - "recall/connectors/**"
+      - "recall/client/**"
+      - "recall/collector/**"
       - "recall/privacy/**"
+      - "recall/scripts/install_gws.py"
       - "recall/skills/recall/scripts/recall.py"
       - ".github/workflows/recall-image.yml"
   workflow_dispatch:

--- a/recall/tests/central_brain/test_core_deployment.py
+++ b/recall/tests/central_brain/test_core_deployment.py
@@ -344,6 +344,22 @@ class ContainerContractTest(unittest.TestCase):
         )
         self.assertNotIn("context: .", workflow)
 
+    def test_image_publication_tracks_every_runtime_copy_input(self) -> None:
+        workflow = (
+            RECALL.parent / ".github" / "workflows" / "recall-image.yml"
+        ).read_text()
+        for runtime_input in (
+            "recall/server/**",
+            "recall/contracts/**",
+            "recall/connectors/**",
+            "recall/client/**",
+            "recall/collector/**",
+            "recall/privacy/**",
+            "recall/scripts/install_gws.py",
+            "recall/skills/recall/scripts/recall.py",
+        ):
+            self.assertIn(f'"{runtime_input}"', workflow)
+
     def test_image_has_pinned_base_nonroot_runtime_and_content_free_healthcheck(
         self,
     ) -> None:


### PR DESCRIPTION
## Outcome

Makes the immutable Recall image workflow trigger whenever any Docker COPY runtime input changes, including client, collector, and the pinned gws installer.

## Verification

- deployment contract test enumerates every runtime input
- 17 deployment tests pass
- no runtime code, credentials, transcripts, or evidence changed