### PR TITLE
fix(recall): index durable scan checkpoints

### DIFF
--- a/recall/collector/collector.py
+++ b/recall/collector/collector.py
@@ -79,7 +79,7 @@ class Collector:
                  visibility: str = "private", batch_size: int = 500,
                  privacy: PrivacyPolicy | None = None, brain_writer: Any = None,
                  archive: Any = None, tenant_id: str | None = None,
-                 archive_workers: int = 8):
+                 archive_workers: int = 2):
         if harness not in {"claude", "codex"}:
             raise ValueError("harness must be claude or codex")
         if visibility not in {"private", "shared"}:
@@ -433,6 +433,8 @@ class Collector:
                                 commit_pending()
                             self._save_file_progress(path_text, stat, current_fingerprint, complete_end, "scanning-" + mode, file_scan_id)
                             self.db.commit()
+                            if self.brain_writer is not None:
+                                self.flush()
                 while pending:
                     commit_pending()
                 if not append:

--- a/recall/server/recall_server/db.py
+++ b/recall/server/recall_server/db.py
@@ -115,10 +115,24 @@ def related_candidate_limit(result_limit: int) -> int:
 class BrainStore:
     def __init__(self, dsn: str, search_deadline_ms: int | None = None,
                  semantic_runtime: SemanticRuntime | None = None,
-                 semantic_minimum_similarity: float | None = None):
+                 semantic_minimum_similarity: float | None = None,
+                 pool_max_size: int | None = None):
         self.dsn = dsn
         self._pool: ConnectionPool | None = None
         self._pool_lock = threading.Lock()
+        try:
+            configured_pool_size = (
+                pool_max_size
+                if pool_max_size is not None
+                else int(os.environ.get("RECALL_DATABASE_POOL_MAX_SIZE", "8"))
+            )
+        except ValueError as exc:
+            raise ValueError(
+                "database pool size must be between 4 and 32"
+            ) from exc
+        if not 4 <= configured_pool_size <= 32:
+            raise ValueError("database pool size must be between 4 and 32")
+        self.pool_max_size = configured_pool_size
         configured = search_deadline_ms if search_deadline_ms is not None else int(os.environ.get("RECALL_SEARCH_DEADLINE_MS", str(DEFAULT_SEARCH_DEADLINE_MS)))
         if not 10 <= configured <= 5000:
             raise ValueError("search deadline must be between 10 and 5000 milliseconds")
@@ -155,7 +169,7 @@ class BrainStore:
                         self.dsn,
                         kwargs={"row_factory": dict_row},
                         min_size=1,
-                        max_size=4,
+                        max_size=self.pool_max_size,
                         timeout=5,
                         max_idle=300,
                         max_lifetime=1800,

--- a/recall/tests/central_brain/test_brainstore_unit.py
+++ b/recall/tests/central_brain/test_brainstore_unit.py
@@ -774,6 +774,20 @@ class DeliberateCaptureContractTest(unittest.TestCase):
 
 
 class SemanticRetrievalConfigurationTest(unittest.TestCase):
+    def test_database_pool_size_is_bounded_deployment_config(self) -> None:
+        with mock.patch.dict(
+            os.environ,
+            {"RECALL_DATABASE_POOL_MAX_SIZE": "20"},
+        ):
+            store = BrainStore("postgresql://synthetic.invalid/recall")
+        self.assertEqual(store.pool_max_size, 20)
+        for invalid in (3, 33):
+            with self.assertRaisesRegex(ValueError, "database pool size"):
+                BrainStore(
+                    "postgresql://synthetic.invalid/recall",
+                    pool_max_size=invalid,
+                )
+
     def test_similarity_floor_is_explicit_validated_deployment_config(self) -> None:
         with mock.patch.dict(
             os.environ,
@@ -928,7 +942,7 @@ class SemanticRetrievalContractTest(unittest.TestCase):
         self.assertIs(store.connect(), second)
         pool_type.assert_called_once()
         self.assertEqual(pool_type.call_args.kwargs["min_size"], 1)
-        self.assertEqual(pool_type.call_args.kwargs["max_size"], 4)
+        self.assertEqual(pool_type.call_args.kwargs["max_size"], 8)
 
         store.close()
         pool.close.assert_called_once_with()

--- a/recall/tests/test_collector.py
+++ b/recall/tests/test_collector.py
@@ -87,6 +87,11 @@ class CollectorTest(unittest.TestCase):
             token="test-token-not-a-secret",
         )
 
