### PR TITLE
fix(recall): bound live transcript scans

### DIFF
--- a/recall/collector/collector.py
+++ b/recall/collector/collector.py
@@ -369,9 +369,9 @@ class Collector:
 
                 with path.open("rb") as source:
                     source.seek(start_offset)
-                    while True:
+                    while source.tell() < stat.st_size:
                         line_start = source.tell()
-                        line = source.readline()
+                        line = source.readline(stat.st_size - line_start)
                         if not line:
                             break
                         if not line.endswith(b"\n"):

--- a/recall/tests/test_collector.py
+++ b/recall/tests/test_collector.py
@@ -398,6 +398,56 @@ class CollectorTest(unittest.TestCase):
         self.assertEqual(starts, sorted(starts))
         collector.close()
 
+    def test_canonical_scan_stops_at_observed_size_when_source_is_appended(self) -> None:
+        source = self.root / "session.jsonl"
+        source.write_text(claude_line("first"))
+        archived = []
+
+        class Archive:
+            def put_raw(inner, **kwargs):
+                archived.append(kwargs["payload"])
+                if len(archived) == 1:
+                    with source.open("a") as output:
+                        output.write(claude_line("appended-during-scan"))
+                digest = hashlib.sha256(kwargs["payload"]).hexdigest()
+                return {
+                    "contract": "recall.artifact-ref.v1",
+                    "schema_version": 1,
+                    "tenant_id": kwargs["tenant_id"],
+                    "source_id": kwargs["source_id"],
+                    "artifact_id": "art_" + digest[:32],
+                    "storage_backend": "s3",
+                    "object_key": "objects/aa/" + digest,
+                    "content_sha256": digest,
+                    "size_bytes": len(kwargs["payload"]),
+                    "media_type": kwargs["media_type"],
+                    "encryption": "sse-s3",
+                    "version_id": "synthetic-version",
+                    "created_at": kwargs["created_at"],
+                }
+
+        collector = Collector(
+            root=self.root,
+            harness="claude",
+            source_id="claude:linux:test",
+            spool_path=self.spool,
+            endpoint=self.endpoint,
+            token="test-token-not-a-secret",
+            principal_id="owner",
+            privacy=PrivacyPolicy(mode="scrub"),
+            brain_writer=object(),
+            archive=Archive(),
+            tenant_id="tenant:personal",
+            archive_workers=1,
+        )
+        first = collector.scan()
+        self.assertEqual(first["records_queued"], 1)
+        self.assertEqual(len(archived), 1)
+        second = collector.scan()
+        self.assertEqual(second["records_queued"], 1)
+        self.assertEqual(len(archived), 2)
+        collector.close()
+
     def test_enabling_drop_compacts_sensitive_pending_bytes_from_legacy_spool(self) -> None:
         canary = "synthetic-legacy-spool-canary-95"
         (self.root / "session.jsonl").write_text(claude_line("legacy pending row"))


### PR DESCRIPTION
## Outcome

Pins every collector scan to the source byte size observed at scan start. Appends written during slow archival are deferred to the next ACK-gated scan, so an active transcript cannot starve flush forever.

## Live failure reproduced

Mac coding sessions continued appending while raw archival was in progress; scan checkpoints advanced but the collectors could keep chasing the moving EOF instead of flushing.

## Verification

- live-append eval injects a second record during the first synchronous archive write and proves it is collected only by the next scan
- 600 Python tests and 3 launcher tests pass
- ruff E9/F/PLE and diff checks pass
- no transcripts, credentials, or private evidence added