### PR TITLE
docs(parable): publish unified subscription verdict

### DIFF
--- a/parable/docs/CLIPROXYAPI_GPT_SUBSCRIPTION.md
+++ b/parable/docs/CLIPROXYAPI_GPT_SUBSCRIPTION.md
@@ -1,30 +1,35 @@
-# GPT and Grok subscription models in stock Claude Code
+# GPT, Claude, and Grok subscription models in stock Claude Code
 
 This is the reproducible OSS path for running stock Claude Code with
-`gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, and `grok-4.5` through a
-local CLIProxyAPI process and the user's own subscription OAuth.
+`gpt-5.6-sol` as the parent and exact GPT, Claude, and Grok named subagents
+through a local CLIProxyAPI process and the user's own subscription OAuth.
 
 No broker or shared deployment is involved:
 
 ```text
                                       ┌→ ChatGPT subscription OAuth
 Claude Code → loopback CLIProxyAPI ───┤
+                                      ├→ Claude subscription OAuth
                                       └→ xAI subscription OAuth
 ```
 
 ## Support state
 
-Released CLIProxyAPI `v7.2.88` can transport all three models, but it maps
-every Claude Code effort setting to upstream `medium`. The patch shipped in
-this repository fixes that protocol translation and has been live-proved for
-all 15 combinations of:
+Released CLIProxyAPI `v7.2.88` can transport all three GPT models, but it
+maps every Claude Code effort setting to upstream `medium`. The patch shipped
+in this repository fixes that protocol translation and has been live-proved
+for all 15 combinations of:
 
 - model: `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`
 - effort: `low`, `medium`, `high`, `xhigh`, `max`
 
 The result was 15/15 exact GPT effort pass-through and 3/3 tool canaries.
-The same build also completed all five Claude Code effort flags with Grok 4.5
-and 3/3 real Grok tool canaries through xAI OAuth:
+It also completed the full 30-cell named-child matrix: five Sol parent effort
+settings times exact Terra, Luna, Grok, Sonnet, Opus, and Haiku children.
+Every cell used a real child Bash artifact followed by parent Agent/Bash
+consumption.
+
+Grok 4.5 ran through xAI OAuth:
 
 - Grok `low`, `medium`, and `high` are exact end to end.
 - Claude's `xhigh` and `max` reach CLIProxyAPI intact, then clamp to Grok's
@@ -32,6 +37,14 @@ and 3/3 real Grok tool canaries through xAI OAuth:
 - A Sol parent invoked exact named agent `parable-grok` at all five parent
   efforts. Claude Code inherited each parent effort into the child; Grok
   applied the same `xhigh|max → high` clamp.
+
+Claude children ran through Claude subscription OAuth:
+
+- `claude-sonnet-5` and `claude-opus-4-8` preserve
+  `low|medium|high|xhigh|max` exactly as Anthropic adaptive-thinking effort.
+- `claude-haiku-4-5-20251001` completes all five cells but normalizes each
+  inherited setting to `thinking.type=enabled`, `budget_tokens=31999`, and no
+  effort label.
 
 The patch is **not** an upstream CLIProxyAPI release. It is pinned to:
 
@@ -116,7 +129,22 @@ printed device code once; stale or previously submitted codes produce
 This route uses ChatGPT subscription OAuth. Do not set `OPENAI_API_KEY` for
 this setup.
 
-To add Grok 4.5, connect the user's xAI subscription separately:
+Connect the user's Claude subscription:
+
+```bash
+./cli-proxy-api \
+  --config "$HOME/.config/parable/cliproxy.yaml" \
+  --claude-login \
+  --no-browser
+```
+
+Keep this command running while you open its newly printed authorization URL
+and complete the callback. A stale URL or a callback delivered to a prior
+process cannot complete the new PKCE flow. CLIProxyAPI stores its own OAuth
+record; do not copy Claude Code's credential and do not set
+`ANTHROPIC_API_KEY`.
+
+Connect the user's xAI subscription separately:
 
 ```bash
 ./cli-proxy-api \
@@ -127,7 +155,7 @@ To add Grok 4.5, connect the user's xAI subscription separately:
 
 Complete the printed xAI device flow. CLIProxyAPI stores and refreshes each
 provider's OAuth record in its user-only auth directory. Do not set
