### PR TITLE
fix(recall): flush canonical backlog between source files

### DIFF
--- a/recall/collector/collector.py
+++ b/recall/collector/collector.py
@@ -291,6 +291,8 @@ class Collector:
         )
         try:
             for path in self.discover():
+                if summary["files_seen"] and self.brain_writer is not None:
+                    self.flush()
                 summary["files_seen"] += 1
                 stat = path.stat()
                 path_text = str(path)

--- a/recall/tests/test_collector.py
+++ b/recall/tests/test_collector.py
@@ -522,6 +522,73 @@ class CollectorTest(unittest.TestCase):
         self.assertEqual(collector.flush()["acked"], 1)
         collector.close()
 
+    def test_canonical_scan_flushes_between_small_source_files(self) -> None:
+        (self.root / "first.jsonl").write_text(claude_line("first record"))
+        (self.root / "second.jsonl").write_text(claude_line("second record"))
+        archived = 0
+        ingested: list[list[dict]] = []
+
+        class Archive:
+            def put_raw(inner, **kwargs):
+                nonlocal archived
+                archived += 1
+                if archived == 2:
+                    self.assertEqual(
+                        sum(len(batch) for batch in ingested),
+                        1,
+                        "the first file must be indexed before the second is archived",
+                    )
+                digest = hashlib.sha256(kwargs["payload"]).hexdigest()
+                return {
+                    "contract": "recall.artifact-ref.v1",
+                    "schema_version": 1,
+                    "tenant_id": kwargs["tenant_id"],
+                    "source_id": kwargs["source_id"],
+                    "artifact_id": "art_" + digest[:32],
+                    "storage_backend": "s3",
+                    "object_key": "objects/aa/" + digest,
+                    "content_sha256": digest,
+                    "size_bytes": len(kwargs["payload"]),
+                    "media_type": kwargs["media_type"],
+                    "encryption": "sse-s3",
+                    "version_id": "synthetic-version",
+                    "created_at": kwargs["created_at"],
+                }
+
+        class Writer:
+            def ingest(self, events):
+                ingested.append(events)
+                return {
+                    "status": "committed",
+                    "inserted": len(events),
+                    "duplicate_events": 0,
+                    "receipts": [
+                        f"recall://{event['source_id']}/{event['native_id']}?rev=1"
+                        for event in events
+                    ],
+                    "replay": False,
+                }
+
+        collector = Collector(
+            root=self.root,
+            harness="claude",
+            source_id="claude:linux:test",
+            spool_path=self.spool,
+            endpoint=self.endpoint,
+            token="test-token-not-a-secret",
+            principal_id="owner",
+            privacy=PrivacyPolicy(mode="scrub"),
+            brain_writer=Writer(),
+            archive=Archive(),
+            tenant_id="tenant:personal",
+            archive_workers=1,
+        )
+        self.assertEqual(collector.scan()["records_queued"], 2)
+        self.assertEqual(collector.doctor()["acked"], 1)
+        self.assertEqual(collector.doctor()["pending"], 1)
+        self.assertEqual(collector.flush()["acked"], 1)
+        collector.close()
+
     def test_enabling_drop_compacts_sensitive_pending_bytes_from_legacy_spool(self) -> None:
         canary = "synthetic-legacy-spool-canary-95"
         (self.root / "session.jsonl").write_text(claude_line("legacy pending row"))


### PR DESCRIPTION
## Summary
- flush durable canonical backlog before advancing from one discovered source file to the next
- preserve the existing 1,000-record checkpoint inside large files
- add a regression proving file two cannot archive before file one is canonically committed

## Verification
- 605 Python tests passed
- 3 Node tests passed
- targeted checkpoint, small-file boundary, concurrent archive, and append-bound tests passed
- `git diff --check`
- added-line secret-shape scan clean

No transcripts, credentials, private evidence, or infrastructure values are included.