### PR TITLE
fix(recall): wrap canonical events for edge-safe transport

### DIFF
--- a/recall/client/mac.py
+++ b/recall/client/mac.py
@@ -539,10 +539,12 @@ class CanonicalBrainWriter(_CanonicalClient):
                 or not isinstance(event.get("provenance", {}).get("artifact_ref"), dict)
             ):
                 raise PermissionError("canonical ingest scope mismatch")
+        events_payload = canonical_json(events)
         body = {
             "tenant_id": self.tenant_id,
             "principal_id": self.principal_id,
-            "events": events,
+            "source_id": self.source_id,
+            "events_base64": base64.b64encode(events_payload).decode(),
         }
         encoded = canonical_json(body)
         if len(encoded) > MAX_INGEST_BYTES:

--- a/recall/server/recall_server/app.py
+++ b/recall/server/recall_server/app.py
@@ -43,6 +43,7 @@ from .webhooks import WEBHOOK_PATH, WebhookError, build_webhook_event
 
 LOG = logging.getLogger("recall.brainstore")
 MAX_BODY_BYTES = 12 * 1024 * 1024
+MAX_CANONICAL_EVENTS_BYTES = 8_000_000
 MAX_ADMIN_BODY_BYTES = 64 * 1024
 ADMIN_INSTALLATION_ACTION = re.compile(
     r"/admin/api/v1/installations/([0-9a-f-]{36})/actions\Z"
@@ -738,6 +739,22 @@ class Handler(BaseHTTPRequestHandler):
                     return
                 tenant_id, principal_id, source_id = authority
                 events = body.get("events")
+                encoded_events = body.get("events_base64")
+                if encoded_events is not None:
+                    if events is not None or not isinstance(encoded_events, str):
+                        self.send_json(
+                            400,
+                            {"error": "canonical ingest request invalid"},
+                        )
+                        return
+                    decoded_events = base64.b64decode(
+                        encoded_events,
+                        validate=True,
+                    )
+                    if len(decoded_events) > MAX_CANONICAL_EVENTS_BYTES:
+                        self.send_json(413, {"error": "request body too large"})
+                        return
+                    events = json.loads(decoded_events)
                 if (
                     not isinstance(events, list)
                     or any(
@@ -778,7 +795,7 @@ class Handler(BaseHTTPRequestHandler):
                     200 if acknowledgement["replay"] else 201,
                     acknowledgement,
                 )
-            except (json.JSONDecodeError, TypeError, ValueError):
+            except (binascii.Error, json.JSONDecodeError, TypeError, ValueError):
                 self.send_json(400, {"error": "canonical ingest request invalid"})
             except CanonicalLifecycleError as exc:
                 status = (

--- a/recall/tests/test_mac_client.py
+++ b/recall/tests/test_mac_client.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 import hashlib
 import contextlib
 import io
@@ -308,6 +309,16 @@ class CanonicalV2ClientTest(unittest.TestCase):
         canonical_body = json.loads(requests[1].data)
         self.assertEqual(archive_body["tenant_id"], "tenant:personal")
         self.assertEqual(canonical_body["principal_id"], "principal:owner")
+        self.assertNotIn("events", canonical_body)
+        self.assertEqual(
+            json.loads(
+                base64.b64decode(
+                    canonical_body["events_base64"],
+                    validate=True,
+                )
+            ),
+            [event],
+        )
         self.assertNotIn("RAW_ARCHIVE_CANARY", json.dumps(canonical_body))
         self.assertNotIn(b"CANONICAL_TOKEN_CANARY", requests[0].data)
         self.assertNotIn(b"CANONICAL_TOKEN_CANARY", requests[1].data)


### PR DESCRIPTION
Base64-wraps authenticated canonical event arrays so edge WAFs cannot reject privacy-safe transcript/code text before Recall receives it. The server authenticates the explicit source first, then validates and bounds the decoded event contract. Plain event arrays remain accepted for compatibility.

Validation: 607 Python tests and 3 Node tests pass. Secret scan clean; no transcripts or evidence artifacts.