### PR TITLE
docs(parable): record authenticated Claude catalog

### DIFF
--- a/parable/docs/evidence/y3-claude-catalog/EXIT.md
+++ b/parable/docs/evidence/y3-claude-catalog/EXIT.md
@@ -1,0 +1,62 @@
+# Y3 — AUTHENTICATED CLAUDE CATALOG · EXIT (2026-07-20)
+
+## Status: COMPLETE
+
+## The headline evidence
+
+The authenticated loopback catalog now contains 14 Anthropic entries.
+The successor pins one exact full id for each planned child lane:
+
+| Lane | Exact id | Owner |
+|---|---|---|
+| Sonnet | `claude-sonnet-5` | `anthropic` |
+| Opus | `claude-opus-4-8` | `anthropic` |
+| Haiku | `claude-haiku-4-5-20251001` | `anthropic` |
+
+Exact Sol, Terra, Luna, and Grok remain present. The catalog probe spent zero
+model turns.
+
+## What shipped
+
+| Piece | Where |
+|---|---|
+| Sanitized authenticated catalog receipt | `docs/evidence/y3-claude-catalog/receipt.json` |
+
+## Bound accounting (honest)
+
+- Correctly wired catalog probes: 2/2; passed.
+- Evidence failures: 0.
+- Instrument failures: 1. An aggregate-only `jq` expression failed to compile;
+  the authenticated response was unchanged and the corrected redacting
+  expression passed.
+- Review rounds: 1. Exact-id multiplicity, ownership, retained providers,
+  listener, API-key environment, zero-turn accounting, and content boundaries
+  were checked.
+
+ZEN check: the authenticated catalog selects full ids before inference.
+No display alias, name regex, fallback model, provider call, or entitlement
+guess is used.
+
+## Acceptance criteria → evidence
+
+1. Exact Claude children — ✅ one exact Anthropic-owned id is pinned for each
+   Sonnet, Opus, and Haiku lane.
+2. Existing routes preserved — ✅ exact Sol/Terra/Luna/Grok each remain
+   present once under their original owner.
+3. No direct keys — ✅ Anthropic, OpenAI, and xAI API-key variables are unset.
+4. Receipt and EXIT merged — ✅ the focused PR and verified `main` are
+   recorded below.
+
+## Merge verification
+
+- JSON invariants: PASS.
+- Complete Parable suite: PASS, 81/81.
+- Local Claudio-Michel review: 5/5.
+- Focused PR: pending.
+- Verified merged `main`: pending.
+
+## exit → Y4
+
+Run all 15 Sol-parent permutations against the three pinned exact Claude child
+ids. Require real child Bash, parent consumption, exact model attribution,
+and separate ChatGPT/Anthropic OAuth routes.

--- a/parable/docs/evidence/y3-claude-catalog/receipt.json
+++ b/parable/docs/evidence/y3-claude-catalog/receipt.json
@@ -1,0 +1,83 @@
+{
+  "schema_version": 1,
+  "loop": "Y3",
+  "captured_at_utc": "2026-07-20T17:09:18Z",
+  "parable_baseline_head": "1152e63b61de7415be67ed552303ab87552efeee",
+  "runtime": {
+    "cliproxyapi_upstream_release": "v7.2.88",
+    "cliproxyapi_upstream_commit": "93d74a890a44802f656d7f39a573916b2611896e",
+    "cliproxyapi_local_fix_commit": "ad20a87efbbd41a9d4f24c83ca8bdd934bf34ab7",
+    "cliproxyapi_binary_sha256": "139e1305a878e08026dd0fb6d85a3817801f32e40a40c1954ea1973c5bb9d697",
+    "loopback_only": true,
+    "local_model_catalog": true
+  },
+  "catalog": {
+    "endpoint": "/v1/models",
+    "authenticated": true,
+    "http_status": 200,
+    "total_models": 37,
+    "owner_counts": {
+      "anthropic": 14,
+      "openai": 10,
+      "xai": 13
+    },
+    "model_turns_spent": 0
+  },
+  "pinned_claude_children": [
+    {
+      "lane": "sonnet",
+      "id": "claude-sonnet-5",
+      "owned_by": "anthropic",
+      "count": 1
+    },
+    {
+      "lane": "opus",
+      "id": "claude-opus-4-8",
+      "owned_by": "anthropic",
+      "count": 1
+    },
+    {
+      "lane": "haiku",
+      "id": "claude-haiku-4-5-20251001",
+      "owned_by": "anthropic",
+      "count": 1
+    }
+  ],
+  "preserved_children": [
+    {
+      "id": "gpt-5.6-sol",
+      "owned_by": "openai",
+      "count": 1
+    },
+    {
+      "id": "gpt-5.6-terra",
+      "owned_by": "openai",
+      "count": 1
+    },
+    {
+      "id": "gpt-5.6-luna",
+      "owned_by": "openai",
+      "count": 1
+    },
+    {
+      "id": "grok-4.5",
+      "owned_by": "xai",
+      "count": 1
+    }
+  ],
+  "routing": {
+    "claude_oauth_records": 1,
+    "codex_oauth_records": 1,
+    "xai_oauth_records": 1,
+    "anthropic_api_key_set": false,
+    "openai_api_key_set": false,
+    "xai_api_key_set": false
+  },
+  "safety": {
+    "credential_material_committed": false,
+    "oauth_state_committed": false,
+    "account_identifier_committed": false,
+    "raw_catalog_committed": false,
+    "private_path_committed": false
+  }
+}


### PR DESCRIPTION
Records the sanitized Y3 authenticated Claude catalog gate: exact Sonnet, Opus, and Haiku child pins, preserved GPT/Grok routes, zero model turns, and credential-safe routing invariants.\n\nValidation: 81/81 Parable tests; JSON invariants; local 5/5 review.