### PR TITLE
feat(parable): probe Kimi headroom and read CLIProxyAPI credentials

### DIFF
--- a/parable/skills/parable/scripts/parable.py
+++ b/parable/skills/parable/scripts/parable.py
@@ -1768,15 +1768,29 @@ def cmd_list(_args: argparse.Namespace) -> int:
 POOL_FOR_PROVIDER_TYPE = {"subagent": "claude", "codex-native": "codex", "cursor": "cursor"}
 
 
+# Every loopback-proxy executor is `subagent`-typed, so provider type alone would
+# bill kimi-k3 against the Claude plan. Non-Anthropic lanes on that proxy own a
+# separate subscription, so their pool comes from the MODEL, checked first.
+POOL_FOR_MODEL_PREFIX = (("kimi", "kimi"),)
+
+
+def pool_for_executor(cfg: dict, ex: dict) -> str | None:
+    model = str(ex.get("model") or "").lower()
+    for prefix, pool in POOL_FOR_MODEL_PREFIX:
+        if model.startswith(prefix):
+            return pool
+    ptype = cfg.get("providers", {}).get(ex.get("provider"), {}).get("type")
+    return POOL_FOR_PROVIDER_TYPE.get(ptype)
+
+
 def pools_in_config(cfg: dict) -> list[str]:
     """The subscription pools this cast actually routes to, in a stable order."""
     seen: set[str] = set()
     for ex in cfg.get("executors", {}).values():
-        ptype = cfg.get("providers", {}).get(ex.get("provider"), {}).get("type")
-        pool = POOL_FOR_PROVIDER_TYPE.get(ptype)
+        pool = pool_for_executor(cfg, ex)
         if pool:
             seen.add(pool)
-    return [p for p in ("claude", "codex", "cursor") if p in seen]
+    return [p for p in ("claude", "codex", "cursor", "kimi") if p in seen]
 
 
 def cursor_env_key_in_config(cfg: dict) -> str:
@@ -1798,7 +1812,7 @@ def cmd_usage(args: argparse.Namespace) -> int:
         sys.path.insert(0, str(Path(__file__).resolve().parent))
         import parable_usage  # noqa: E402
     cfg, _ = load_config(git_root())
-    pools = ["claude", "codex", "cursor"] if args.all else pools_in_config(cfg)
+    pools = ["claude", "codex", "cursor", "kimi"] if args.all else pools_in_config(cfg)
     if not pools:
         print("parable usage — no subscription-covered pools in this cast (nothing to probe)")
         return 0

--- a/parable/skills/parable/scripts/parable_usage.py
+++ b/parable/skills/parable/scripts/parable_usage.py
@@ -105,20 +105,60 @@ def _duration_label(seconds, fallback: str) -> str:
 
 
 # ---------------------------------------------------------------------------
+# CLIProxyAPI-stored credentials
+#
+# `parable setup`'s subscription-only path delegates each vendor's native OAuth
+# into a loopback CLIProxyAPI, which writes one <vendor>-<id>.json per connected
+# account with a flat `access_token`. In that setup the vendors' own CLI
+# credential files are never created, so a probe that only knows the native path
+# reports `unknown` for a subscription that is in fact connected — and unknown
+# headroom routes as "has room".
+# ---------------------------------------------------------------------------
+
+def _cliproxy_auth_dir() -> Path:
+    return Path(os.environ.get(
+        "CLIPROXY_AUTH_DIR", str(Path.home() / ".cli-proxy-api"))).expanduser()
+
+
+def _cliproxy_token(prefix: str) -> str | None:
+    """`access_token` from the newest <prefix>-*.json CLIProxyAPI wrote.
+
+    Read-only, like every credential access in this module: it never mints,
+    refreshes, or writes a token.
+    """
+    try:
+        found = sorted(_cliproxy_auth_dir().glob(f"{prefix}-*.json"),
+                       key=lambda f: f.stat().st_mtime, reverse=True)
+    except Exception:
+        return None
+    for path in found:
+        try:
+            token = json.loads(path.read_text()).get("access_token")
+        except Exception:
+            continue
+        if token:
+            return token
+    return None
+
+
+# ---------------------------------------------------------------------------
 # claude — Anthropic subscription (OAuth)
 # ---------------------------------------------------------------------------
 
 def probe_claude() -> dict:
     cred = Path(os.environ.get("CLAUDE_CONFIG_DIR", str(Path.home() / ".claude"))) / ".credentials.json"