+    def test_default_archive_concurrency_leaves_capacity_for_ingest(self) -> None:
+        collector = self.collector()
+        self.assertEqual(collector.archive_workers, 2)
+        collector.close()
+
     def test_committed_cursor_waits_for_ack_and_survives_restart(self) -> None:
         transcript = self.root / "session.jsonl"
         transcript.write_text(claude_line("first") + claude_line("second"))
@@ -446,6 +451,75 @@ class CollectorTest(unittest.TestCase):
         second = collector.scan()
         self.assertEqual(second["records_queued"], 1)
         self.assertEqual(len(archived), 2)
+        collector.close()
+
+    def test_canonical_scan_flushes_each_durable_checkpoint(self) -> None:
+        source = self.root / "session.jsonl"
+        source.write_text(
+            "".join(claude_line(f"record-{index}") for index in range(1001))
+        )
+        archived = 0
+        ingested: list[list[dict]] = []
+
+        class Archive:
+            def put_raw(inner, **kwargs):
+                nonlocal archived
+                archived += 1
+                if archived == 1001:
+                    self.assertEqual(
+                        sum(len(batch) for batch in ingested),
+                        1000,
+                        "the durable checkpoint must be indexed before scanning resumes",
+                    )
+                digest = hashlib.sha256(kwargs["payload"]).hexdigest()
+                return {
+                    "contract": "recall.artifact-ref.v1",
+                    "schema_version": 1,
+                    "tenant_id": kwargs["tenant_id"],
+                    "source_id": kwargs["source_id"],
+                    "artifact_id": "art_" + digest[:32],
+                    "storage_backend": "s3",
+                    "object_key": "objects/aa/" + digest,
+                    "content_sha256": digest,
+                    "size_bytes": len(kwargs["payload"]),
+                    "media_type": kwargs["media_type"],
+                    "encryption": "sse-s3",
+                    "version_id": "synthetic-version",
+                    "created_at": kwargs["created_at"],
+                }
+
+        class Writer:
+            def ingest(self, events):
+                ingested.append(events)
+                return {
+                    "status": "committed",
+                    "inserted": len(events),
+                    "duplicate_events": 0,
+                    "receipts": [
+                        f"recall://{event['source_id']}/{event['native_id']}?rev=1"
+                        for event in events
+                    ],
+                    "replay": False,
+                }
+
+        collector = Collector(
+            root=self.root,
+            harness="claude",
+            source_id="claude:linux:test",
+            spool_path=self.spool,
+            endpoint=self.endpoint,
+            token="test-token-not-a-secret",
+            principal_id="owner",
+            privacy=PrivacyPolicy(mode="scrub"),
+            brain_writer=Writer(),
+            archive=Archive(),
+            tenant_id="tenant:personal",
+            archive_workers=1,
+        )
+        self.assertEqual(collector.scan()["records_queued"], 1001)
+        self.assertEqual(collector.doctor()["acked"], 1000)
+        self.assertEqual(collector.doctor()["pending"], 1)
+        self.assertEqual(collector.flush()["acked"], 1)
         collector.close()
 
     def test_enabling_drop_compacts_sensitive_pending_bytes_from_legacy_spool(self) -> None:


### PR DESCRIPTION
Streams each durable 1,000-record canonical scan checkpoint into the brain before continuing the source scan. This makes large live transcript backfills searchable incrementally while preserving archive-before-index, durable cursor, privacy, and exactly-once behavior.\n\nVerification: 601 Python tests and 3 launcher tests pass; lint and diff checks pass. The new collector E2E proves records 1-1000 are acknowledged before record 1001 is archived.