-`XAI_API_KEY`; this recipe proves the subscription route, not metered API
+`XAI_API_KEY`; this recipe proves subscription routes, not metered API
 billing.
 
 ### 4. Start and verify the local proxy
@@ -141,8 +169,8 @@ source "$HOME/.config/parable/cliproxy.env"
   --local-model
 ```
 
-Verify the combined authenticated catalog from another terminal. Remove
-`grok-4.5` from the assertion if you intentionally configured only ChatGPT:
+Verify the combined authenticated catalog from another terminal. Remove ids
+for subscriptions you intentionally did not connect:
 
 ```bash
 source "$HOME/.config/parable/cliproxy.env"
@@ -156,7 +184,10 @@ curl -fsS \
         "gpt-5.6-sol",
         "gpt-5.6-terra",
         "gpt-5.6-luna",
-        "grok-4.5"
+        "grok-4.5",
+        "claude-sonnet-5",
+        "claude-opus-4-8",
+        "claude-haiku-4-5-20251001"
       ][];
       . as $model | $ids | index($model)
     )
@@ -187,37 +218,6 @@ provider = "claude"
 model = "grok-4.5"
 use_for = "A third-family implementation or adversarial review."
 avoid_for = "Reviewing its own diff."
-EOF
-
-source "$HOME/.config/parable/cliproxy.env"
-npx @parcha/parable doctor
-npx @parcha/parable agents sync
-npx @parcha/parable claude -- --effort high
-```
-
-That launches the installed stock `claude` binary with Sol as the session
-model and materializes exact project agent `parable-grok`. Change the final
-effort to any of the five verified values. In the session, explicitly ask Sol
-to use the `parable-grok` agent when that is the intended lane.
-
-The effort rule is observable, not advisory:
-
-| Sol parent effort | Grok child inbound | Grok upstream |
-|---|---|---|
-| `low` | `low` | `low` |
-| `medium` | `medium` | `medium` |
-| `high` | `high` | `high` |
-| `xhigh` | `xhigh` | `high` |
-| `max` | `max` | `high` |
-
-## Optional GPT named subagents
-
-Terra and Luna can be materialized as exact project-local Claude agents by
-adding:
-
-```toml
-[providers.claude]
-type = "subagent"
 
 [executors.terra]
 provider = "claude"
@@ -228,18 +228,61 @@ use_for = "Independent GPT implementation or debugging."
 provider = "claude"
 model = "gpt-5.6-luna"
 use_for = "Independent GPT review or a second implementation."
-```
 
-Then run:
+[executors.sonnet_exact]
+provider = "claude"
+model = "claude-sonnet-5"
+use_for = "Implementation through the exact entitled Sonnet model."
 
-```bash
+[executors.opus_exact]
+provider = "claude"
+model = "claude-opus-4-8"
+use_for = "Deep review through the exact entitled Opus model."
+
+[executors.haiku_exact]
+provider = "claude"
+model = "claude-haiku-4-5-20251001"
+use_for = "Fast mechanical work through the exact entitled Haiku model."
+EOF
+
+source "$HOME/.config/parable/cliproxy.env"
+npx @parcha/parable doctor
 npx @parcha/parable agents sync
