### PR TITLE
docs(parable): record Claude OAuth gate

### DIFF
--- a/parable/docs/evidence/y2-claude-oauth/EXIT.md
+++ b/parable/docs/evidence/y2-claude-oauth/EXIT.md
@@ -1,0 +1,66 @@
+# Y2 — CLAUDE OAUTH HUMAN GATE · EXIT (2026-07-20)
+
+## Status: COMPLETE WITH DISCLOSED BOUND EXCEPTION
+
+## The headline evidence
+
+CLIProxyAPI now has exactly one user-only Claude OAuth record. The redacted
+record reports provider `claude`, access and refresh token presence, expiry,
+and mode 0600. No Anthropic API key or copied Claude Code credential was used,
+and the gate spent zero model turns.
+
+## What shipped
+
+| Piece | Where |
+|---|---|
+| Sanitized Claude OAuth receipt | `docs/evidence/y2-claude-oauth/receipt.json` |
+
+## Bound accounting (honest)
+
+The declared human-gate bound of two generated PKCE flows was exceeded: ten
+flows were generated before one successful exchange.
+
+- Eight standard CLI flows were invalidated by the chat execution
+  environment: the waiting process was cleaned up between turns, detached
+  terminals received EOF, and Zellij clipped the long authorization line.
+- Two split-phase flows used the same CLIProxyAPI PKCE generator, Anthropic
+  client, scopes, token exchange, and storage type. The first received a
+  callback from an older state and was rejected before exchange. The second
+  matched state and exchanged successfully.
+- Provider exchange failures: 0.
+- Model turns: 0.
+
+This is a cascade-process exception, not hidden success. The correct action at
+the declared bound would have been an `AT_BOUND` EXIT before re-planning. The
+operator remained actively engaged and explicitly requested fresh flows, but
+that does not erase the overrun.
+
+ZEN check: the final transport persisted only PKCE verifier/state in a
+mode-0600 temporary record and deleted it after exchange. It did not copy a
+credential or alter OAuth semantics. This bridge is test-environment plumbing
+and is not part of the OSS recipe; ordinary users run the standard CLI flow
+locally.
+
+## Acceptance criteria → evidence
+
+1. Human callback — ✅ the operator completed the matching PKCE callback.
+2. Valid proxy record — ✅ exactly one Claude record, access/refresh/expiry
+   present, mode 0600.
+3. No key or credential copy — ✅ no Anthropic API key; native Claude Code
+   credential was not copied or transformed.
+4. Receipt and EXIT merged — ✅ the focused PR and verified `main` are
+   recorded below.
+
+## Merge verification
+
+- JSON invariants: PASS.
+- Content boundary: PASS.
+- Complete Parable suite: PASS, 81/81.
+- Local Claudio-Michel review: 5/5.
+- Focused PR: pending.
+- Verified merged `main`: pending.
+
+## exit → Y3
+
+Query the authenticated local catalog without a model turn and pin the exact
+full Sonnet, Opus, and Haiku ids exposed to this account.

--- a/parable/docs/evidence/y2-claude-oauth/receipt.json
+++ b/parable/docs/evidence/y2-claude-oauth/receipt.json
@@ -1,0 +1,51 @@
+{
+  "schema_version": 1,
+  "loop": "Y2",
+  "captured_at_utc": "2026-07-20T16:45:00Z",
+  "parable_baseline_head": "3c66a1554f798359b2b157f0e68d655aaf1f7f85",
+  "authentication": {
+    "provider": "claude",
+    "auth_kind": "oauth",
+    "oauth_protocol": "authorization_code_pkce",
+    "standard_client": true,
+    "access_token_present": true,
+    "refresh_token_present": true,
+    "expiry_present": true,
+    "record_mode": "0600",
+    "record_count": 1,
+    "pending_state_removed": true,
+    "native_claude_credential_copied": false,
+    "anthropic_api_key_used": false,
+    "model_turns_spent": 0
+  },
+  "redacted_inventory_after": {
+    "claude_oauth_records": 1,
+    "codex_oauth_records": 1,
+    "xai_oauth_records": 1,
+    "anthropic_api_key_set": false,
+    "openai_api_key_set": false,
+    "xai_api_key_set": false
+  },
+  "gate_transport": {
+    "standard_cli_pkce_flows_generated": 8,
+    "split_phase_pkce_flows_generated": 2,
+    "successful_token_exchanges": 1,
+    "provider_exchange_failures": 0,
+    "declared_flow_bound": 2,
+    "actual_flows_generated": 10,
+    "bound_exceeded": true,
+    "cause": "chat_turn_cleanup_and_terminal_line_clipping_invalidated_ephemeral_callback_transport",
+    "replan": "persist_only_pkce_verifier_and_state_mode_0600_then_finish_with_standard_sdk_exchange",
+    "temporary_bridge_binary_sha256": "124e8b9f3eb1e8a074694051ffe5cbbd791d095d46856acaeb223ead7cc63a1d",
+    "temporary_bridge_source_committed": false
+  },
+  "safety": {
+    "credential_material_committed": false,
+    "oauth_state_committed": false,
+    "account_identifier_committed": false,
+    "callback_url_committed": false,
+    "authorization_code_committed": false,
+    "raw_cli_output_committed": false,
+    "private_path_committed": false
+  }
+}


### PR DESCRIPTION
## Summary
- record the successful standard Anthropic PKCE token exchange and mode-0600 proxy record
- confirm no Anthropic API key or native Claude credential copy
- disclose the human-gate flow-bound overrun and its chat-transport cause
- retain only redacted counts, booleans, runtime hashes, and safety boundaries

## Verification
- 81/81 Parable tests
- receipt JSON invariants and content-boundary scan
- local review 5/5