### PR TITLE
fix(recall): repair canonical lineage during backfill

### DIFF
--- a/recall/collector/collector.py
+++ b/recall/collector/collector.py
@@ -18,6 +18,7 @@ from privacy.transport import open_no_redirect
 
 COLLECTOR_VERSION = 1
 MAX_BATCH_BYTES = 8_000_000
+MAX_CANONICAL_BATCH_EVENTS = 50
 SENSITIVE_KEY = re.compile(r"(?:litellm.*master.*key|api[_-]?key|password|secret|authorization|bearer|access[_-]?token|refresh[_-]?token|token)$", re.I)
 SENSITIVE_LINE = re.compile(
     r"(?i)\b(LITELLM_MASTER_KEY|api[_-]?key|access[_-]?key|private[_-]?key|client[_-]?secret|password|secret|authorization|bearer|access[_-]?token|refresh[_-]?token|token|key)"
@@ -93,6 +94,8 @@ class Collector:
             or not 1 <= archive_workers <= 16
         ):
             raise ValueError("archive_workers must be between 1 and 16")
+        if type(batch_size) is not int or batch_size < 1:
+            raise ValueError("batch_size must be a positive integer")
         self.root = Path(root).expanduser().resolve()
         self.harness = harness
         self.source_id = source_id
@@ -101,7 +104,11 @@ class Collector:
         self.token = token
         self.principal_id = principal_id
         self.visibility = visibility
-        self.batch_size = batch_size
+        self.batch_size = (
+            min(batch_size, MAX_CANONICAL_BATCH_EVENTS)
+            if brain_writer is not None
+            else batch_size
+        )
         self.privacy = privacy or PrivacyPolicy(mode="off")
         self.brain_writer = brain_writer
         self.archive = archive
@@ -547,7 +554,13 @@ class Collector:
                     (row["path"],),
                 )
                 result["recovered"] += 1