+npx @parcha/parable claude -- --effort high
 ```
 
-Parable writes `parable-terra` and `parable-luna` agent definitions with exact
-`model:` fields. Live main-model transport and effort are proved for both
-models; a Sol-parent → named-GPT-subagent tool proof is the next gate and is
-not claimed by the current receipt.
+That launches the installed stock `claude` binary with Sol as the session
+model and materializes six exact project agents:
+
+```text
+parable-terra          gpt-5.6-terra
+parable-luna           gpt-5.6-luna
+parable-grok           grok-4.5
+parable-sonnet-exact   claude-sonnet-5
+parable-opus-exact     claude-opus-4-8
+parable-haiku-exact    claude-haiku-4-5-20251001
+```
+
+Change the final effort to any verified value. In the session, ask Sol to use
+the exact `parable-*` agent intended for the task.
+
+The named-child effort rule is observable, not advisory:
+
+| Child | `low` | `medium` | `high` | `xhigh` | `max` |
+|---|---|---|---|---|---|
+| Terra | exact | exact | exact | exact | exact |
+| Luna | exact | exact | exact | exact | exact |
+| Grok 4.5 | exact | exact | exact | → `high` | → `high` |
+| Sonnet 5 | adaptive exact | adaptive exact | adaptive exact | adaptive exact | adaptive exact |
+| Opus 4.8 | adaptive exact | adaptive exact | adaptive exact | adaptive exact | adaptive exact |
+| Haiku 4.5 | → enabled/31,999 | → enabled/31,999 | → enabled/31,999 | → enabled/31,999 | → enabled/31,999 |
+
+## What the 30/30 proof means
+
+The proof covers exact model selection, model-specific effort behavior, real
+child Bash use, parent Agent/Bash consumption, and distinct OAuth routes. It
+does not promise that every plan tier entitles every model forever. The
+authenticated catalog remains the fail-closed entitlement check at launch.
 
 Kimi remains paused and is intentionally absent from this setup.
 
@@ -251,8 +294,12 @@ Kimi remains paused and is intentionally absent from this setup.
 - [xAI OAuth and catalog proof](https://github.com/miguelrios/unc-skills/blob/main/parable/docs/evidence/x1-grok45-catalog/EXIT.md)
 - [Grok main-model matrix](https://github.com/miguelrios/unc-skills/blob/main/parable/docs/evidence/x2-grok45-main-permutations/EXIT.md)
 - [Sol to named Grok matrix](https://github.com/miguelrios/unc-skills/blob/main/parable/docs/evidence/x3-sol-grok-named-subagent/EXIT.md)
+- [Sol to named Terra/Luna matrix](https://github.com/miguelrios/unc-skills/blob/main/parable/docs/evidence/y1-sol-terra-luna/EXIT.md)
+- [Claude OAuth gate](https://github.com/miguelrios/unc-skills/blob/main/parable/docs/evidence/y2-claude-oauth/EXIT.md)
+- [Authenticated Claude catalog](https://github.com/miguelrios/unc-skills/blob/main/parable/docs/evidence/y3-claude-catalog/EXIT.md)
+- [Sol to named Claude-child matrix](https://github.com/miguelrios/unc-skills/blob/main/parable/docs/evidence/y4-sol-claude-children/EXIT.md)
 
 This is a per-user localhost setup. CLIProxyAPI owns OAuth storage and token
-refresh; Parable stores neither provider credentials nor OAuth state. ChatGPT
-and xAI plan limits, model entitlements, and provider terms still apply. Do
-not expose the proxy port outside loopback.
+refresh; Parable stores neither provider credentials nor OAuth state.
+ChatGPT, Claude, and xAI plan limits, model entitlements, and provider terms
+still apply. Do not expose the proxy port outside loopback.

--- a/parable/docs/evidence/y5-unified-subscription-verdict/EXIT.md
+++ b/parable/docs/evidence/y5-unified-subscription-verdict/EXIT.md
@@ -1,0 +1,89 @@
+# Y5 — UNIFIED OSS VERDICT · EXIT (2026-07-20)
+
+## Status: COMPLETE
+
+## The headline evidence
+
+One stock Claude Code `2.1.215` harness now has a merged 30/30
+subscription-subagent matrix: exact Sol parent at five efforts calling exact
+Terra, Luna, Grok 4.5, Sonnet 5, Opus 4.8, and Haiku 4.5 children. Every
+child cell used a real Bash artifact and every parent consumed it with Agent
+and Bash. No broker, shared deployment, provider API key, or fallback model is
+part of the OSS path.
+
+The public example generates the same six exact `parable-*` agents proved
+live. The guide and provider reference now distinguish exact GPT effort,
+Grok's `xhigh|max → high` clamp, exact adaptive Sonnet/Opus effort, and
+Haiku's fixed enabled-thinking normalization.
+
+## What shipped
+
+| Piece | Where |
+|---|---|
+| Reproducible subscription setup | `docs/CLIPROXYAPI_GPT_SUBSCRIPTION.md` |
+| Provider behavior and 30-cell table | `skills/parable/references/providers.md` |
+| Six-agent exact-id configuration | `examples/parable.claude-subscriptions.toml` |
+| Sanitized final receipt | `docs/evidence/y5-unified-subscription-verdict/receipt.json` |
+
+## Bound accounting (honest)
+
+- Correctly wired documentation proofs: 1/2 maximum; passed.
+- Evidence failures: 0.
+- Instrument failures: 2. A first temporary validation command requested
+  destructive cleanup and was rejected before execution. The additive
+  unique-directory rerun passed. A final output assertion then inspected
+  stdout while unittest wrote its PASS summary to stderr; combined-output
+  verification passed.
+- Review rounds: 1/3. Exact ids, merged evidence links, effort mappings,
+  OAuth boundaries, example generation, Kimi pause, package contents, and
+  credential/privacy boundaries were checked.
+- Y5 spent zero model turns and made zero OAuth probes.
+
+ZEN check: six declarative executor entries create six exact native Claude
+Code agents. Catalog membership fails closed before launch. There is no
+broker, shared service, scoring function, provider fallback, credential
+adapter, model regex, or imperative per-model dispatch.
+
+## Acceptance criteria → evidence
+
+1. Every claim maps to merged evidence — ✅ Grok's 5 cells map to X3, the 10
+   Terra/Luna cells map to Y1, and the 15 Claude-child cells map to Y4.
+2. Exact selection and billing routes — ✅ the example pins six full ids;
+   receipts attribute ChatGPT, xAI, and Claude subscription OAuth separately.
+3. Credential-safe OSS delivery — ✅ content scanning finds no credential,
+   OAuth state, account id, callback URL, raw trace, or private path.
+4. Complete verification — ✅ example validation and six-agent generation
+   pass, the complete suite passes 81/81, and package dry-run passes with all
+   three public deliverables included.
+5. Focused PR merged — ✅ the PR and verified `main` are recorded below.
+
+## Final matrix
+
+| Exact child | `low` | `medium` | `high` | `xhigh` | `max` | Total |
+|---|---:|---:|---:|---:|---:|---:|
+| `gpt-5.6-terra` | ✅ | ✅ | ✅ | ✅ | ✅ | 5/5 |
+| `gpt-5.6-luna` | ✅ | ✅ | ✅ | ✅ | ✅ | 5/5 |
+| `grok-4.5` | ✅ | ✅ | ✅ | ✅→`high` | ✅→`high` | 5/5 |
+| `claude-sonnet-5` | ✅ adaptive | ✅ adaptive | ✅ adaptive | ✅ adaptive | ✅ adaptive | 5/5 |
+| `claude-opus-4-8` | ✅ adaptive | ✅ adaptive | ✅ adaptive | ✅ adaptive | ✅ adaptive | 5/5 |
+| `claude-haiku-4-5-20251001` | ✅→31,999 | ✅→31,999 | ✅→31,999 | ✅→31,999 | ✅→31,999 | 5/5 |
+
+MEASURE: 30/30 live cells, 30/30 deterministic child artifacts, 30/30 parent
+consumption markers. Kimi remains paused and absent.
+
+## Merge verification
+
+- JSON invariants: PASS.
+- Example config and six-agent generation: PASS.
+- Complete Parable suite: PASS, 81/81.
+- Package dry-run: PASS, 32 files.
+- Local Claudio-Michel review: 5/5.
+- Focused PR: pending.
+- Verified merged `main`: pending.
+
+## final human verdict
+
+Ship the local OSS mode. Each user connects their own ChatGPT, Claude, and
+xAI subscriptions to their own loopback CLIProxyAPI instance; Parable
+launches Sol and materializes exact named children in stock Claude Code.
+Model availability, plan limits, and provider terms remain per-user gates.

--- a/parable/docs/evidence/y5-unified-subscription-verdict/receipt.json
+++ b/parable/docs/evidence/y5-unified-subscription-verdict/receipt.json
@@ -1,0 +1,144 @@
+{
+  "schema_version": 1,
+  "loop": "Y5",
+  "captured_at_utc": "2026-07-20T17:37:40Z",
+  "parable_baseline_head": "e53d30a3b1303d80779bf8ed3204c30ae829c8a5",
+  "inherited_live_evidence": [
+    {
+      "lane": "grok",
+      "cells": 5,
+      "receipt": "docs/evidence/x3-sol-grok-named-subagent/receipt.json",
+      "focused_pr": 158,
+      "verified_merged_main": "63e715f8e6b2baf16d8782d0426970eec3dd7347"
+    },
+    {
+      "lane": "terra_luna",
+      "cells": 10,
+      "receipt": "docs/evidence/y1-sol-terra-luna/receipt.json",
+      "focused_pr": 165,
+      "verified_merged_main": "a73fc5e34545439102b0c41ad08a733ca13427b3"
+    },
+    {
+      "lane": "sonnet_opus_haiku",
+      "cells": 15,
+      "receipt": "docs/evidence/y4-sol-claude-children/receipt.json",
+      "focused_pr": 183,
+      "verified_merged_main": "3e3baf7475c10c05da775618d101c29d2eeedc3e"
+    }
+  ],
+  "matrix": {
+    "parent_model": "gpt-5.6-sol",
+    "parent_efforts": [
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+      "max"
+    ],
+    "cells_passed": "30/30",
+    "children": [
+      {
+        "agent": "parable-terra",
+        "model": "gpt-5.6-terra",
+        "oauth_route": "chatgpt",
+        "cells": "5/5",
+        "effort_behavior": "exact_5_of_5"
+      },
+      {
+        "agent": "parable-luna",
+        "model": "gpt-5.6-luna",
+        "oauth_route": "chatgpt",
+        "cells": "5/5",
+        "effort_behavior": "exact_5_of_5"
+      },
+      {
+        "agent": "parable-grok",
+        "model": "grok-4.5",
+        "oauth_route": "xai",
+        "cells": "5/5",
+        "effort_behavior": "low_medium_high_exact_xhigh_max_clamp_high"
+      },
+      {
+        "agent": "parable-sonnet-exact",
+        "model": "claude-sonnet-5",
+        "oauth_route": "claude",
+        "cells": "5/5",
+        "effort_behavior": "exact_adaptive_5_of_5"
+      },
+      {
+        "agent": "parable-opus-exact",
+        "model": "claude-opus-4-8",
+        "oauth_route": "claude",
+        "cells": "5/5",
+        "effort_behavior": "exact_adaptive_5_of_5"
+      },
+      {
+        "agent": "parable-haiku-exact",
+        "model": "claude-haiku-4-5-20251001",
+        "oauth_route": "claude",
+        "cells": "5/5",
+        "effort_behavior": "all_normalize_enabled_budget_31999"
+      }
+    ],
+    "exact_named_child_model_cells": "30/30",
+    "deterministic_child_tool_artifacts": "30/30",
+    "deterministic_parent_consumption": "30/30",
+    "provider_fallback_observed": false
+  },
+  "delivery": {
+    "guide": "docs/CLIPROXYAPI_GPT_SUBSCRIPTION.md",
+    "provider_reference": "skills/parable/references/providers.md",
+    "example": "examples/parable.claude-subscriptions.toml",
+    "example_config_valid": true,
+    "generated_exact_agents": {
+      "parable-terra": "gpt-5.6-terra",
+      "parable-luna": "gpt-5.6-luna",
+      "parable-grok": "grok-4.5",
+      "parable-sonnet-exact": "claude-sonnet-5",
+      "parable-opus-exact": "claude-opus-4-8",
+      "parable-haiku-exact": "claude-haiku-4-5-20251001"
+    },
+    "kimi_status": "paused_absent",
+    "broker_required": false,
+    "shared_deployment_required": false,
+    "per_user_loopback_oauth": true
+  },
+  "verification": {
+    "complete_parable_suite": "PASS_81_OF_81",
+    "package_dry_run": "PASS",
+    "package_version": "0.1.9",
+    "package_files": 32,
+    "package_size_kb": 63.5,
+    "unpacked_size_kb": 201.2,
+    "diff_check": "PASS",
+    "content_boundary": "PASS",
+    "local_review": "PASS_5_OF_5"
+  },
+  "bounds": {
+    "correctly_wired_documentation_proofs": "1/2",
+    "evidence_failures": 0,
+    "instrument_failures": 2,
+    "review_rounds": "1/3",
+    "y5_model_turns": 0,
+    "y5_oauth_probes": 0
+  },
+  "instrumentation_events": [
+    {
+      "event": "The first temporary validation command requested destructive cleanup and was rejected before execution.",
+      "resolution": "Validation reran in a unique additive temporary directory and passed."
+    },
+    {
+      "event": "A final test-output assertion inspected stdout while unittest emitted its PASS summary on stderr.",
+      "resolution": "The test process had passed; the verification reran with combined output and passed."
+    }
+  ],
+  "safety": {
+    "credential_material_committed": false,
+    "oauth_state_committed": false,
+    "account_identifier_committed": false,
+    "raw_prompt_or_response_committed": false,
+    "raw_proxy_log_committed": false,
+    "callback_url_committed": false,
+    "private_path_committed": false
+  }
+}

--- a/parable/examples/parable.claude-subscriptions.toml
+++ b/parable/examples/parable.claude-subscriptions.toml
@@ -1,5 +1,5 @@
-# ChatGPT- and xAI-subscription-backed models in one stock Claude Code session
-# through a local Claude-compatible proxy. This file contains no
+# ChatGPT-, Claude-, and xAI-subscription-backed models in one stock Claude
+# Code session through a local Claude-compatible proxy. This file contains no
 # OAuth/provider credentials: only the NAME of the environment variable
 # holding the proxy's localhost client token. Configure and authenticate the
 # local proxy separately.
@@ -7,7 +7,7 @@
 [parable]
 version = 1
 default_executor = "terra"
-default_reviewer = "opus"
+default_reviewer = "opus_exact"
 
 [claude]
 base_url = "http://127.0.0.1:8317"
@@ -36,11 +36,29 @@ model = "gpt-5.6-luna"
 tags = ["reviewer", "subscription"]
 use_for = "Independent GPT review or a second implementation."
 
+[executors.sonnet_exact]
+provider = "claude"
+model = "claude-sonnet-5"
+tags = ["implementer", "subscription"]
+use_for = "Implementation through the exact entitled Sonnet model."
+
+[executors.opus_exact]
+provider = "claude"
+model = "claude-opus-4-8"
+tags = ["reviewer", "subscription"]
+use_for = "Deep review through the exact entitled Opus model."
+
+[executors.haiku_exact]
+provider = "claude"
+model = "claude-haiku-4-5-20251001"
+tags = ["mechanical", "subscription"]
+use_for = "Fast mechanical work through the exact entitled Haiku model."
+
 [routing]
-mechanical    = ["luna", "sonnet"]
-feature       = ["terra", "sonnet", "grok"]
-refactor_wide = ["terra", "sonnet", "grok"]
-gnarly        = ["opus"]
-review        = ["opus", "luna", "grok"]
-smoke_test    = ["opus"]
-escalation    = ["terra", "sonnet", "grok", "opus"]
+mechanical    = ["haiku_exact", "luna", "sonnet_exact"]
+feature       = ["terra", "sonnet_exact", "grok"]
+refactor_wide = ["terra", "sonnet_exact", "grok"]
+gnarly        = ["opus_exact"]
+review        = ["opus_exact", "luna", "grok"]
+smoke_test    = ["opus_exact"]
+escalation    = ["terra", "sonnet_exact", "grok", "opus_exact"]

--- a/parable/skills/parable/references/providers.md
+++ b/parable/skills/parable/references/providers.md
@@ -158,7 +158,7 @@ owns subagent dispatch directly. If the current harness has no native agent-spaw
 provider is unavailable.
 
 When the session itself is launched with `parable claude`, this same provider can carry exact
-third-party model ids exposed by a localhost Claude-compatible proxy:
+catalog model ids exposed by a localhost Claude-compatible proxy:
 
 ```toml
 [claude]