-    if not cred.is_file():
-        return _unknown("claude", f"no {cred}")
-    try:
-        oauth = json.loads(cred.read_text()).get("claudeAiOauth", {})
-        token = oauth.get("accessToken")
-    except Exception as e:
-        return _unknown("claude", f"unreadable credentials ({e})")
+    oauth: dict = {}
+    token = None
+    if cred.is_file():
+        try:
+            oauth = json.loads(cred.read_text()).get("claudeAiOauth", {}) or {}
+            token = oauth.get("accessToken")
+        except Exception as e:
+            return _unknown("claude", f"unreadable credentials ({e})")
     if not token:
-        return _unknown("claude", "no accessToken in credentials")
+        token = _cliproxy_token("claude")
+    if not token:
+        return _unknown("claude", f"no {cred} and no claude-*.json in {_cliproxy_auth_dir()}")
     try:
         body = _get_json(
             "https://api.anthropic.com/api/oauth/usage",
@@ -306,7 +346,128 @@ def probe_cursor(env_key: str = "CURSOR_API_KEY") -> dict:
                          "limit_usd": round(limit / 100, 2)}]}
 
 
-PROBES = {"claude": probe_claude, "codex": probe_codex, "cursor": probe_cursor}
+# ---------------------------------------------------------------------------
+# kimi — Kimi Code subscription (OAuth, via CLIProxyAPI's stored credential)
+# ---------------------------------------------------------------------------
+
+KIMI_USAGE_URL = "https://api.kimi.com/coding/v1/usages"
+
+
+def _kimi_token() -> str | None:
+    """Kimi's access token: an explicit override, else CLIProxyAPI's store.
+
+    Kimi Code has no native CLI credential path to fall back to — `parable auth
+    login` is the only writer — so the proxy store is the sole source.
+    """
+    explicit = os.environ.get("PARABLE_KIMI_CRED")
+    if explicit:
+        path = Path(explicit).expanduser()
+        if not path.is_file():
+            return None
+        try:
+            return json.loads(path.read_text()).get("access_token")
+        except Exception:
+            return None
+    return _cliproxy_token("kimi")
+
+
+def _kimi_pct(limit, remaining) -> float | None:
+    """used% from a limit/remaining pair; None when the shape is unusable."""
+    try:
+        limit, remaining = float(limit), float(remaining)
+    except (TypeError, ValueError):
+        return None
+    if limit <= 0:
+        return None
+    return round(max(0.0, min(100.0, (1.0 - remaining / limit) * 100.0)), 1)
+
+
+def _kimi_pair(entry: dict) -> float | None:
+    """limit/remaining may sit on the entry or one level down in a detail object."""
+    pct = _kimi_pct(entry.get("limit"), entry.get("remaining"))
+    if pct is not None:
+        return pct
+    for value in entry.values():
+        if isinstance(value, dict):
+            pct = _kimi_pct(value.get("limit"), value.get("remaining"))
+            if pct is not None:
+                return pct
+    return None
+
+
+def probe_kimi() -> dict:
+    token = _kimi_token()
+    if not token:
+        return _unknown("kimi", f"no kimi-*.json in {_cliproxy_auth_dir()}")
+    try:
+        body = _get_json(KIMI_USAGE_URL,
+                         {"Authorization": f"Bearer {token}",
+                          "Accept": "application/json",
+                          "User-Agent": "parable-usage/1"})
+    except urllib.error.HTTPError as e:
+        # Kimi access tokens are short-lived and CLIProxyAPI refreshes them as it
+        # proxies, persisting each new one to the auth dir. A 401 outside a running
+        # session just means nothing has refreshed the stored token lately — which is
+        # harmless, because the probe only informs routing while a session is live.
+        return _unknown("kimi", f"HTTP {e.code}" + (
+            " (stored token stale; refreshes once a parable session is running —"
+            " re-auth only if it persists)" if e.code == 401 else ""))
+    except Exception as e:
+        return _unknown("kimi", f"probe failed ({e})")
+
+    plan = None
+    user = body.get("user")
+    if isinstance(user, dict) and isinstance(user.get("membership"), dict):
+        plan = user["membership"].get("level")
+    return {"pool": "kimi", "status": "ok", "plan": plan,
+            "windows": kimi_windows(body), "billing": {}}
+
+
+def kimi_windows(body: dict) -> list[dict]:
+    """Normalize /usages into window dicts.
+
+    Kimi meters two things independently, and the tightest one governs routing:
+      * ``usage``    — the billing-cycle (weekly) quota
+      * ``limits[]`` — rolling rate windows; ``window.duration`` plus
+                       ``window.timeUnit`` give the cadence (duration=300 with
+                       TIME_UNIT_MINUTE is the 5-hour session window).
+
+    These field names come from Kimi's undocumented console endpoint, so every
+    read is defensive: an unparseable section is skipped, never fatal.
+    """
+    windows = []
+
+    overall = body.get("usage")
+    if isinstance(overall, dict):
+        pct = _kimi_pct(overall.get("limit"), overall.get("remaining"))
+        if pct is not None:
+            windows.append({"window": "cycle", "used_pct": pct,
+                            "resets_in_min": _mins_until(overall.get("resetTime")
+                                                         or overall.get("reset_time"))})
+
+    for entry in body.get("limits") or []:
+        if not isinstance(entry, dict):
+            continue
+        pct = _kimi_pair(entry)
+        if pct is None:
+            continue
+        win = entry.get("window") if isinstance(entry.get("window"), dict) else {}
+        try:
+            unit = str(win.get("timeUnit") or win.get("time_unit") or "").upper()
+            seconds = int(float(win.get("duration")) * (
+                60 if "MINUTE" in unit else
+                3600 if "HOUR" in unit else
+                86400 if "DAY" in unit else 1))
+        except (TypeError, ValueError):
+            seconds = None
+        windows.append({"window": _duration_label(seconds, "window"), "used_pct": pct,
+                        "resets_in_min": _mins_until(entry.get("resetTime")
+                                                     or entry.get("reset_time"))})
+    return windows
+
+
+PROBES = {"claude": probe_claude, "codex": probe_codex, "cursor": probe_cursor,
+          "kimi": probe_kimi}
 
 
 def _probe_one(name: str, cursor_env_key: str) -> dict:


### PR DESCRIPTION
## Problem

`parable_usage.py` documents the load-balancing contract as *"which pool has room is measured, not guessed-from-throttle-after-the-fact"*, and `probe_all` treats an unknown pool as **"route as if it has room"**. Two gaps break that for the subscription-only path:

1. **Kimi is never probed.** `PROBES` covers claude/codex/cursor only, so a Kimi executor always reports `unknown`.
2. **`probe_claude` looks in the wrong place.** `parable setup` delegates OAuth into a loopback CLIProxyAPI, which stores `claude-<email>.json` with a flat `access_token`. The native `~/.claude/.credentials.json` is never created in that setup, so a *connected* Claude plan also reports `unknown`.

With both pools unknown, the brain has no headroom signal at all. Observed result — the brain kept dispatching to Kimi after its plan was exhausted, and CLIProxyAPI logged repeated ~1.1 MB requests each rejected with:

```
{"type":"error","error":{"type":"permission_error",
 "message":"You've reached your usage limit for this billing cycle..."}}
```

A third issue makes the accounting wrong even once a probe exists: `POOL_FOR_PROVIDER_TYPE` maps provider *type* → pool, and every loopback-proxy executor is `subagent`-typed, so `kimi-k3` was counted against the **Claude** pool.

## Changes

- **`probe_kimi`** — `GET https://api.kimi.com/coding/v1/usages`, OAuth bearer. Base URL matches CLIProxyAPI's own `KimiAPIBaseURL`. Normalizes the billing-cycle quota and the rolling 5h window (`window.duration` + `window.timeUnit`) into the existing `{window, used_pct, resets_in_min}` shape, so `worst_used_pct` works unchanged.
- **`_cliproxy_token(prefix)`** — shared resolver for CLIProxyAPI's store. `probe_claude` now falls back to it; `probe_kimi` uses it as its only source (Kimi Code has no native CLI credential path).
- **`pool_for_executor`** — pool comes from the model (`POOL_FOR_MODEL_PREFIX`) before the provider type, so non-Anthropic lanes on the proxy bill to their own subscription.

## Notes

- Both probes stay **read-only** — never mint, refresh, or write a token — per the module contract, and fail soft to `_unknown` on every path.
- Kimi's `/usages` field names come from its undocumented console endpoint, so parsing is defensive: an unparseable section is skipped, never fatal. `_kimi_pair` tolerates `limit`/`remaining` on the entry or one level down.
- Kimi access tokens are short-lived and refreshed by CLIProxyAPI as it proxies. A 401 outside a live session is expected and the message says so; `probe_all`'s stale-cache fallback keeps serving the last good read, so routing stays informed.

## Verification

Against a real `claude,kimi` setup:

```
$ parable usage
parable usage — live subscription headroom (zero model tokens)
  claude  ?                   5h=6%↻47m  7d=63%↻5837m  7d-fable=46%↻5837m  extra=$0.00/$27.00 current
  kimi    LEVEL_INTERMEDIATE  cycle=20%↻8773m  5h=0%
```

Both pools were `unknown` before this change. `python3 -m py_compile` clean on both files.