-            except (OSError, ValueError, json.JSONDecodeError, UnicodeDecodeError):
+            except (
+                OSError,
+                TypeError,
+                ValueError,
+                json.JSONDecodeError,
+                UnicodeDecodeError,
+            ):
                 self.db.execute(
                     "INSERT OR IGNORE INTO dead_letters(path,byte_offset,error_code,error_summary,created_at) VALUES (?,?,?,?,?)",
                     (row["path"], row["start_offset"], "RecoveryError", "record recovery rejected", time.time()),
@@ -558,6 +571,87 @@ class Collector:
 
     def _repair_pending_envelope(self, row: sqlite3.Row) -> dict | None:
         envelope = json.loads(row["envelope_json"])
+        if (
+            self.archive is not None
+            and "artifact_ref" not in envelope.get("provenance", {})
+        ):
+            try:
+                if envelope.get("kind") == "tombstone":
+                    raw = canonical_json({
+                        "deleted": True,
+                        "native_id": row["native_id"],
+                    })
+                    content = envelope["content"]
+                else:
+                    path = Path(row["path"])
+                    with path.open("rb") as source:
+                        source.seek(row["start_offset"])
+                        raw = source.read(row["end_offset"] - row["start_offset"])
+                    if not raw.endswith(b"\n"):
+                        raise ValueError("source byte window is incomplete")
+                    original = json.loads(raw)
+                    if not isinstance(original, dict):
+                        raise ValueError("record is not an object")
+                    privacy = self.privacy.apply(original)
+                    if privacy.action == "drop":
+                        self.db.execute("DELETE FROM outbox WHERE id=?", (row["id"],))
+                        return None
+                    content = envelope["content"]
+                    expected_content = dict(content)
+                    generation = expected_content.pop(
+                        "_recall_collector_generation",
+                        None,
+                    )
+                    if (
+                        not isinstance(generation, int)
+                        or sanitize(privacy.value) != expected_content
+                    ):
+                        raise ValueError("source byte window changed")
+                artifact_ref = self._archive_raw(
+                    native_id=row["native_id"],
+                    payload=raw,
+                    occurred_at=envelope["occurred_at"],
+                )
+                envelope = self._envelope(
+                    Path(row["path"]),
+                    row["native_id"],
+                    envelope["kind"],
+                    content,
+                    envelope["occurred_at"],
+                    row["start_offset"],
+                    row["end_offset"],
+                    artifact_ref,
+                )
+                rendered = canonical_json(envelope).decode()
+                self.db.execute(
+                    "UPDATE outbox SET envelope_json=?,queued_at=? WHERE id=?",
+                    (rendered, time.time(), row["id"]),
+                )
+                repaired = dict(row)
+                repaired["envelope_json"] = rendered
+                row = repaired
+            except (
+                OSError,
+                TypeError,
+                ValueError,
+                json.JSONDecodeError,
+                UnicodeDecodeError,
+            ):
+                self.db.execute(
+                    "UPDATE outbox SET state='dead' WHERE id=?",
+                    (row["id"],),
+                )
+                self.db.execute(
+                    "INSERT OR IGNORE INTO dead_letters(path,byte_offset,error_code,error_summary,created_at) VALUES (?,?,?,?,?)",
+                    (
+                        row["path"],
+                        row["start_offset"],
+                        "RecoveryError",
+                        "record recovery rejected",
+                        time.time(),
+                    ),
+                )
+                return None
         if envelope.get("kind") == "tombstone":
             clean = sanitize(envelope["content"])
         else:

--- a/recall/tests/test_collector.py
+++ b/recall/tests/test_collector.py
@@ -333,6 +333,80 @@ class CollectorTest(unittest.TestCase):
         self.assertNotIn(canary.encode(), self.spool.read_bytes())
         collector.close()
 
+    def test_canonical_flush_repairs_and_bounds_legacy_pending_rows(self) -> None:
+        (self.root / "session.jsonl").write_text(
+            "".join(claude_line(f"legacy pending row {index}") for index in range(51))
+        )
+        legacy = self.collector()
+        self.assertEqual(legacy.scan()["records_queued"], 51)
+        self.assertTrue(all(
+            "artifact_ref" not in envelope["provenance"]
+            for envelope in legacy.pending_envelopes()
+        ))
+        legacy.close()
+        archived = []
+        ingested = []
+        batch_sizes = []
+
+        class Archive:
+            def put_raw(self, **kwargs):
+                archived.append(kwargs)
+                digest = hashlib.sha256(kwargs["payload"]).hexdigest()
+                return {
+                    "contract": "recall.artifact-ref.v1",
+                    "schema_version": 1,
+                    "tenant_id": kwargs["tenant_id"],
+                    "source_id": kwargs["source_id"],
+                    "artifact_id": "art_" + digest[:32],
+                    "storage_backend": "s3",
+                    "object_key": "objects/aa/" + digest,
+                    "content_sha256": digest,
+                    "size_bytes": len(kwargs["payload"]),
+                    "media_type": kwargs["media_type"],
+                    "encryption": "sse-s3",
+                    "version_id": "synthetic-version",
+                    "created_at": kwargs["created_at"],
+                }
+
+        class Writer:
+            def ingest(self, events):
+                batch_sizes.append(len(events))
+                ingested.extend(events)
+                return {
+                    "status": "committed",
+                    "inserted": len(events),
+                    "duplicate_events": 0,
+                    "receipts": [
+                        f"recall://{event['source_id']}/{event['native_id']}?rev=1"
+                        for event in events
+                    ],
+                    "replay": False,
+                }
+
+        canonical = Collector(
+            root=self.root,
+            harness="claude",
+            source_id="claude:linux:test",
+            spool_path=self.spool,
+            endpoint=self.endpoint,
+            token="test-token-not-a-secret",
+            principal_id="owner",
+            privacy=PrivacyPolicy(mode="scrub"),
+            brain_writer=Writer(),
+            archive=Archive(),
+            tenant_id="tenant:personal",
+        )
+
+        self.assertEqual(canonical.flush()["acked"], 51)
+        self.assertEqual(len(archived), 51)
+        self.assertEqual(len(ingested), 51)
+        self.assertEqual(batch_sizes, [50, 1])
+        self.assertTrue(all(
+            "artifact_ref" in event["provenance"]
+            for event in ingested
+        ))
+        canonical.close()
+
     def test_canonical_scan_archives_concurrently_but_spools_in_source_order(self) -> None:
         (self.root / "session.jsonl").write_text(
             "".join(claude_line(f"record-{index}") for index in range(12))


### PR DESCRIPTION
Repairs legacy pending transcript rows by re-reading their exact source byte windows, reapplying privacy, and archiving raw lineage before canonical ingest. Canonical batches are capped at 50 events to stay within remote HTTP deadlines.

Validation: 606 Python tests and 3 Node tests pass. Only collector code and synthetic tests changed; secret scan clean.