@@ -166,18 +166,28 @@ base_url = "http://127.0.0.1:8317"
 auth_token_env = "CLIPROXY_API_KEY"
 brain_model = "gpt-5.6-sol"
 
-[executors.kimi]
+[executors.terra]
 provider = "claude"
-model = "kimi-k3"
-use_for = "Independent implementation through the Kimi Code subscription."
+model = "gpt-5.6-terra"
+use_for = "Independent GPT implementation through ChatGPT subscription OAuth."
+
+[executors.sonnet_exact]
+provider = "claude"
+model = "claude-sonnet-5"
+use_for = "Implementation through Claude subscription OAuth."
+
+[executors.grok]
+provider = "claude"
+model = "grok-4.5"
+use_for = "Third-family implementation or review through xAI subscription OAuth."
 ```
 
-`parable agents sync` materializes that executor as project agent `parable-kimi`; stock Claude
-Code sends its child requests to `kimi-k3` through the same endpoint. The launcher strips
+`parable agents sync` materializes those executors as exact project agents; stock Claude
+Code sends child requests to each full model id through the same endpoint. The launcher strips
 `CLAUDE_CODE_SUBAGENT_MODEL`, because Claude Code gives that environment variable priority over
 every agent's own `model:` field and would otherwise silently route all children to the parent.
 The proxy owns provider OAuth. Parable stores no provider credential and does not implement an
-OAuth flow.
+OAuth flow. Kimi is currently paused and is intentionally absent from the proved setup.
 
 ### Verified GPT effort support
 
@@ -232,6 +242,34 @@ separate ChatGPT/xAI OAuth routes.
 This xAI OAuth route is distinct from Parable's Cursor executor. Cursor uses a
 Cursor plan and `cursor-agent`; it is not the Grok child route inside Claude
 Code.
+
+### Verified Sol subscription-subagent matrix
+
+The exact named-child proof is complete for stock Claude Code `2.1.215`.
+With `gpt-5.6-sol` as parent, every child below created a Bash artifact and
+the parent consumed it with Agent and Bash at all five parent efforts:
+
+| Exact child | OAuth route | `low` | `medium` | `high` | `xhigh` | `max` |
+|---|---|---|---|---|---|---|
+| `gpt-5.6-terra` | ChatGPT | exact | exact | exact | exact | exact |
+| `gpt-5.6-luna` | ChatGPT | exact | exact | exact | exact | exact |
+| `grok-4.5` | xAI | exact | exact | exact | → `high` | → `high` |
+| `claude-sonnet-5` | Claude | adaptive exact | adaptive exact | adaptive exact | adaptive exact | adaptive exact |
+| `claude-opus-4-8` | Claude | adaptive exact | adaptive exact | adaptive exact | adaptive exact | adaptive exact |
+| `claude-haiku-4-5-20251001` | Claude | → enabled/31,999 | → enabled/31,999 | → enabled/31,999 | → enabled/31,999 | → enabled/31,999 |
+
+This is 30/30 live cells with exact model attribution and no provider
+fallback. Sonnet and Opus preserve the effort label under adaptive thinking.
+Haiku removes the label and consistently uses classic enabled thinking with a
+31,999-token budget. See the
+[GPT-child receipt](../../../docs/evidence/y1-sol-terra-luna/receipt.json),
+[Claude-child receipt](../../../docs/evidence/y4-sol-claude-children/receipt.json),
+and the [source-pinned setup guide](../../../docs/CLIPROXYAPI_GPT_SUBSCRIPTION.md).
+
+Each operator must connect their own subscriptions to their own loopback
+proxy. Catalog availability is the entitlement gate; do not substitute a
+display alias when an exact id is missing. Plan limits and provider terms
+still apply.
 
 ## Reading subscription headroom (parable-usage.sh)
 


### PR DESCRIPTION
Publishes the final OSS subscription routing verdict for stock Claude Code: exact Sol parent plus exact Terra, Luna, Grok 4.5, Sonnet 5, Opus 4.8, and Haiku 4.5 named children. Updates the source-pinned guide, provider reference, and example to match the merged 30/30 live matrix. Kimi remains explicitly paused.\n\nValidation: exact example config; six generated agents; 81/81 Parable tests; npm package dry-run (32 files); credential/privacy scan; local 5/5 review.